### PR TITLE
corpus: record nec2c external candidate for dipole-ground

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -40,9 +40,9 @@
         "imag_ohm": 16.416629
       },
       "external_reference_candidate": {
-        "source": "xnec2c/4nec2 external capture pending",
-        "real_ohm": null,
-        "imag_ohm": null
+        "source": "nec2c 1.3.1 on Arch Linux (deck copy with XQ appended)",
+        "real_ohm": 74.792,
+        "imag_ohm": 43.942
       },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
@@ -50,7 +50,7 @@
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate placeholder added; xnec2c/4nec2 capture pending."
+      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy; xnec2c/4nec2 parity capture remains pending."
     },
     "yagi-5elm-51seg": {
       "deck_file": "yagi-5elm-51seg.nec",


### PR DESCRIPTION
## Summary
- fill dipole-ground external_reference_candidate with nec2c 1.3.1 capture
- keep fnec regression reference unchanged
- note provenance (XQ appended in copied deck for nec2c command execution)

## Validation
- cargo test -p nec-cli --test corpus_validation