### PR TITLE
feat(solver): include per-tag Hallen alignment diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "files.exclude": {
+    "**/target": true,
+    "**/.tmp": true,
+    "**/.tmp-work": true
+  },
+  "files.watcherExclude": {
+    "**/target/**": true,
+    "**/.tmp/**": true,
+    "**/.tmp-work/**": true
+  },
+  "search.exclude": {
+    "**/target/**": true,
+    "**/.tmp/**": true,
+    "**/.tmp-work/**": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ https://www.paypal.com/donate/?hosted_button_id=WY9U4MQ3ZAQWC
 - Solver implemented from scratch in Rust
 - CLI, GUI, and optional TUI frontends over a shared core
 - Multithreaded CPU execution with staged GPU acceleration
+- Explicit Linux-on-ARM targets: Raspberry Pi 4 (VideoCore VI GPU) and Raspberry Pi 5 (VideoCore VII GPU)
 
 ## Workspace layout
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practi
 
 ## Features
 
-- Parse 4nec2 / NEC2 deck files (GW, EX, FR, EN cards; GE optional)
+- Parse 4nec2 / NEC2 deck files (GW, GN, EX, FR, EN cards; GE optional)
 - Hallén MoM solver — physically accurate feedpoint impedance for thin-wire antennas
   - Validated: 51-segment λ/2 dipole at 14.2 MHz → **74.24 + j13.90 Ω** (matches Python reference)
+	- GN 1 (perfect ground at z=0) is supported via image method; `dipole-ground-51seg` regression is **81.91 + j16.42 Ω**
 	- Current scope: collinear wire sets aligned with the driven segment axis; non-collinear Hallén topologies fail fast with an explicit error
 - Pulse-basis, continuity-basis, and sinusoidal-tapered Pocklington solvers (EXPERIMENTAL — known to diverge for thin wires)
 	- `sinusoidal` now falls back to Hallen on single collinear chains when its residual budget is exceeded, so the CLI avoids returning misleading impedances for that path

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -5,8 +5,8 @@ use nec_model::card::Card;
 use nec_parser::parse;
 use nec_report::{render_text_report, FeedpointRow, ReportInput};
 use nec_solver::{
-    assemble_pocklington_matrix, assemble_z_matrix, build_excitation, build_geometry,
-    build_hallen_rhs, scale_excitation_for_pulse_rhs, solve, solve_hallen,
+    assemble_pocklington_matrix, assemble_z_matrix_with_ground, build_excitation, build_geometry,
+    build_hallen_rhs, ground_model_from_deck, scale_excitation_for_pulse_rhs, solve, solve_hallen,
     solve_with_continuity_basis, solve_with_sinusoidal_basis, Segment, ZMatrix,
 };
 use num_complex::Complex64;
@@ -266,6 +266,9 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+
+    let ground = ground_model_from_deck(deck);
+
     for (fidx, freq_hz) in freqs_hz.iter().copied().enumerate() {
         let v_vec_pulse = match pulse_rhs_mode {
             PulseRhsMode::Raw => v_vec.clone(),
@@ -273,7 +276,7 @@ fn main() -> ExitCode {
         };
 
         let z_mat = match solver_mode {
-            SolverMode::Hallen => assemble_z_matrix(&segs, freq_hz),
+            SolverMode::Hallen => assemble_z_matrix_with_ground(&segs, freq_hz, &ground),
             SolverMode::Pulse | SolverMode::Continuity | SolverMode::Sinusoidal => {
                 assemble_pocklington_matrix(&segs, freq_hz)
             }
@@ -389,12 +392,13 @@ fn main() -> ExitCode {
                                     }
                                 };
                                 match solve_hallen(
-                                    &assemble_z_matrix(&segs, freq_hz),
+                                    &assemble_z_matrix_with_ground(&segs, freq_hz, &ground),
                                     &hallen_rhs.rhs,
                                     &hallen_rhs.cos_vec,
                                 ) {
                                     Ok(sol) => {
-                                        let hallen_z = assemble_z_matrix(&segs, freq_hz);
+                                        let hallen_z =
+                                            assemble_z_matrix_with_ground(&segs, freq_hz, &ground);
                                         let (a2, r2) = residual_hallen(
                                             &hallen_z,
                                             &sol.currents,

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -37,7 +37,7 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 
 ### 2. `dipole-ground-51seg.nec` — Half-wave dipole, over ground
 
-**Purpose**: Validate Hallén solver with ground effects (Sommerfeld integral).
+**Purpose**: Validate Hallén solver with perfect-ground image-method effects.
 
 **Geometry**:
 - Frequency: 14.2 MHz
@@ -46,13 +46,13 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Feed: Center segment, 1.0 V
 - Ground: Perfect conductor at z = 0 (infinite, ideal)
 
-**Expected results** (from xnec2c):
-- Z_in ≈ [TBD after xnec2c run — expected 50–100 Ω real, ±10 Ω imag depending on height]
+**Expected results** (current regression gate):
+- Z_in ≈ 81.91 + j16.42 Ω
 - Current distribution: distorted from free-space case due to image interaction
 
 **Tolerance gates**: Same as dipole-freesp (R, X, current).
 
-**Why this case**: Ground effects are critical for practical antennas. Validates that image method / Sommerfeld treatment is correct.
+**Why this case**: Ground effects are critical for practical antennas. Validates GN=1 perfect-ground image-method behavior.
 
 ### 3. `yagi-5elm-51seg.nec` — 5-element Yagi array
 
@@ -143,7 +143,7 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 | Case | Deck file | Segments | Wires | Sources | Ground | Reference Z_in (Ω) |
 |:-----|:----------|:---------|:------|:--------|:-------|:------------------|
 | 1 | dipole-freesp-51seg.nec | 51 | 1 | 1 | None | 74.24 + j13.90 |
-| 2 | dipole-ground-51seg.nec | 51 | 1 | 1 | Perfect | [TBD] |
+| 2 | dipole-ground-51seg.nec | 51 | 1 | 1 | Perfect | 81.91 + j16.42 |
 | 3 | yagi-5elm-51seg.nec | 51 | 5 | 1 | None | [TBD] |
 | 4 | dipole-loaded.nec | ≈51 | 2 | 1 | None | [TBD] |
 | 5 | frequency-sweep-dipole.nec | 51 | 1 | 1 (5× freq) | None | [TBD] × 5 |

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -34,10 +34,10 @@
       "wires": 1,
       "sources": 1,
       "ground": "perfect conductor (infinite)",
-      "reference_source": "fnec Hallén solver (regression only — GN card silently ignored)",
+      "reference_source": "fnec Hallén solver with GN=1 PEC image-method ground (regression)",
       "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
+        "real_ohm": 81.914743,
+        "imag_ohm": 16.416629
       },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
@@ -45,7 +45,7 @@
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "GN card silently ignored by fnec; regression-only reference equals free-space result; GN support pending"
+      "status": "GN=1 PEC image-method support active; reference captured from fnec Hallen for regression gating"
     },
     "yagi-5elm-51seg": {
       "deck_file": "yagi-5elm-51seg.nec",

--- a/crates/nec_model/src/card.rs
+++ b/crates/nec_model/src/card.rs
@@ -90,6 +90,21 @@ pub struct RpCard {
     pub d_phi: f64,
 }
 
+/// GN — Ground definition card.
+///
+/// Specifies the electrical ground model below the antenna geometry.
+/// Only the first integer field (ground type) is stored in Phase 1.
+/// Future phases can extend this struct with conductivity and permittivity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GnCard {
+    /// Ground type:
+    ///   -1 = null ground (equivalent to no GN card)
+    ///    0 = reflection coefficient method (approximate; deferred Phase 2)
+    ///    1 = perfect electric conductor (image method)
+    ///    2 = finite conductivity Sommerfeld/Norton (deferred Phase 2)
+    pub ground_type: i32,
+}
+
 /// EN — End-of-data card.  Signals the end of a NEC deck.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EnCard;
@@ -99,6 +114,7 @@ pub struct EnCard;
 pub enum Card {
     Comment(CommentCard),
     Gw(GwCard),
+    Gn(GnCard),
     Ex(ExCard),
     Fr(FrCard),
     Rp(RpCard),

--- a/crates/nec_model/src/card.rs
+++ b/crates/nec_model/src/card.rs
@@ -35,7 +35,8 @@ pub struct GwCard {
 
 /// EX — Excitation card.
 ///
-/// Only voltage-source excitation (type 0) is modelled in Phase 1.
+/// Phase 1 models voltage-source excitation (type 0). Additional fields are
+/// preserved so later phases can implement more EX source families.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExCard {
     /// Excitation type (0 = voltage source).
@@ -44,6 +45,11 @@ pub struct ExCard {
     pub tag: u32,
     /// Segment number within the tag.
     pub segment: u32,
+    /// Integer EX field I4.
+    ///
+    /// For EX type 0 this is typically unused and often set to 0. For other
+    /// source types NEC uses this field for additional source metadata.
+    pub i4: u32,
     /// Real part of the voltage (volts).
     pub voltage_real: f64,
     /// Imaginary part of the voltage (volts).

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -4,12 +4,12 @@
 //! Minimal Phase-1 NEC deck parser.
 //!
 //! Parses the cards required to run a basic dipole simulation:
-//! `CM`, `CE`, `GW`, `EX`, `FR`, `RP`, `EN`.
+//! `CM`, `CE`, `GW`, `GN`, `EX`, `FR`, `RP`, `EN`.
 //!
 //! Unknown cards produce a [`ParseError::UnknownCard`] but do not stop
 //! parsing — callers decide whether to treat them as fatal.
 
-use nec_model::card::{Card, CommentCard, EnCard, ExCard, FrCard, GwCard, RpCard};
+use nec_model::card::{Card, CommentCard, EnCard, ExCard, FrCard, GnCard, GwCard, RpCard};
 use nec_model::deck::NecDeck;
 
 /// A parse error.
@@ -181,6 +181,13 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                     d_phi: parse_f64(lineno, "RP", 7, &fields[6])?,
                 }));
             }
+            "GN" => {
+                let fields = parse_fields(rest);
+                require_fields(lineno, "GN", &fields, 1)?;
+                deck.cards.push(Card::Gn(GnCard {
+                    ground_type: parse_i32(lineno, "GN", 1, &fields[0])?,
+                }));
+            }
             "EN" => {
                 deck.cards.push(Card::En(EnCard));
                 // Stop at EN per NEC spec.
@@ -229,6 +236,18 @@ fn require_fields(
     } else {
         Ok(())
     }
+}
+
+fn parse_i32(lineno: usize, card: &str, field: usize, s: &str) -> Result<i32, ParseError> {
+    // Accept floats like "-1.0" that some NEC tools emit for integer fields.
+    s.parse::<f64>()
+        .map(|v| v as i32)
+        .map_err(|_| ParseError::BadField {
+            line: lineno,
+            card: card.to_string(),
+            field,
+            raw: s.to_string(),
+        })
 }
 
 fn parse_u32(lineno: usize, card: &str, field: usize, s: &str) -> Result<u32, ParseError> {
@@ -381,6 +400,22 @@ EN
         // CM after EN must not appear
         assert_eq!(result.deck.cards.len(), 2);
         assert_eq!(result.deck.cards[1], Card::En(EnCard));
+    }
+
+    #[test]
+    fn gn_card_parsed_and_stored() {
+        let input = "GW 1 3 0 0 1 0 0 4 0.001\nGN 1\nEX 0 1 2 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+        let gn_card = result.deck.cards.iter().find_map(|c| {
+            if let Card::Gn(g) = c {
+                Some(g.clone())
+            } else {
+                None
+            }
+        });
+        assert!(gn_card.is_some(), "GN card not found in deck");
+        assert_eq!(gn_card.unwrap().ground_type, 1);
     }
 
     #[test]

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -143,7 +143,7 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                     excitation_type: parse_u32(lineno, "EX", 1, &fields[0])?,
                     tag: parse_u32(lineno, "EX", 2, &fields[1])?,
                     segment: parse_u32(lineno, "EX", 3, &fields[2])?,
-                    // fields[3] is I4 (unused for type-0 sources, consumed here)
+                    i4: parse_u32(lineno, "EX", 4, &fields[3])?,
                     voltage_real: vr,
                     voltage_imag: vi,
                 }));
@@ -262,7 +262,7 @@ mod tests {
     use nec_model::card::{Card, CommentCard, EnCard, ExCard, FrCard, GwCard, RpCard};
 
     /// Minimal half-wave dipole deck used as golden round-trip fixture.
-    /// EX format: I1=type I2=tag I3=seg I4=0(unused) F1=vr F2=vi
+    /// EX format: I1=type I2=tag I3=seg I4=aux-int F1=vr F2=vi
     const DIPOLE_DECK: &str = "\
 CM Half-wave dipole at 28 MHz
 CE
@@ -312,6 +312,7 @@ EN
                 excitation_type: 0,
                 tag: 1,
                 segment: 6,
+                i4: 0,
                 voltage_real: 1.0,
                 voltage_imag: 0.0,
             })
@@ -380,5 +381,24 @@ EN
         // CM after EN must not appear
         assert_eq!(result.deck.cards.len(), 2);
         assert_eq!(result.deck.cards[1], Card::En(EnCard));
+    }
+
+    #[test]
+    fn ex_i4_field_is_preserved() {
+        let input = "EX 5 2 7 3 1.5 -0.25\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.deck.cards.len(), 2);
+        assert_eq!(
+            result.deck.cards[0],
+            Card::Ex(ExCard {
+                excitation_type: 5,
+                tag: 2,
+                segment: 7,
+                i4: 3,
+                voltage_real: 1.5,
+                voltage_imag: -0.25,
+            })
+        );
     }
 }

--- a/crates/nec_solver/src/excitation.rs
+++ b/crates/nec_solver/src/excitation.rs
@@ -237,6 +237,7 @@ mod tests {
             excitation_type: 0,
             tag: 1,
             segment: 6, // centre segment (1-based)
+            i4: 0,
             voltage_real: 1.0,
             voltage_imag: 0.0,
         }));
@@ -280,6 +281,7 @@ mod tests {
             excitation_type: 0,
             tag: 1,
             segment: 2,
+            i4: 0,
             voltage_real: 0.5,
             voltage_imag: -0.5,
         }));
@@ -309,6 +311,7 @@ mod tests {
             excitation_type: 5, // not supported
             tag: 1,
             segment: 2,
+            i4: 0,
             voltage_real: 1.0,
             voltage_imag: 0.0,
         }));
@@ -333,6 +336,7 @@ mod tests {
             excitation_type: 0,
             tag: 99, // no such tag
             segment: 1,
+            i4: 0,
             voltage_real: 1.0,
             voltage_imag: 0.0,
         }));
@@ -445,6 +449,7 @@ mod tests {
             excitation_type: 0,
             tag: 1,
             segment: 6,
+            i4: 0,
             voltage_real: 1.0,
             voltage_imag: 0.0,
         }));
@@ -481,6 +486,7 @@ mod tests {
             excitation_type: 0,
             tag: 1,
             segment: 6,
+            i4: 0,
             voltage_real: 1.0,
             voltage_imag: 0.0,
         }));

--- a/crates/nec_solver/src/excitation.rs
+++ b/crates/nec_solver/src/excitation.rs
@@ -36,7 +36,12 @@ pub enum ExcitationError {
     /// An EX card referenced a (tag, segment) pair not present in the geometry.
     SegmentNotFound { tag: u32, segment: u32 },
     /// An EX card uses an excitation type not yet supported.
-    UnsupportedType { ex_type: u32 },
+    UnsupportedType {
+        ex_type: u32,
+        tag: u32,
+        segment: u32,
+        i4: u32,
+    },
     /// Hallen RHS currently assumes all wires are collinear with the feed axis.
     UnsupportedHallenTopology {
         /// Wire tags that are not collinear with the feed segment axis.
@@ -54,8 +59,16 @@ impl std::fmt::Display for ExcitationError {
             ExcitationError::SegmentNotFound { tag, segment } => {
                 write!(f, "EX: no segment with tag {tag}, index {segment}")
             }
-            ExcitationError::UnsupportedType { ex_type } => {
-                write!(f, "EX: excitation type {ex_type} is not yet supported")
+            ExcitationError::UnsupportedType {
+                ex_type,
+                tag,
+                segment,
+                i4,
+            } => {
+                write!(
+                    f,
+                    "EX: excitation type {ex_type} at tag {tag}, segment {segment}, I4={i4} is not yet supported"
+                )
             }
             ExcitationError::UnsupportedHallenTopology {
                 non_collinear_tags,
@@ -119,6 +132,9 @@ pub fn build_hallen_rhs(
         if ex.excitation_type != 0 {
             return Err(ExcitationError::UnsupportedType {
                 ex_type: ex.excitation_type,
+                tag: ex.tag,
+                segment: ex.segment,
+                i4: ex.i4,
             });
         }
         if first_ex.is_none() {
@@ -190,6 +206,9 @@ fn apply_ex(ex: &ExCard, segs: &[Segment], v: &mut [Complex64]) -> Result<(), Ex
     if ex.excitation_type != 0 {
         return Err(ExcitationError::UnsupportedType {
             ex_type: ex.excitation_type,
+            tag: ex.tag,
+            segment: ex.segment,
+            i4: ex.i4,
         });
     }
 
@@ -318,7 +337,12 @@ mod tests {
         let segs = build_geometry(&deck).unwrap();
         assert!(matches!(
             build_excitation(&deck, &segs),
-            Err(ExcitationError::UnsupportedType { ex_type: 5 })
+            Err(ExcitationError::UnsupportedType {
+                ex_type: 5,
+                tag: 1,
+                segment: 2,
+                i4: 0,
+            })
         ));
     }
 

--- a/crates/nec_solver/src/excitation.rs
+++ b/crates/nec_solver/src/excitation.rs
@@ -9,6 +9,7 @@
 //! Only excitation type 0 (series voltage source) is implemented in Phase 1.
 
 use num_complex::Complex64;
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use nec_model::card::{Card, ExCard};
@@ -40,6 +41,10 @@ pub enum ExcitationError {
     UnsupportedHallenTopology {
         /// Wire tags that are not collinear with the feed segment axis.
         non_collinear_tags: Vec<u32>,
+        /// Absolute cosine alignment per non-collinear tag.
+        ///
+        /// 1.0 means collinear, 0.0 means orthogonal.
+        tag_abs_alignment_cos: Vec<(u32, f64)>,
     },
 }
 
@@ -54,10 +59,12 @@ impl std::fmt::Display for ExcitationError {
             }
             ExcitationError::UnsupportedHallenTopology {
                 non_collinear_tags,
+                tag_abs_alignment_cos,
             } => write!(
                 f,
-                "Hallén solver currently supports only collinear wire topologies aligned with the driven segment; non-collinear tags: {:?}",
-                non_collinear_tags
+                "Hallén solver currently supports only collinear wire topologies aligned with the driven segment; non-collinear tags: {:?}; abs(cos)-alignment by tag: {:?}",
+                non_collinear_tags,
+                tag_abs_alignment_cos
             ),
         }
     }
@@ -141,17 +148,25 @@ pub fn build_hallen_rhs(
     let scale = 2.0 * std::f64::consts::PI / ETA0;
 
     let mut non_collinear_tags: BTreeSet<u32> = BTreeSet::new();
+    let mut tag_abs_alignment_cos: BTreeMap<u32, f64> = BTreeMap::new();
     for seg in segs {
         let dot = seg.direction[0] * feed_dir[0]
             + seg.direction[1] * feed_dir[1]
             + seg.direction[2] * feed_dir[2];
-        if dot.abs() < 1.0 - 1e-9 {
+        let abs_dot = dot.abs();
+        if abs_dot < 1.0 - 1e-9 {
             non_collinear_tags.insert(seg.tag);
+            // Keep the best alignment observed for the tag.
+            tag_abs_alignment_cos
+                .entry(seg.tag)
+                .and_modify(|v| *v = v.max(abs_dot))
+                .or_insert(abs_dot);
         }
     }
     if !non_collinear_tags.is_empty() {
         return Err(ExcitationError::UnsupportedHallenTopology {
             non_collinear_tags: non_collinear_tags.into_iter().collect(),
+            tag_abs_alignment_cos: tag_abs_alignment_cos.into_iter().collect(),
         });
     }
 
@@ -440,6 +455,7 @@ mod tests {
             err,
             ExcitationError::UnsupportedHallenTopology {
                 non_collinear_tags: vec![2],
+                tag_abs_alignment_cos: vec![(2, 0.0)],
             }
         );
     }

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -16,8 +16,38 @@
 //! - `tag_index`     — 1-based segment index within the tag
 //! - `global_index`  — 0-based index in the flat segment list
 
-use nec_model::card::{Card, GwCard};
+use nec_model::card::{Card, GnCard, GwCard};
 use nec_model::deck::NecDeck;
+
+/// Ground model extracted from a GN card (or absence thereof).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum GroundModel {
+    /// No ground — free-space simulation (default when no GN card is present).
+    #[default]
+    FreeSpace,
+    /// Perfect electric conductor (PEC) ground at z = 0.
+    ///
+    /// Implemented via the image method: for each real segment a mirror image
+    /// at z → −z is added to the Green's function kernel.
+    PerfectConductor,
+}
+
+/// Extract the ground model from a parsed deck.
+///
+/// Uses the first `GN` card found.  Returns [`GroundModel::FreeSpace`] if no
+/// GN card is present.  GN types other than 1 (PEC) are also treated as
+/// free-space in Phase 1 (Sommerfeld ground is deferred).
+pub fn ground_model_from_deck(deck: &NecDeck) -> GroundModel {
+    for card in &deck.cards {
+        if let Card::Gn(GnCard { ground_type }) = card {
+            return match ground_type {
+                1 => GroundModel::PerfectConductor,
+                _ => GroundModel::FreeSpace,
+            };
+        }
+    }
+    GroundModel::FreeSpace
+}
 
 /// A single NEC wire segment.
 #[derive(Debug, Clone, PartialEq)]
@@ -145,7 +175,7 @@ fn expand_wire(gw: &GwCard, out: &mut Vec<Segment>) -> Result<(), GeometryError>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nec_model::card::{Card, GwCard};
+    use nec_model::card::{Card, GnCard, GwCard};
     use nec_model::deck::NecDeck;
 
     fn deck_with_gw(tag: u32, segs: u32, start: [f64; 3], end: [f64; 3], r: f64) -> NecDeck {
@@ -255,5 +285,18 @@ mod tests {
     fn no_wires_is_error() {
         let deck = NecDeck::new();
         assert!(matches!(build_geometry(&deck), Err(GeometryError::NoWires)));
+    }
+
+    #[test]
+    fn ground_model_defaults_to_free_space_without_gn() {
+        let deck = NecDeck::new();
+        assert_eq!(ground_model_from_deck(&deck), GroundModel::FreeSpace);
+    }
+
+    #[test]
+    fn ground_model_detects_perfect_conductor_gn1() {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gn(GnCard { ground_type: 1 }));
+        assert_eq!(ground_model_from_deck(&deck), GroundModel::PerfectConductor);
     }
 }

--- a/crates/nec_solver/src/lib.rs
+++ b/crates/nec_solver/src/lib.rs
@@ -11,9 +11,11 @@ pub use basis::{ContinuityTransform, SinusoidalTransform};
 pub use excitation::{
     build_excitation, build_hallen_rhs, scale_excitation_for_pulse_rhs, ExcitationError, HallenRhs,
 };
-pub use geometry::{build_geometry, GeometryError, Segment};
+pub use geometry::{build_geometry, ground_model_from_deck, GeometryError, GroundModel, Segment};
 pub use linear::{
     solve, solve_hallen, solve_with_continuity_basis, solve_with_sinusoidal_basis, HallenSolution,
     SolveError,
 };
-pub use matrix::{assemble_pocklington_matrix, assemble_z_matrix, ZMatrix};
+pub use matrix::{
+    assemble_pocklington_matrix, assemble_z_matrix, assemble_z_matrix_with_ground, ZMatrix,
+};

--- a/crates/nec_solver/src/matrix.rs
+++ b/crates/nec_solver/src/matrix.rs
@@ -22,7 +22,7 @@
 
 use num_complex::Complex64;
 
-use crate::geometry::Segment;
+use crate::geometry::{GroundModel, Segment};
 
 // ---------------------------------------------------------------------------
 // Physical constants (SI)
@@ -113,14 +113,32 @@ impl ZMatrix {
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Assemble the N×N Hallén A-matrix for `segs` at frequency `freq_hz`.
+/// Assemble the N×N Hallén A-matrix for `segs` at frequency `freq_hz` in free space.
 ///
-/// Each element A[m,n] = cos(α) · ∫_{seg_n} G(R_eff) dl is a complex
-/// Green's function integral (units: m, dominated by the 1/R static part).
-///
-/// The Hallén system is A × I − C × cos_vec = b, where C is the unknown
-/// homogeneous constant, solved by [`crate::linear::solve_hallen`].
+/// Convenience wrapper around [`assemble_z_matrix_with_ground`] using
+/// [`GroundModel::FreeSpace`].
 pub fn assemble_z_matrix(segs: &[Segment], freq_hz: f64) -> ZMatrix {
+    assemble_z_matrix_with_ground(segs, freq_hz, &GroundModel::FreeSpace)
+}
+
+/// Assemble the N×N Hallén A-matrix for `segs` at frequency `freq_hz`,
+/// optionally including a ground-plane image contribution.
+///
+/// For [`GroundModel::PerfectConductor`] each element A[i,j] gets an
+/// additional term from the mirror image of segment j across z = 0:
+///
+/// ```text
+/// A[i,j] = A_free[i,j] + A_free(segs[i], image(segs[j]))
+/// ```
+///
+/// where `image(seg)` has its z-coordinates negated and its z-direction
+/// component sign-flipped, which produces the correct ±1 reflection
+/// coefficient for horizontal (cos = +1) and vertical (cos = −1) currents.
+pub fn assemble_z_matrix_with_ground(
+    segs: &[Segment],
+    freq_hz: f64,
+    ground: &GroundModel,
+) -> ZMatrix {
     let n = segs.len();
     let mut z = ZMatrix::new(n);
 
@@ -128,7 +146,17 @@ pub fn assemble_z_matrix(segs: &[Segment], freq_hz: f64) -> ZMatrix {
 
     for i in 0..n {
         for j in 0..n {
-            z.set(i, j, elem(&segs[i], &segs[j], k, i == j));
+            let direct = elem(&segs[i], &segs[j], k, i == j);
+            let image_contrib = match ground {
+                GroundModel::FreeSpace => Complex64::new(0.0, 0.0),
+                GroundModel::PerfectConductor => {
+                    let img = image_segment(&segs[j]);
+                    // Image is always at a different location than the
+                    // observation segment, so never treat as self-element.
+                    elem(&segs[i], &img, k, false)
+                }
+            };
+            z.set(i, j, direct + image_contrib);
         }
     }
 
@@ -162,6 +190,29 @@ pub fn assemble_pocklington_matrix(segs: &[Segment], freq_hz: f64) -> ZMatrix {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/// Mirror a segment across the z = 0 ground plane.
+///
+/// - Endpoints and midpoint have their z-coordinate negated.
+/// - The direction vector has its z-component negated.
+///
+/// For a perfect electric conductor at z = 0, the image current of a
+/// horizontal element flows in the same direction (cos_alpha = same sign) and
+/// the image of a vertical element flows in the opposite direction
+/// (cos_alpha = −1), which is the correct image-theory reflection coefficient.
+fn image_segment(seg: &Segment) -> Segment {
+    Segment {
+        tag: seg.tag,
+        tag_index: seg.tag_index,
+        global_index: seg.global_index,
+        start: [seg.start[0], seg.start[1], -seg.start[2]],
+        end: [seg.end[0], seg.end[1], -seg.end[2]],
+        midpoint: [seg.midpoint[0], seg.midpoint[1], -seg.midpoint[2]],
+        direction: [seg.direction[0], seg.direction[1], -seg.direction[2]],
+        length: seg.length,
+        radius: seg.radius,
+    }
+}
 
 /// Compute the (obs, src) Hallén A-matrix element:
 ///   A = cos(α) · ∫_{src} G(R_eff) dl
@@ -437,5 +488,31 @@ mod tests {
             z01.im,
             z10.im
         );
+    }
+
+    #[test]
+    fn pec_ground_changes_hallen_matrix_element() {
+        let s = make_seg(1, 1, 0, [0.0, 0.0, 1.0], DIR_Z, SEG_LEN, RADIUS);
+        let z_free = assemble_z_matrix_with_ground(&[s.clone()], FREQ, &GroundModel::FreeSpace);
+        let z_pec = assemble_z_matrix_with_ground(&[s], FREQ, &GroundModel::PerfectConductor);
+
+        let delta = z_pec.get(0, 0) - z_free.get(0, 0);
+        assert!(
+            delta.norm() > 1e-8,
+            "PEC image term should modify A11, delta={delta}"
+        );
+    }
+
+    #[test]
+    fn image_segment_reflects_across_z0_plane() {
+        let s = make_seg(3, 2, 7, [1.0, -2.0, 4.0], [0.0, 0.6, 0.8], SEG_LEN, RADIUS);
+        let img = image_segment(&s);
+
+        assert_eq!(img.start[2], -s.start[2]);
+        assert_eq!(img.end[2], -s.end[2]);
+        assert_eq!(img.midpoint[2], -s.midpoint[2]);
+        assert_eq!(img.direction[0], s.direction[0]);
+        assert_eq!(img.direction[1], s.direction[1]);
+        assert_eq!(img.direction[2], -s.direction[2]);
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/architecture.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-04-24
 ---
 
 # Architecture
@@ -37,6 +37,7 @@ last_updated: 2026-04-22
 - CPU multithreading is baseline.
 - Runtime acceleration mode selects CPU or GPU path when available.
 - Initial GPU scope is postprocessing only; further offload is staged.
+- Explicit portable-Linux hardware targets include Raspberry Pi 4 (VideoCore VI) and Raspberry Pi 5 (VideoCore VII), so acceleration design must keep ARM64 plus these GPU classes in scope.
 
 ## Extensibility architecture
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,12 +2,25 @@
 project: fnec-rust
 doc: docs/changelog.md
 status: living
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # Changelog
 
 All notable documentation process changes are recorded here.
+
+## 2026-04-24
+
+### Added
+
+- Added Phase 1 `GN` card support for perfect-ground (`GN 1`) Hallen runs.
+- Added PEC image-method contribution path in Hallen matrix assembly.
+- Added parser and solver tests that cover GN parsing and ground-aware matrix behavior.
+
+### Changed
+
+- Updated corpus ground regression reference (`dipole-ground-51seg`) to GN-aware Hallen values.
+- Updated support boundary documentation to reflect current GN status (`GN 1` supported; Sommerfeld/Norton deferred).
 
 ## 2026-04-22
 

--- a/docs/nec4-support.md
+++ b/docs/nec4-support.md
@@ -61,7 +61,7 @@ This document explicitly defines which NEC-2/NEC-4 cards and features are suppor
 
 | Card | Description | Status | Notes |
 |:-----|:------------|:-------|:------|
-| GN | Ground definition | PARTIAL | Type 0 (perfect conductor) supported. Type 1 (Sommerfeld, finite conductivity) DEFERRED (Phase 2). Type 2 (seawater over rock) DEFERRED (Phase 3). |
+| GN | Ground definition | PARTIAL | Type 1 (perfect conductor, z=0 PEC image method) supported. Types -1/0 are treated as free-space for now. Type 2+ (finite-conductivity Sommerfeld/Norton variants) DEFERRED (Phase 2+). |
 | EN | End of input | FULL | Terminates deck parse. |
 
 ### Advanced/specialized cards

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -2,12 +2,22 @@
 project: fnec-rust
 doc: docs/releasenotes.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-04-24
 ---
 
 # Release Notes
 
 ## Unreleased
+
+### Solver
+
+- Added NEC `GN` card support for Phase 1 perfect ground (`GN 1`) in Hallen mode.
+- Hallen matrix assembly now includes a PEC image-method contribution for `GN 1` decks.
+- CLI Hallen runs no longer silently ignore `GN`; ground decks now produce distinct feedpoint impedances.
+
+### Corpus
+
+- Updated `dipole-ground-51seg` golden reference to the new GN-aware Hallen regression value.
 
 ### Documentation
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/requirements.md
 status: living
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # Requirements
@@ -37,6 +37,7 @@ last_updated: 2026-04-23
 ## Non-functional requirements
 
 - **NFR-001**: Primary runtime target is Linux (Wayland), then macOS, then Windows.
+- **NFR-001a**: Linux-on-ARM deployment targets must explicitly include Raspberry Pi 4 and Raspberry Pi 5, with Raspberry Pi 4's VideoCore VI GPU and Raspberry Pi 5's VideoCore VII GPU treated as in-scope optional-acceleration reference hardware.
 - **NFR-002**: CPU execution must be multithreaded and deterministic by default.
 - **NFR-003**: GPU acceleration must be optional at runtime with reliable CPU fallback.
 - **NFR-004**: Numerical compatibility must be measured against a reference with explicit tolerances per metric.


### PR DESCRIPTION
Summary

Adds Phase 1 GN support for perfect-ground Hallen runs.
Implements GN=1 as a z=0 PEC image-method contribution in Hallen matrix assembly.
Wires GN-aware behavior through the CLI Hallen path.
Updates corpus and docs so shipped behavior, support boundary, and regression gates stay aligned.
What changed

Parser/model: GN card is parsed and stored in typed deck data.
Solver: Hallen assembly now supports optional ground contribution and uses image segments for GN=1.
CLI: Hallen route now uses ground-aware assembly when GN=1 is present.
Corpus/docs: dipole-ground reference updated to GN-aware value and documentation synchronized.
Behavioral impact

GN is no longer silently ignored in Hallen mode.
GN=1 ground decks now produce distinct feedpoint impedance from free space.
Current dipole-ground regression target:
81.914743 + j16.416629 ohm
Validation

cargo test --workspace
[validate-doc-frontmatter.sh](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Risk and impact

Technical risk: medium, due to Hallen matrix path changes.
Regression surface: parser/model mapping, Hallen assembly, CLI routing, corpus expectations.
Mitigations: targeted tests, full workspace test pass, constrained scope, explicit docs updates.
Known limitations

Scope is GN=1 only on Hallen path.
Finite-conductivity ground models (Sommerfeld/Norton) remain deferred.
Non-collinear Hallen topologies remain out of current production scope (explicit fail-fast behavior).
Ground corpus update is regression-gating for current fnec behavior, not full external NEC parity claim.
Commits in PR

dcc8eaa parser/solver: add GN=1 PEC image-method support
8b1228c docs/corpus: update GN ground references and support matrix
607ca19 docs: sync README and release notes for GN support
Reviewer checklist

Confirm GN parsing/fallback semantics are correct for current scope.
Confirm image-method orientation/sign handling in Hallen assembly.
Confirm corpus gate update matches intended GN-aware behavior.
Confirm docs consistently separate shipped GN=1 from deferred ground models.