### PR TITLE
cli: surface parser warnings in stderr

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -267,6 +267,10 @@ fn main() -> ExitCode {
         }
     };
 
+    for warning in &result.warnings {
+        eprintln!("warning: {warning}");
+    }
+
     let deck = &result.deck;
 
     warn_pulse_mode_experimental(solver_mode);

--- a/apps/nec-cli/tests/parser_warnings.rs
+++ b/apps/nec-cli/tests/parser_warnings.rs
@@ -1,0 +1,39 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn unknown_card_emits_parser_warning_but_run_succeeds() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-unknown-card-{now}.nec"));
+
+    let deck = "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nZZ 123\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary deck with unknown card");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for parser warning test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: line 2: unknown card 'ZZ'"),
+        "expected parser warning in stderr, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Emit non-fatal parser warnings from `nec_parser::ParseResult.warnings` in CLI stderr.
- Preserve existing run behavior (warnings do not fail execution).
- Add integration test coverage for unknown-card warning output.

## Changes
- Update CLI warning emission path in `apps/nec-cli/src/main.rs`.
- Add `apps/nec-cli/tests/parser_warnings.rs`.

## Validation
- cargo fmt --all
- cargo test --workspace
- Result: 64 passed, 0 failed.

## Risk
Low. Diagnostics-only output change with integration test coverage.