### PR TITLE
corpus/docs: track pending external parity for dipole-ground

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -50,6 +50,10 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Z_in ≈ 81.91 + j16.42 Ω
 - Current distribution: distorted from free-space case due to image interaction
 
+**External parity status**:
+- External reference candidate for this case is tracked in `corpus/reference-results.json` and remains pending capture from xnec2c/4nec2.
+- CI currently gates the GN=1 regression value and prints external deltas when candidate values are present.
+
 **Tolerance gates**: Same as dipole-freesp (R, X, current).
 
 **Why this case**: Ground effects are critical for practical antennas. Validates GN=1 perfect-ground image-method behavior.

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -39,13 +39,18 @@
         "real_ohm": 81.914743,
         "imag_ohm": 16.416629
       },
+      "external_reference_candidate": {
+        "source": "xnec2c/4nec2 external capture pending",
+        "real_ohm": null,
+        "imag_ohm": null
+      },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "GN=1 PEC image-method support active; reference captured from fnec Hallen for regression gating"
+      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate placeholder added; xnec2c/4nec2 capture pending."
     },
     "yagi-5elm-51seg": {
       "deck_file": "yagi-5elm-51seg.nec",

--- a/docs/solver-findings.md
+++ b/docs/solver-findings.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/solver-findings.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-04-24
 ---
 
 # Solver Findings
@@ -31,6 +31,18 @@ After fixing two bugs (`e098fb4`, `c302f29`):
 
 The Hallén augmented system (`[A | −cos] [I; C] = b`) with the correct
 `2π/η₀` RHS prefactor and NEC sign convention is the production-accurate solver.
+
+### Hallén with GN=1 (PEC image method) — REGRESSION-COVERED
+
+For `corpus/dipole-ground-51seg.nec` (14.2 MHz, 10 m AGL), current CI-regression value is:
+
+| Mode | Case | Value |
+|:-----|:-----|:------|
+| hallen + GN=1 | dipole-ground-51seg | **81.914743 + j16.416629 Ω** |
+
+This confirms GN=1 ground behavior is no longer silently ignored in the Hallen path.
+External-reference parity for this case is still pending explicit xnec2c/4nec2 capture;
+the corpus now tracks an `external_reference_candidate` placeholder for that follow-up.
 
 ### Pulse/continuity solver — DIVERGES (known broken)
 


### PR DESCRIPTION
## Summary
- Add an explicit `external_reference_candidate` placeholder for `dipole-ground-51seg` in corpus metadata.
- Update corpus README to clarify current regression gating vs pending external parity capture.
- Update solver findings with current GN=1 ground regression snapshot and external parity status.

## Why
Ground-case regression is active, but external NEC parity capture for this case is still pending. This change makes that state explicit and auditable.

## Validation
- ./scripts/validate-doc-frontmatter.sh
- cargo test -p nec-cli --test corpus_validation