### PR TITLE
docs: add KaTeX formula equivalents

### DIFF
--- a/docs/applied-math.md
+++ b/docs/applied-math.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/applied-math.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-04-24
 ---
 
 # Applied Math Reference
@@ -91,3 +91,53 @@ Recover segment currents by I_seg = T*a after solve.
   with analytic integral for 1/R_eff part.
 - Direct normal equations amplify conditioning issues; QR/SVD is typically more robust for overdetermined augmented systems.
 - Constraint enforcement (tip current, symmetry, feed normalization) should be explicit and unit-tested.
+
+## KaTeX Formula Equivalents
+
+$$
+\omega = 2\pi f
+$$
+
+$$
+\eta_0 = \sqrt{\frac{\mu_0}{\varepsilon_0}}, \qquad
+k = \frac{\omega}{c_0} = \frac{2\pi}{\lambda}
+$$
+
+$$
+G(R) = \frac{e^{-jkR}}{R}
+$$
+
+$$
+E_{\mathrm{inc}}(z) + E_{\mathrm{scat}}(z) = 0
+$$
+
+$$
+E_{\mathrm{scat}} = -j\omega A_t - \nabla_t \Phi
+$$
+
+$$
+A_z(z) = \frac{\mu_0}{4\pi}\int I(z')\,G(R)\,dz'
+$$
+
+$$
+E_{\mathrm{scat}}(z) = -\frac{j\omega\mu_0}{4\pi}\int I(z')\left[k^2 + \frac{d^2}{dz^2}\right]G(R)\,dz'
+$$
+
+$$
+\int I(z')\,G(R)\,dz' = F(z) + C_1\cos(kz) + C_2\sin(kz)
+$$
+
+$$
+Z_{\mathrm{in}} = \frac{V_{\mathrm{source}}}{I_{\mathrm{source}}}, \qquad
+V_{\mathrm{source}} = \left(\frac{V_0}{dl}\right)dl
+$$
+
+$$
+I_{\mathrm{seg}} = Ta, \qquad
+ZTa = v, \qquad
+\left(T^H Z^H Z T\right)a = T^H Z^H v
+$$
+
+$$
+G(R_{\mathrm{eff}})=\left[G(R_{\mathrm{eff}})-\frac{1}{R_{\mathrm{eff}}}\right]+\frac{1}{R_{\mathrm{eff}}}
+$$

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/backlog.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-04-24
 ---
 
 # Backlog
@@ -42,3 +42,9 @@ last_updated: 2026-04-22
 
 - [ ] **PAR-009 / xnec2c-optimize external optimizer-loop parity / Owner: Automation+CLI / Target: Phase 3 / Issue: #22**
 	Resolution criteria: deterministic objective-evaluation CLI/API contract documented; at least one xnec2c-optimize-style optimization flow reproduced end-to-end with fnec-rust automation hooks; machine-readable outputs verified stable across repeated runs.
+
+## KaTeX Formula Equivalents
+
+$$
+	ext{Pulse RHS normalization candidate: } \frac{1}{dl\,\lambda}
+$$

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,3 +42,9 @@ All notable documentation process changes are recorded here.
 - Added documented mode benchmark deltas across segment counts in solver findings.
 - Added explicit Hallen vs Pocklington matrix routing by solver mode and post-change benchmark notes.
 - Added NEC2 reference-inspired pulse RHS wavelength normalization path (`1/(dl*lambda)`) and validation notes.
+
+## KaTeX Formula Equivalents
+
+$$
+	ext{Pulse RHS wavelength normalization: } \frac{1}{dl\,\lambda}
+$$

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/cli-guide.md
 status: living
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # CLI Guide — fnec (v0.1.0)
@@ -170,3 +170,17 @@ EN
 - The Hallén solver currently rejects non-collinear wire topologies such as loaded loops and hats attached off-axis to the driven wire.
 - Only EX type 0 (voltage source) is implemented.  EX type 5 (current source / NEC `qdsrc`) is not yet supported.
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
+
+## KaTeX Formula Equivalents
+
+$$
+Z_{\mathrm{in}} = R + jX
+$$
+
+$$
+Z_{\mathrm{in}} = \frac{V_{\mathrm{source}}}{I_{\mathrm{source}}}
+$$
+
+$$
+\mathrm{rel\_res} = \frac{\lVert Ax-b\rVert_2}{\lVert b\rVert_2}
+$$

--- a/docs/corpus-validation-strategy.md
+++ b/docs/corpus-validation-strategy.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/corpus-validation-strategy.md
 status: living
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # Corpus Validation Strategy
@@ -257,3 +257,24 @@ To add a new corpus case:
 - `apps/nec-cli/tests/corpus_validation.rs` — Integration test implementation
 - `docs/requirements.md` — Tolerance matrix and numerical compatibility policy
 - `docs/roadmap.md` — Phase gates and blocker definitions
+
+## KaTeX Formula Equivalents
+
+$$
+\Delta R \le \max\left(0.05\,\Omega,\, 0.001\,|R_{\mathrm{ref}}|\right)
+$$
+
+$$
+\Delta X \le \max\left(0.05\,\Omega,\, 0.001\,|X_{\mathrm{ref}}|\right)
+$$
+
+$$
+\Delta G_{\max} \le 0.05\,\mathrm{dB}, \qquad
+\Delta G_{\mathrm{sample}} \le 0.1\,\mathrm{dB}
+$$
+
+$$
+\Delta |I| \le 0.001\,|I_{\mathrm{ref}}|, \qquad
+\Delta \angle I \le 0.1^\circ, \qquad
+\Delta \mathrm{SWR} \le 0.01
+$$

--- a/docs/nec4-support.md
+++ b/docs/nec4-support.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/nec4-support.md
 status: living
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # NEC-4 Support Boundary
@@ -193,3 +193,17 @@ fnec-rust is **4nec2-first**. The parser and solver primarily target 4nec2 compa
 - `docs/requirements.md` — Tolerance matrix and numerical compatibility policy
 - `docs/roadmap.md` — Phase definitions and deliverables
 - `corpus/README.md` — Golden reference corpus cases and validation
+
+## KaTeX Formula Equivalents
+
+$$
+	ext{GN type }1 \Rightarrow \text{PEC image method at } z=0
+$$
+
+$$
+Z_{\mathrm{in}} = \frac{V_{\mathrm{source}}}{I_{\mathrm{source}}} = R + jX
+$$
+
+$$
+	ext{Validated Hallen baseline: } Z_{\mathrm{in}} \approx 74.24 + j\,13.90\,\Omega
+$$

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -88,6 +88,27 @@ Tolerances below define the strictest acceptable deviation; any failure is a def
 | Segment current phase | degrees | ≤ 0.1 ° | Near-exact parity |
 | SWR (derived) | — | ≤ 0.01 absolute | Derived metric; tight because R/X targets already bind it |
 
+### KaTeX Formula Equivalents
+
+$$
+\Delta R \le \max\left(0.05\,\Omega,\, 0.001\,|R_{\mathrm{ref}}|\right)
+$$
+
+$$
+\Delta X \le \max\left(0.05\,\Omega,\, 0.001\,|X_{\mathrm{ref}}|\right)
+$$
+
+$$
+\Delta G_{\max} \le 0.05\,\mathrm{dB}, \qquad
+\Delta G_{\mathrm{sample}} \le 0.1\,\mathrm{dB}
+$$
+
+$$
+\Delta |I| \le 0.001\,|I_{\mathrm{ref}}|, \qquad
+\Delta \angle I \le 0.1^\circ, \qquad
+\Delta \mathrm{SWR} \le 0.01
+$$
+
 ### Tolerance policy
 
 - If a reference value is near zero the absolute floor applies to avoid meaninglessly large relative errors.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/roadmap.md
 status: living
-last_updated: 2026-04-23
+last_updated: 2026-04-24
 ---
 
 # Roadmap
@@ -198,3 +198,13 @@ fnec-rust is not aiming for "good enough for a Rust rewrite". The target is to b
 | BLK-003 | 4nec2 text report format contract locked; golden corpus results validated within tolerance | **Resolved 2026-04-23** |
 | BLK-004 | Plugin API design, safety model, first two extension points working | Phase 3 → Phase 4 |
 | BLK-005 | GPLv2 dependency policy thresholds and exception process documented | Phase 2 → Phase 3 |
+
+## KaTeX Formula Equivalents
+
+$$
+\lambda/2\ \text{dipole validation point: } Z_{\mathrm{in}} \approx 74.24 + j\,13.90\,\Omega
+$$
+
+$$
+\Delta R,\Delta X,\Delta G,\Delta I\ \text{must remain within contract tolerances at each phase gate}
+$$

--- a/docs/rooftop-basis-plan.md
+++ b/docs/rooftop-basis-plan.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/rooftop-basis-plan.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-04-24
 ---
 
 # Rooftop Basis Plan
@@ -53,3 +53,21 @@ Recent findings showed that pulse-only formulations can produce strong cancellat
 - Keep CLI output contract unchanged.
 - Introduce this as an internal solver path first, behind a clearly isolated API.
 - Preserve room for later sinusoidal basis or higher-order basis options.
+
+## KaTeX Formula Equivalents
+
+$$
+I_{\mathrm{seg}} = T a
+$$
+
+$$
+Z T a = v
+$$
+
+$$
+Z_{\mathrm{in}} = \frac{V_{\mathrm{source}}}{I_{\mathrm{source}}}
+$$
+
+$$
+I_{\mathrm{tip}} = 0
+$$

--- a/docs/solver-findings.md
+++ b/docs/solver-findings.md
@@ -92,3 +92,26 @@ runtime warning.  A sinusoidal-basis EFIE fix is tracked in `docs/backlog.md`.
 - Burke & Poggio, "NEC2 Theory of Operation", LLNL 1981
 - M5AIQ NEC resources: https://www.qsl.net/m5aiq/nec.html
 
+## KaTeX Formula Equivalents
+
+$$
+Z_{\mathrm{hallen}}(N=51) \approx 74.242874 + j\,13.899516\,\Omega
+$$
+
+$$
+\left[\,A\;|\;-\cos\,\right]
+\begin{bmatrix}
+I\\
+C
+\end{bmatrix}
+= b
+$$
+
+$$
+	ext{Hallen RHS prefactor} = \frac{2\pi}{\eta_0}
+$$
+
+$$
+Z_{\mathrm{hallen},\,GN=1} \approx 81.914743 + j\,16.416629\,\Omega
+$$
+


### PR DESCRIPTION
## Summary
- add KaTeX-renderable equivalents alongside existing notation in formula-heavy docs
- keep existing notation unchanged
- update docs frontmatter dates where touched

## Validation
- ./scripts/validate-doc-frontmatter.sh