### PR TITLE
corpus: record nec2c external candidates for yagi and multi-source

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -65,13 +65,18 @@
         "real_ohm": 139.097279,
         "imag_ohm": -125.572548
       },
+      "external_reference_candidate": {
+        "source": "nec2c 1.3.1 on Arch Linux (deck copy with XQ appended)",
+        "real_ohm": 8.1749,
+        "imag_ohm": 56.538
+      },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "Regression reference captured from fnec; NEC2 cross-validation TBD"
+      "status": "Regression reference captured from fnec; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy"
     },
     "dipole-loaded": {
       "deck_file": "dipole-loaded.nec",
@@ -144,13 +149,18 @@
         "source_1": {"real_ohm": 152.352950, "imag_ohm": 31.560358},
         "source_2": {"real_ohm": 152.352950, "imag_ohm": 31.560358}
       },
+      "external_reference_candidate": {
+        "source": "nec2c 1.3.1 on Arch Linux (deck copy with XQ appended)",
+        "source_1": {"real_ohm": 163.20, "imag_ohm": 68.529},
+        "source_2": {"real_ohm": 163.20, "imag_ohm": 68.529}
+      },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05
       },
-      "status": "Regression reference captured from fnec for both feedpoints; NEC2 cross-validation TBD"
+      "status": "Regression reference captured from fnec for both feedpoints; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy"
     }
   }
 }


### PR DESCRIPTION
Captures nec2c 1.3.1 external reference impedances for the two remaining corpus cases that lacked external candidates.

- **yagi-5elm-51seg**: 8.1749 + j56.538 Ω (nec2c 1.3.1, XQ-appended deck copy)
- **multi-source** (both feedpoints): 163.20 + j68.529 Ω (nec2c 1.3.1, XQ-appended deck copy)

All 6 corpus cases now have external reference candidates. Experiment deck copies retained under `.tmp-work/nec2c-experiments/` (untracked).