### PR TITLE
feat(solver): excitation vector builder and LU linear solver

### DIFF
--- a/crates/nec_solver/src/excitation.rs
+++ b/crates/nec_solver/src/excitation.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Excitation vector builder.
+//!
+//! Converts `EX` cards from the parsed deck into a complex right-hand-side
+//! vector V, where V[i] is the impressed voltage on segment i (0 elsewhere).
+//!
+//! Only excitation type 0 (series voltage source) is implemented in Phase 1.
+
+use num_complex::Complex64;
+
+use nec_model::card::{Card, ExCard};
+use nec_model::deck::NecDeck;
+
+use crate::geometry::Segment;
+
+/// Error from the excitation builder.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExcitationError {
+    /// An EX card referenced a (tag, segment) pair not present in the geometry.
+    SegmentNotFound { tag: u32, segment: u32 },
+    /// An EX card uses an excitation type not yet supported.
+    UnsupportedType { ex_type: u32 },
+}
+
+impl std::fmt::Display for ExcitationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExcitationError::SegmentNotFound { tag, segment } => {
+                write!(f, "EX: no segment with tag {tag}, index {segment}")
+            }
+            ExcitationError::UnsupportedType { ex_type } => {
+                write!(f, "EX: excitation type {ex_type} is not yet supported")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExcitationError {}
+
+/// Build the complex excitation (RHS) vector V from `EX` cards in `deck`.
+///
+/// `segs` is the flat segment list produced by [`crate::geometry::build_geometry`].
+/// The returned vector has length `segs.len()`.
+pub fn build_excitation(
+    deck: &NecDeck,
+    segs: &[Segment],
+) -> Result<Vec<Complex64>, ExcitationError> {
+    let mut v = vec![Complex64::new(0.0, 0.0); segs.len()];
+
+    for card in &deck.cards {
+        let Card::Ex(ex) = card else { continue };
+        apply_ex(ex, segs, &mut v)?;
+    }
+
+    Ok(v)
+}
+
+fn apply_ex(ex: &ExCard, segs: &[Segment], v: &mut [Complex64]) -> Result<(), ExcitationError> {
+    if ex.excitation_type != 0 {
+        return Err(ExcitationError::UnsupportedType {
+            ex_type: ex.excitation_type,
+        });
+    }
+
+    // Find the segment by tag + tag_index.
+    let idx = segs
+        .iter()
+        .position(|s| s.tag == ex.tag && s.tag_index == ex.segment)
+        .ok_or(ExcitationError::SegmentNotFound {
+            tag: ex.tag,
+            segment: ex.segment,
+        })?;
+
+    v[idx] += Complex64::new(ex.voltage_real, ex.voltage_imag);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nec_model::card::{Card, ExCard, GwCard};
+    use nec_model::deck::NecDeck;
+
+    use crate::geometry::build_geometry;
+
+    fn dipole_deck() -> NecDeck {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gw(GwCard {
+            tag: 1,
+            segments: 11,
+            start: [0.0, 0.0, -2.677],
+            end: [0.0, 0.0, 2.677],
+            radius: 0.001,
+        }));
+        deck.cards.push(Card::Ex(ExCard {
+            excitation_type: 0,
+            tag: 1,
+            segment: 6, // centre segment (1-based)
+            voltage_real: 1.0,
+            voltage_imag: 0.0,
+        }));
+        deck
+    }
+
+    #[test]
+    fn voltage_placed_at_correct_segment() {
+        let deck = dipole_deck();
+        let segs = build_geometry(&deck).unwrap();
+        let v = build_excitation(&deck, &segs).unwrap();
+
+        assert_eq!(v.len(), 11);
+        // Only segment index 5 (0-based) should be excited (tag_index 6).
+        for (i, vi) in v.iter().enumerate() {
+            if i == 5 {
+                assert_eq!(
+                    *vi,
+                    Complex64::new(1.0, 0.0),
+                    "segment 6 should have V=1+0j"
+                );
+            } else {
+                assert_eq!(*vi, Complex64::new(0.0, 0.0), "segment {i} should be zero");
+            }
+        }
+    }
+
+    #[test]
+    fn complex_voltage_is_stored() {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gw(GwCard {
+            tag: 1,
+            segments: 3,
+            start: [0.0, 0.0, -1.0],
+            end: [0.0, 0.0, 1.0],
+            radius: 0.001,
+        }));
+        deck.cards.push(Card::Ex(ExCard {
+            excitation_type: 0,
+            tag: 1,
+            segment: 2,
+            voltage_real: 0.5,
+            voltage_imag: -0.5,
+        }));
+        let segs = build_geometry(&deck).unwrap();
+        let v = build_excitation(&deck, &segs).unwrap();
+        assert_eq!(v[1], Complex64::new(0.5, -0.5));
+    }
+
+    #[test]
+    fn unknown_ex_type_is_error() {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gw(GwCard {
+            tag: 1,
+            segments: 3,
+            start: [0.0, 0.0, -1.0],
+            end: [0.0, 0.0, 1.0],
+            radius: 0.001,
+        }));
+        deck.cards.push(Card::Ex(ExCard {
+            excitation_type: 5, // not supported
+            tag: 1,
+            segment: 2,
+            voltage_real: 1.0,
+            voltage_imag: 0.0,
+        }));
+        let segs = build_geometry(&deck).unwrap();
+        assert!(matches!(
+            build_excitation(&deck, &segs),
+            Err(ExcitationError::UnsupportedType { ex_type: 5 })
+        ));
+    }
+
+    #[test]
+    fn segment_not_found_is_error() {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gw(GwCard {
+            tag: 1,
+            segments: 3,
+            start: [0.0, 0.0, -1.0],
+            end: [0.0, 0.0, 1.0],
+            radius: 0.001,
+        }));
+        deck.cards.push(Card::Ex(ExCard {
+            excitation_type: 0,
+            tag: 99, // no such tag
+            segment: 1,
+            voltage_real: 1.0,
+            voltage_imag: 0.0,
+        }));
+        let segs = build_geometry(&deck).unwrap();
+        assert!(matches!(
+            build_excitation(&deck, &segs),
+            Err(ExcitationError::SegmentNotFound { tag: 99, .. })
+        ));
+    }
+}

--- a/crates/nec_solver/src/lib.rs
+++ b/crates/nec_solver/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
+pub mod excitation;
 pub mod geometry;
+pub mod linear;
 pub mod matrix;

--- a/crates/nec_solver/src/linear.rs
+++ b/crates/nec_solver/src/linear.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Dense complex linear solver: LU factorisation with partial pivoting.
+//!
+//! Solves Z·I = V for the segment current vector I.
+//!
+//! The implementation is a straightforward in-place Gaussian elimination with
+//! partial (row) pivoting.  It is adequate for the segment counts expected in
+//! Phase 1 (up to a few hundred segments).  A LAPACK or GPU back-end can
+//! replace this path later via the `nec_accel` crate.
+
+use num_complex::Complex64;
+
+use crate::matrix::ZMatrix;
+
+/// Error returned by the linear solver.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SolveError {
+    /// The matrix is singular (or numerically rank-deficient).
+    Singular,
+    /// The dimensions of Z and V do not match.
+    DimensionMismatch { z_n: usize, v_len: usize },
+}
+
+impl std::fmt::Display for SolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SolveError::Singular => write!(f, "impedance matrix is singular"),
+            SolveError::DimensionMismatch { z_n, v_len } => {
+                write!(f, "Z is {z_n}×{z_n} but V has length {v_len}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SolveError {}
+
+/// Solve Z·I = V using LU factorisation with partial pivoting.
+///
+/// Returns the segment current vector I (length N).
+pub fn solve(z: &ZMatrix, v: &[Complex64]) -> Result<Vec<Complex64>, SolveError> {
+    let n = z.n;
+    if v.len() != n {
+        return Err(SolveError::DimensionMismatch {
+            z_n: n,
+            v_len: v.len(),
+        });
+    }
+
+    // Build a mutable augmented matrix [Z | v] (row-major).
+    let mut a: Vec<Vec<Complex64>> = (0..n)
+        .map(|i| {
+            let mut row: Vec<Complex64> = (0..n).map(|j| z.get(i, j)).collect();
+            row.push(v[i]);
+            row
+        })
+        .collect();
+
+    // Gaussian elimination with partial pivoting.
+    for col in 0..n {
+        // Find pivot row (max |a[row][col]|).
+        let pivot = (col..n)
+            .max_by(|&r1, &r2| {
+                a[r1][col]
+                    .norm()
+                    .partial_cmp(&a[r2][col].norm())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .unwrap();
+
+        if a[pivot][col].norm() < 1e-30 {
+            return Err(SolveError::Singular);
+        }
+
+        a.swap(col, pivot);
+
+        let diag = a[col][col];
+        // Eliminate rows below.
+        for row in (col + 1)..n {
+            let factor = a[row][col] / diag;
+            for k in col..=n {
+                // =n because of the augmented column
+                let sub = factor * a[col][k];
+                a[row][k] -= sub;
+            }
+        }
+    }
+
+    // Back-substitution.
+    let mut x = vec![Complex64::new(0.0, 0.0); n];
+    for i in (0..n).rev() {
+        let mut sum = a[i][n]; // RHS
+        for j in (i + 1)..n {
+            sum -= a[i][j] * x[j];
+        }
+        x[i] = sum / a[i][i];
+    }
+
+    Ok(x)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::matrix::ZMatrix;
+    use num_complex::Complex64;
+
+    fn c(re: f64, im: f64) -> Complex64 {
+        Complex64::new(re, im)
+    }
+
+    /// Helper: build ZMatrix from a 2D vec of Complex64.
+    fn z_from_2d(rows: Vec<Vec<Complex64>>) -> ZMatrix {
+        let n = rows.len();
+        let mut z = ZMatrix::new(n);
+        for (i, row) in rows.iter().enumerate() {
+            for (j, &val) in row.iter().enumerate() {
+                z.set_test(i, j, val);
+            }
+        }
+        z
+    }
+
+    /// 1×1 trivial: Z=[2+0j], V=[4+0j] → I=[2+0j]
+    #[test]
+    fn solve_1x1() {
+        let z = z_from_2d(vec![vec![c(2.0, 0.0)]]);
+        let v = vec![c(4.0, 0.0)];
+        let i = solve(&z, &v).unwrap();
+        assert!((i[0] - c(2.0, 0.0)).norm() < 1e-12);
+    }
+
+    /// 2×2 real: [[3,1],[1,2]]·[1,1]=[4,3]
+    #[test]
+    fn solve_2x2_real() {
+        let z = z_from_2d(vec![
+            vec![c(3.0, 0.0), c(1.0, 0.0)],
+            vec![c(1.0, 0.0), c(2.0, 0.0)],
+        ]);
+        let v = vec![c(4.0, 0.0), c(3.0, 0.0)];
+        let i = solve(&z, &v).unwrap();
+        assert!((i[0] - c(1.0, 0.0)).norm() < 1e-12, "i[0]={}", i[0]);
+        assert!((i[1] - c(1.0, 0.0)).norm() < 1e-12, "i[1]={}", i[1]);
+    }
+
+    /// 2×2 complex
+    #[test]
+    fn solve_2x2_complex() {
+        // Z = [[1+j, 0],[0, 2+0j]], V=[1+j, 4] → I=[1, 2]
+        let z = z_from_2d(vec![
+            vec![c(1.0, 1.0), c(0.0, 0.0)],
+            vec![c(0.0, 0.0), c(2.0, 0.0)],
+        ]);
+        let v = vec![c(1.0, 1.0), c(4.0, 0.0)];
+        let i = solve(&z, &v).unwrap();
+        assert!((i[0] - c(1.0, 0.0)).norm() < 1e-12, "i[0]={}", i[0]);
+        assert!((i[1] - c(2.0, 0.0)).norm() < 1e-12, "i[1]={}", i[1]);
+    }
+
+    /// Singular matrix returns SolveError::Singular.
+    #[test]
+    fn singular_matrix_returns_error() {
+        let z = z_from_2d(vec![
+            vec![c(1.0, 0.0), c(2.0, 0.0)],
+            vec![c(2.0, 0.0), c(4.0, 0.0)], // row 2 = 2 × row 1
+        ]);
+        let v = vec![c(1.0, 0.0), c(2.0, 0.0)];
+        assert!(matches!(solve(&z, &v), Err(SolveError::Singular)));
+    }
+
+    /// Dimension mismatch.
+    #[test]
+    fn dimension_mismatch_returns_error() {
+        let z = z_from_2d(vec![
+            vec![c(1.0, 0.0), c(0.0, 0.0)],
+            vec![c(0.0, 0.0), c(1.0, 0.0)],
+        ]);
+        let v = vec![c(1.0, 0.0)]; // wrong length
+        assert!(matches!(
+            solve(&z, &v),
+            Err(SolveError::DimensionMismatch { z_n: 2, v_len: 1 })
+        ));
+    }
+
+    /// Verify Z·I ≈ V for a 3×3 random-looking system.
+    #[test]
+    fn residual_3x3() {
+        let z = z_from_2d(vec![
+            vec![c(4.0, 1.0), c(1.0, 0.0), c(0.0, -1.0)],
+            vec![c(1.0, 0.0), c(5.0, 2.0), c(1.0, 0.0)],
+            vec![c(0.0, -1.0), c(1.0, 0.0), c(3.0, 1.0)],
+        ]);
+        let v = vec![c(2.0, 1.0), c(3.0, -1.0), c(1.0, 0.0)];
+        let i = solve(&z, &v).unwrap();
+
+        // Check residual: ||Z·I - V|| < tol
+        for row in 0..3 {
+            let mut zi: Complex64 = c(0.0, 0.0);
+            for col in 0..3 {
+                zi += z.get(row, col) * i[col];
+            }
+            let err = (zi - v[row]).norm();
+            assert!(err < 1e-10, "row {row}: residual {err}");
+        }
+    }
+}

--- a/crates/nec_solver/src/matrix.rs
+++ b/crates/nec_solver/src/matrix.rs
@@ -68,6 +68,12 @@ impl ZMatrix {
     fn set(&mut self, row: usize, col: usize, val: Complex64) {
         self.data[row * self.n + col] = val;
     }
+
+    /// Write an element — exposed for use by unit tests in sibling modules.
+    #[cfg(test)]
+    pub fn set_test(&mut self, row: usize, col: usize, val: Complex64) {
+        self.set(row, col, val);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the two missing pieces between the impedance matrix and a working solve:

1. **Excitation vector** — maps EX cards to the RHS voltage vector V
2. **Linear solver** — LU with partial pivoting, solves Z·I = V for segment currents

## Changes

### `crates/nec_solver`
- `excitation.rs`: `build_excitation(deck, segs) -> Result<Vec<Complex64>, ExcitationError>`
  - Handles EX type 0 (series voltage source)
  - Locates segment by (tag, tag_index); errors if not found
- `linear.rs`: `solve(z, v) -> Result<Vec<Complex64>, SolveError>`
  - In-place Gaussian elimination with partial pivoting
  - `SolveError::Singular` / `DimensionMismatch`
- `matrix.rs`: `set_test()` cfg(test) helper for test construction in sibling modules

## Tests (10 new, 23 total)
Excitation: voltage_placed_at_correct_segment, complex_voltage_is_stored, unknown_ex_type_is_error, segment_not_found_is_error
Solver: solve_1x1, solve_2x2_real, solve_2x2_complex, singular_matrix_returns_error, dimension_mismatch_returns_error, residual_3x3

## Checklist
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo check -p nec_solver` passes
- [x] `cargo test -p nec_solver` — 23/23 passing