### PR TITLE
solver/cli: infer PEC ground from GE I1=1 when no GN card present

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -60,6 +60,7 @@ jobs:
             echo "Skipping benchmark compare: expected files not found."
             echo "  base_csv=${base_csv}"
             echo "  candidate_csv=${candidate_csv}"
+          fi
 
       - name: Write skip summary
         if: steps.detect.outputs.should_run != 'true'
@@ -72,7 +73,6 @@ jobs:
             echo "- base_csv: \`${{ steps.cfg.outputs.base_csv }}\`"
             echo "- candidate_csv: \`${{ steps.cfg.outputs.candidate_csv }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
-          fi
 
       - name: Run benchmark compare gate
         if: steps.detect.outputs.should_run == 'true'

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -204,9 +204,12 @@ fn warn_ge_ground_reflection_flag(deck: &nec_model::deck::NecDeck) {
         return;
     };
 
-    if flag != 0 {
+    // GE I1=0: no ground (default, no action needed).
+    // GE I1=1: PEC image method — now handled via ground_model_from_deck.
+    // Other values (e.g. -1 for half-space absorption) are not yet supported.
+    if flag != 0 && flag != 1 {
         eprintln!(
-            "warning: GE ground-reflection flag {flag} is not yet implemented; geometry reflection is ignored in Phase 1"
+            "warning: GE ground-reflection flag {flag} is not yet supported; treating as free-space"
         );
     }
 }

--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -41,17 +41,22 @@ fn gn_deferred_type_emits_warning_and_falls_back_to_free_space() {
 }
 
 #[test]
-fn ge_reflection_flag_emits_warning() {
+fn ge1_without_gn_infers_pec_ground() {
+    // GE 1 without an explicit GN card should infer PEC image-method ground.
+    // The dipole from z=4.718m to z=15.282m over PEC ground (same geometry as
+    // corpus/dipole-ground-51seg.nec which uses GE + GN 1) should produce the
+    // same feedpoint impedance: ~81.91 + j16.42 Ω.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock before UNIX_EPOCH")
         .as_nanos();
-    let deck_path = std::env::temp_dir().join(format!("fnec-ge1-{now}.nec"));
+    let deck_path = std::env::temp_dir().join(format!("fnec-ge1-pec-{now}.nec"));
 
+    // Same wire geometry as dipole-ground-51seg.nec, GE 1 instead of GE + GN 1.
     let deck =
-        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGE 1\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
-    fs::write(&deck_path, deck).expect("failed to write temporary GE deck");
+        "GW 1 51 0 0 4.718 0 0 15.282 0.001\nGE 1\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary GE1 deck");
 
     let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
         .arg("--solver")
@@ -59,7 +64,7 @@ fn ge_reflection_flag_emits_warning() {
         .arg(&deck_path)
         .current_dir(&workspace_root)
         .output()
-        .unwrap_or_else(|e| panic!("Failed to run fnec for GE diagnostics test: {e}"));
+        .unwrap_or_else(|e| panic!("Failed to run fnec for GE1 PEC inference test: {e}"));
 
     let _ = fs::remove_file(&deck_path);
 
@@ -71,9 +76,80 @@ fn ge_reflection_flag_emits_warning() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains(
-            "warning: GE ground-reflection flag 1 is not yet implemented; geometry reflection is ignored in Phase 1"
-        ),
-        "expected GE reflection warning in stderr, got:\n{stderr}"
+        !stderr.contains("warning: GE ground-reflection flag"),
+        "unexpected GE warning for GE 1 (should be silently handled):\n{stderr}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Parse Z_RE from the feedpoint row: "1 26 ... Z_RE Z_IM"
+    let z_re = stdout
+        .lines()
+        .find_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 8 && parts[0] == "1" && parts[1] == "26" {
+                parts[6].parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .expect("no feedpoint row in output");
+
+    let z_im = stdout
+        .lines()
+        .find_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 8 && parts[0] == "1" && parts[1] == "26" {
+                parts[7].parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .expect("no feedpoint row for imag");
+
+    // Tolerance: same as corpus gate (0.05 Ω absolute).
+    assert!(
+        (z_re - 81.914743).abs() < 0.05,
+        "Z_RE mismatch for GE1 PEC deck: got {z_re}, expected ~81.91"
+    );
+    assert!(
+        (z_im - 16.416629).abs() < 0.05,
+        "Z_IM mismatch for GE1 PEC deck: got {z_im}, expected ~16.42"
+    );
+}
+
+#[test]
+fn ge_negative_flag_emits_unsupported_warning() {
+    // GE I1=-1 (half-space without image) is not supported; should warn.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-ge-neg-{now}.nec"));
+
+    let deck =
+        "GW 1 51 0 0 4.718 0 0 15.282 0.001\nGE -1\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary GE-1 deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for GE negative flag test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: GE ground-reflection flag -1 is not yet supported"),
+        "expected unsupported-flag warning in stderr, got:\n{stderr}"
     );
 }

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -16,7 +16,7 @@
 //! - `tag_index`     — 1-based segment index within the tag
 //! - `global_index`  — 0-based index in the flat segment list
 
-use nec_model::card::{Card, GnCard, GwCard};
+use nec_model::card::{Card, GeCard, GnCard, GwCard};
 use nec_model::deck::NecDeck;
 
 /// Ground model extracted from a GN card (or absence thereof).
@@ -39,18 +39,35 @@ pub enum GroundModel {
 
 /// Extract the ground model from a parsed deck.
 ///
-/// Uses the first `GN` card found.  Returns [`GroundModel::FreeSpace`] if no
-/// GN card is present.
-///
-/// - `GN 1` maps to [`GroundModel::PerfectConductor`].
-/// - Any other GN type maps to [`GroundModel::Deferred`].
+/// Resolution order:
+/// 1. If a `GN` card is present it takes priority.
+///    - `GN 1`  → [`GroundModel::PerfectConductor`].
+///    - Other GN types → [`GroundModel::Deferred`].
+/// 2. If no `GN` card is present but a `GE` card has `ground_reflection_flag > 0`
+///    (the standard NEC flag for "enable image-method PEC ground at z = 0"),
+///    infer [`GroundModel::PerfectConductor`].
+/// 3. Otherwise returns [`GroundModel::FreeSpace`].
 pub fn ground_model_from_deck(deck: &NecDeck) -> GroundModel {
+    // GN card takes priority.
     for card in &deck.cards {
         if let Card::Gn(GnCard { ground_type }) = card {
             return match ground_type {
                 1 => GroundModel::PerfectConductor,
                 other => GroundModel::Deferred { gn_type: *other },
             };
+        }
+    }
+    // No GN card: check GE flag.  GE I1=1 is the conventional NEC shorthand
+    // for "perfect electric conductor ground, apply image method", and GE I1=-1
+    // is a half-space variant that is not yet supported.
+    for card in &deck.cards {
+        if let Card::Ge(GeCard {
+            ground_reflection_flag,
+        }) = card
+        {
+            if *ground_reflection_flag == 1 {
+                return GroundModel::PerfectConductor;
+            }
         }
     }
     GroundModel::FreeSpace


### PR DESCRIPTION
GE I1=1 is the standard NEC shorthand for image-method PEC ground. Previously it warned and fell back to free-space.

Changes:
- `ground_model_from_deck` falls through to GE flag when no GN card present; GE 1 → `PerfectConductor`
- `warn_ge_ground_reflection_flag` only warns for flags outside {0, 1} (e.g. -1 is still unsupported)
- Tests updated: `ge1_without_gn_infers_pec_ground` verifies correct PEC impedance; `ge_negative_flag_emits_unsupported_warning` verifies warning fires for GE -1

All 25 tests passing.