### PR TITLE
docs(validation): add PAR-008 NEC-5 coverage matrix

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -81,13 +81,18 @@
         "real_ohm": null,
         "imag_ohm": null
       },
+      "external_reference_candidate": {
+        "source": "NEC2DXS500 via Wine (temporary XQ-inserted deck)",
+        "real_ohm": 13.4632,
+        "imag_ohm": -896.032
+      },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "known-broken: fnec returns negative R (-45 Ohm); multi-wire loaded geometry creates ill-conditioned coupling; pending deck redesign or solver fix"
+      "status": "known-broken: fnec returns negative R (-45 Ohm); multi-wire loaded geometry creates ill-conditioned coupling; pending deck redesign or solver fix. External candidate captured via NEC2DXS500+XQ."
     },
     "frequency-sweep-dipole": {
       "deck_file": "frequency-sweep-dipole.nec",
@@ -105,13 +110,21 @@
         "16.0": {"real_ohm": null, "imag_ohm": null},
         "18.0": {"real_ohm": null, "imag_ohm": null}
       },
+      "external_reference_candidate": {
+        "source": "NEC2DXS500 via Wine (temporary XQ-inserted deck)",
+        "10.0": {"real_ohm": 29.9113, "imag_ohm": -433.231},
+        "12.0": {"real_ohm": 48.2252, "imag_ohm": -193.523},
+        "14.0": {"real_ohm": 75.8645, "imag_ohm": 24.6461},
+        "16.0": {"real_ohm": 119.275, "imag_ohm": 244.988},
+        "18.0": {"real_ohm": 191.973, "imag_ohm": 490.75}
+      },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "fnec only solves first FR frequency point; multi-frequency sweep support pending; references TBD"
+      "status": "fnec only solves first FR frequency point; multi-frequency sweep support pending. External sweep candidates captured via NEC2DXS500+XQ."
     },
     "multi-source": {
       "deck_file": "multi-source.nec",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -38,7 +38,7 @@ last_updated: 2026-04-22
 	Resolution criteria: go/no-go decision recorded with evidence from open-tool and documentation benchmarking; if go, purchase and benchmark plan logged; if no-go, defer rationale and next review date logged.
 
 - [ ] **PAR-008 / NEC-5 validation-manual coverage matrix / Owner: Solver+Validation / Target: Phase 2 / Issue: #21**
-	Resolution criteria: NEC-5 Validation Manual scenario classes mapped to fnec-rust in-scope equivalents; each mapped class has at least one reproducible corpus test with explicit tolerance gating; known out-of-scope classes are documented with rationale.
+	Resolution criteria: NEC-5 Validation Manual scenario classes mapped to fnec-rust in-scope equivalents; each mapped class has at least one reproducible corpus test with explicit tolerance gating; known out-of-scope classes are documented with rationale. Matrix source: `docs/corpus-validation-strategy.md` section "NEC-5 validation coverage matrix (PAR-008)".
 
 - [ ] **PAR-009 / xnec2c-optimize external optimizer-loop parity / Owner: Automation+CLI / Target: Phase 3 / Issue: #22**
 	Resolution criteria: deterministic objective-evaluation CLI/API contract documented; at least one xnec2c-optimize-style optimization flow reproduced end-to-end with fnec-rust automation hooks; machine-readable outputs verified stable across repeated runs.

--- a/docs/corpus-validation-strategy.md
+++ b/docs/corpus-validation-strategy.md
@@ -196,6 +196,23 @@ Example PR comment:
 **Overall**: 1 pass, 2 skipped, 0 failures ✓
 ```
 
+## Host tooling dependencies
+
+The following external tools are required for the reference-capture and validation workflow used in this repository:
+
+| Tool | Required | Purpose |
+|:-----|:--------:|:--------|
+| `gh` (GitHub CLI) | Yes | PR/issue automation, milestone/label management, and workflow integration from terminal runs |
+| `jq` | Yes | JSON inspection and extraction in terminal workflows (corpus status, reference field queries) |
+| `wine` | Conditional | Run Windows NEC engines (4nec2/NEC2 binaries) when native xnec2c batch execution is unstable |
+| `xnec2c` | Preferred | Primary external NEC2 reference engine for golden-reference capture |
+| 4nec2 + NEC2 executable (`nec2dxs500.exe`/equivalent) | Fallback | External reference capture path when xnec2c is unavailable or unstable on host |
+| `pdftotext` | Conditional | Extract text from NEC-5 Validation Manual for planning and traceability work |
+
+Notes:
+- zsh command autocorrect prompts (for example, suggesting `jaq` when `jq` is missing) indicate the originally requested tool is not installed.
+- Project workflow assumes `jq` for scripts/commands unless explicitly stated otherwise.
+
 ## Adding new corpus cases
 
 To add a new corpus case:

--- a/docs/corpus-validation-strategy.md
+++ b/docs/corpus-validation-strategy.md
@@ -55,6 +55,40 @@ Each corpus case is defined in `corpus/README.md` with:
 - Tolerance gates for this case
 - Status (captured, validated, etc.)
 
+## NEC-5 validation coverage matrix (PAR-008)
+
+This matrix maps NEC-5 Validation Manual scenario classes to current fnec-rust corpus coverage.
+The intent is not to claim full NEC-5 capability; it is to make coverage explicit, tolerance-gated, and auditable.
+
+| NEC-5 validation class | Manual section/theme | fnec-rust in-scope equivalent | Corpus mapping | Gate metrics | Current status |
+|:-----------------------|:---------------------|:-------------------------------|:---------------|:-------------|:---------------|
+| Thin-wire kernel behavior | 2.1 Thin-wire Kernel | Hallen thin-wire wire-only behavior at resonance | `dipole-freesp-51seg` | R, X (and current where reference exists) | Covered (reference captured) |
+| Source model behavior | Wire source-model comparisons (Section 2 wire modeling themes) | EX type 0 voltage-source behavior in wire-only decks | `dipole-freesp-51seg`, `multi-source` | R, X per source | Partially covered (EX-0 only) |
+| Convergence for dipole antenna | 2.3 Convergence for a Dipole Antenna | Segmentation and frequency behavior around dipole resonance | `frequency-sweep-dipole` (+ planned segmentation variants) | R, X trend across sweep | Planned (sweep refs TBD) |
+| Wires over ground | 4.1 Horizontal Wires over Ground | Single wire over ideal/perfect ground in current scope | `dipole-ground-51seg` | R, X | Not yet valid for parity claim (GN currently ignored) |
+| Loop antennas over ground | 4.2 Loop Antennas over Ground | Small-loop/loaded-loop over ground | No current equivalent corpus case | R, X, pattern/gain (future) | Out of scope in current phase |
+| Surface meshing and wire-surface junctions | Surface/junction validation themes (wire+patch classes) | Wire-surface coupling and patch meshing | No current equivalent corpus case | Junction current continuity and field behavior (future) | Out of scope in current architecture |
+| Monopole on finite box and patch-ground classes | 3.1 Monopole on a Box | Finite conducting surfaces and mixed wire/surface models | No current equivalent corpus case | R, X, pattern/gain vs reference | Out of scope in current architecture |
+
+### Coverage interpretation rules
+
+- A row is considered covered only when the mapped corpus case has a non-null external reference in `corpus/reference-results.json` and passes tolerance in CI.
+- A row with regression-only references from fnec itself does not count as parity evidence.
+- Out-of-scope rows remain explicit and tracked; they are not treated as failures until their phase target is active.
+
+### Out-of-scope rationale (current phase)
+
+- Surface meshing, wire-surface junctions, and finite box/patch classes are out of scope because current solver architecture is wire-focused and does not implement NEC-5 mixed wire/surface capability.
+- Loop-over-ground parity is deferred until advanced ground and loop-specific corpus cases are added in Phase 2 expansion work.
+- Ground-case parity is blocked today where GN behavior is not yet modeled in solver execution; those cases remain listed but not credited as covered.
+
+### Entry/exit criteria for PAR-008 completion
+
+- Matrix rows above remain synchronized with corpus cases and `corpus/reference-results.json` status.
+- In-scope rows must have external references (xnec2c/4nec2 or documented equivalent), not solver self-reference.
+- Each in-scope row must have an explicit tolerance gate binding to `docs/requirements.md` metrics.
+- Out-of-scope rows must include phase target and rationale until implemented.
+
 ## Validation workflow
 
 ### Step 1: Reference capture (manual, one-time per case)

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -53,6 +53,10 @@ Verify each crate's SPDX before adding it. MIT, Apache-2.0, BSD, GPL-3.0-only, a
 | rustfmt | Code formatting | MIT OR Apache-2.0 | Active | https://github.com/rust-lang/rustfmt |
 | clippy | Linting | MIT OR Apache-2.0 | Active | https://github.com/rust-lang/rust-clippy |
 | cargo-sbom | SPDX SBOM generation (run on version bump) | MIT OR Apache-2.0 | Active | https://github.com/psastras/sbom-rs |
+| GitHub CLI (`gh`) | PR/issue/milestone automation | MIT | Active | https://github.com/cli/cli |
+| jq | JSON querying in automation and terminal workflows | MIT | Active | https://github.com/jqlang/jq |
+| Wine | Windows binary compatibility layer for 4nec2/NEC2 fallback runs | LGPL-2.1-or-later | Active | https://www.winehq.org/ |
+| poppler (`pdftotext`) | PDF text extraction for validation-manual analysis workflows | GPL-2.0-or-later | Active | https://poppler.freedesktop.org/ |
 
 ## Reference implementations (study and validation only — no code inclusion)
 


### PR DESCRIPTION
Implements PAR-008 documentation deliverable by adding an explicit NEC-5 Validation Manual coverage matrix mapped to current corpus cases, tolerance gates, and out-of-scope rationale.

Includes:
- matrix section in docs/corpus-validation-strategy.md
- coverage interpretation rules and completion criteria
- backlog cross-link for PAR-008 (#21)

Notes:
- Does not claim full NEC-5 feature support; rows remain explicit about out-of-scope classes.