### PR TITLE
Support per-wire sinusoidal/continuity basis

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -8,8 +8,8 @@ use nec_solver::build_loads;
 use nec_solver::{
     assemble_pocklington_matrix, assemble_z_matrix_with_ground, build_excitation, build_geometry,
     build_hallen_rhs_with_options, ground_model_from_deck, scale_excitation_for_pulse_rhs, solve,
-    solve_hallen, solve_with_continuity_basis, solve_with_sinusoidal_basis, GroundModel, Segment,
-    ZMatrix,
+    solve_hallen, solve_with_continuity_basis_per_wire, solve_with_sinusoidal_basis_per_wire,
+    wire_endpoints_from_segs, GroundModel, ZMatrix,
 };
 use num_complex::Complex64;
 use std::path::PathBuf;
@@ -24,17 +24,6 @@ enum SolverMode {
     Pulse,
     Continuity,
     Sinusoidal,
-}
-
-impl SolverMode {
-    fn as_str(self) -> &'static str {
-        match self {
-            SolverMode::Hallen => "hallen",
-            SolverMode::Pulse => "pulse",
-            SolverMode::Continuity => "continuity",
-            SolverMode::Sinusoidal => "sinusoidal",
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,22 +108,6 @@ fn parse_args(args: &[String]) -> Result<(SolverMode, PulseRhsMode, bool, PathBu
         hallen_allow_non_collinear,
         path,
     ))
-}
-
-fn is_single_linear_chain(segs: &[Segment]) -> bool {
-    if segs.is_empty() {
-        return false;
-    }
-    let tag = segs[0].tag;
-    for (idx, s) in segs.iter().enumerate() {
-        if s.tag != tag {
-            return false;
-        }
-        if s.tag_index as usize != idx + 1 {
-            return false;
-        }
-    }
-    true
 }
 
 fn l2_norm(v: &[Complex64]) -> f64 {
@@ -358,16 +331,9 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let single_linear_chain = is_single_linear_chain(&segs);
-
-    if matches!(solver_mode, SolverMode::Continuity | SolverMode::Sinusoidal)
-        && !single_linear_chain
-    {
-        eprintln!(
-            "warning: {} solver currently supports only single linear chains; falling back to pulse on this topology",
-            solver_mode.as_str()
-        );
-    }
+    // Per-wire basis solve requires every wire to have >= 2 segments.
+    let wire_endpoints = wire_endpoints_from_segs(&segs);
+    let per_wire_basis_feasible = wire_endpoints.iter().all(|&(first, last)| last > first);
 
     let v_vec = match build_excitation(deck, &segs) {
         Ok(v) => v,
@@ -447,7 +413,10 @@ fn main() -> ExitCode {
                 }
             },
             SolverMode::Continuity => {
-                if !single_linear_chain {
+                if !per_wire_basis_feasible {
+                    eprintln!(
+                        "warning: continuity solver requires >=2 segments per wire; falling back to pulse"
+                    );
                     match solve(&z_mat, &v_vec_pulse) {
                         Ok(i) => {
                             let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
@@ -459,7 +428,11 @@ fn main() -> ExitCode {
                         }
                     }
                 } else {
-                    match solve_with_continuity_basis(&z_mat, &v_vec_pulse) {
+                    match solve_with_continuity_basis_per_wire(
+                        &z_mat,
+                        &v_vec_pulse,
+                        &wire_endpoints,
+                    ) {
                         Ok(i) => {
                             let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
                             if r <= CONTINUITY_REL_RESIDUAL_MAX {
@@ -490,7 +463,10 @@ fn main() -> ExitCode {
                 }
             }
             SolverMode::Sinusoidal => {
-                if !single_linear_chain {
+                if !per_wire_basis_feasible {
+                    eprintln!(
+                        "warning: sinusoidal solver requires >=2 segments per wire; falling back to pulse"
+                    );
                     match solve(&z_mat, &v_vec_pulse) {
                         Ok(i) => {
                             let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
@@ -502,7 +478,11 @@ fn main() -> ExitCode {
                         }
                     }
                 } else {
-                    match solve_with_sinusoidal_basis(&z_mat, &v_vec_pulse) {
+                    match solve_with_sinusoidal_basis_per_wire(
+                        &z_mat,
+                        &v_vec_pulse,
+                        &wire_endpoints,
+                    ) {
                         Ok(i) => {
                             let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
                             if r <= SINUSOIDAL_REL_RESIDUAL_MAX {

--- a/apps/nec-cli/tests/topology_fallback.rs
+++ b/apps/nec-cli/tests/topology_fallback.rs
@@ -14,8 +14,9 @@ fn assert_non_single_chain_fallback(solver: &str, expected_diag_mode: &str) {
         .as_nanos();
     let deck_path = std::env::temp_dir().join(format!("fnec-topology-fallback-{solver}-{now}.nec"));
 
-    // Two disjoint wires (different tags) to ensure the topology is not a single linear chain.
-    let deck = "GW 1 11 0.0 0.0 -1.0 0.0 0.0 1.0 0.001\nGW 2 11 0.5 0.0 -1.0 0.5 0.0 1.0 0.001\nEX 0 1 6 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    // Topology that is invalid for per-wire basis solve: one wire has only 1 segment.
+    // This must force continuity/sinusoidal to fall back to pulse.
+    let deck = "GW 1 11 0.0 0.0 -1.0 0.0 0.0 1.0 0.001\nGW 2 1 0.5 0.0 0.0 0.5 0.0 0.1 0.001\nEX 0 1 6 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
     fs::write(&deck_path, deck).expect("failed to write temporary topology-fallback deck");
 
     let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
@@ -36,7 +37,7 @@ fn assert_non_single_chain_fallback(solver: &str, expected_diag_mode: &str) {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(&format!(
-            "warning: {solver} solver currently supports only single linear chains; falling back to pulse on this topology"
+            "warning: {solver} solver requires >=2 segments per wire; falling back to pulse"
         )),
         "expected topology fallback warning in stderr, got:\n{stderr}"
     );

--- a/crates/nec_solver/src/excitation.rs
+++ b/crates/nec_solver/src/excitation.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 use nec_model::card::{Card, ExCard};
 use nec_model::deck::NecDeck;
 
-use crate::geometry::Segment;
+use crate::geometry::{wire_endpoints_from_segs, Segment};
 
 const C0: f64 = 299_792_458.0; // m/s
 const MU0: f64 = 4.0 * std::f64::consts::PI * 1e-7; // H/m
@@ -314,26 +314,6 @@ pub fn build_hallen_rhs_with_options(
         cos_vec,
         wire_endpoints: wire_endpoints_from_segs(segs),
     })
-}
-
-/// Compute per-wire endpoint indices (first, last global segment index per wire tag).
-fn wire_endpoints_from_segs(segs: &[Segment]) -> Vec<(usize, usize)> {
-    let mut out: Vec<(usize, usize)> = Vec::new();
-    let mut current_tag = u32::MAX;
-    let mut first = 0usize;
-    for (i, seg) in segs.iter().enumerate() {
-        if seg.tag != current_tag {
-            if current_tag != u32::MAX {
-                out.push((first, i - 1));
-            }
-            current_tag = seg.tag;
-            first = i;
-        }
-    }
-    if current_tag != u32::MAX {
-        out.push((first, segs.len() - 1));
-    }
-    out
 }
 
 fn apply_ex(ex: &ExCard, segs: &[Segment], v: &mut [Complex64]) -> Result<(), ExcitationError> {

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -123,6 +123,30 @@ impl std::fmt::Display for GeometryError {
 
 impl std::error::Error for GeometryError {}
 
+/// Compute per-wire endpoint indices from a flat segment list.
+///
+/// Wires are identified by contiguous runs of segments sharing the same tag.
+/// Returns a `Vec` of `(first, last)` inclusive global-index pairs, one per
+/// wire, in deck order.  An empty segment list returns an empty `Vec`.
+pub fn wire_endpoints_from_segs(segs: &[Segment]) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::new();
+    let mut current_tag = u32::MAX;
+    let mut first = 0usize;
+    for (i, seg) in segs.iter().enumerate() {
+        if seg.tag != current_tag {
+            if current_tag != u32::MAX {
+                out.push((first, i - 1));
+            }
+            current_tag = seg.tag;
+            first = i;
+        }
+    }
+    if current_tag != u32::MAX {
+        out.push((first, segs.len() - 1));
+    }
+    out
+}
+
 /// Build the flat segment list from all `GW`, `GM`, and `GR` cards in `deck`.
 ///
 /// Cards are processed in deck order:

--- a/crates/nec_solver/src/lib.rs
+++ b/crates/nec_solver/src/lib.rs
@@ -13,10 +13,13 @@ pub use excitation::{
     build_excitation, build_hallen_rhs, build_hallen_rhs_with_options,
     scale_excitation_for_pulse_rhs, ExcitationError, HallenRhs,
 };
-pub use geometry::{build_geometry, ground_model_from_deck, GeometryError, GroundModel, Segment};
+pub use geometry::{
+    build_geometry, ground_model_from_deck, wire_endpoints_from_segs, GeometryError, GroundModel,
+    Segment,
+};
 pub use linear::{
-    solve, solve_hallen, solve_with_continuity_basis, solve_with_sinusoidal_basis, HallenSolution,
-    SolveError,
+    solve, solve_hallen, solve_with_continuity_basis, solve_with_continuity_basis_per_wire,
+    solve_with_sinusoidal_basis, solve_with_sinusoidal_basis_per_wire, HallenSolution, SolveError,
 };
 pub use loads::{build_loads, LoadWarning};
 pub use matrix::{

--- a/crates/nec_solver/src/linear.rs
+++ b/crates/nec_solver/src/linear.rs
@@ -222,6 +222,158 @@ fn projected_system(
     (projected_z, projected_v)
 }
 
+/// Build a block-diagonal sinusoidal transform for `n` segments split into
+/// `wire_endpoints` chains.  Each wire `(first, last)` gets its own
+/// `SinusoidalTransform::for_single_chain(n_w)` block placed at the
+/// corresponding rows/columns of the global transform.
+fn build_block_sinusoidal_transform(n: usize, wire_endpoints: &[(usize, usize)]) -> Vec<Vec<f64>> {
+    let m: usize = wire_endpoints
+        .iter()
+        .map(|&(first, last)| (last - first + 1).saturating_sub(1))
+        .sum();
+    let mut t = vec![vec![0.0f64; m]; n];
+    let mut col_offset = 0;
+    for &(first, last) in wire_endpoints {
+        let n_w = last - first + 1;
+        let tr_w = SinusoidalTransform::for_single_chain(n_w);
+        for (local_row, t_row) in tr_w.t.iter().enumerate() {
+            let global_row = first + local_row;
+            for (local_col, &coeff) in t_row.iter().enumerate() {
+                if coeff != 0.0 {
+                    t[global_row][col_offset + local_col] = coeff;
+                }
+            }
+        }
+        col_offset += tr_w.n_basis;
+    }
+    t
+}
+
+/// Build a block-diagonal continuity transform for `n` segments split into
+/// `wire_endpoints` chains.
+fn build_block_continuity_transform(n: usize, wire_endpoints: &[(usize, usize)]) -> Vec<Vec<f64>> {
+    let m: usize = wire_endpoints
+        .iter()
+        .map(|&(first, last)| (last - first + 1).saturating_sub(1))
+        .sum();
+    let mut t = vec![vec![0.0f64; m]; n];
+    let mut col_offset = 0;
+    for &(first, last) in wire_endpoints {
+        let n_w = last - first + 1;
+        let tr_w = ContinuityTransform::for_single_chain(n_w);
+        for (local_row, t_row) in tr_w.t.iter().enumerate() {
+            let global_row = first + local_row;
+            for (local_col, &coeff) in t_row.iter().enumerate() {
+                if coeff != 0.0 {
+                    t[global_row][col_offset + local_col] = coeff;
+                }
+            }
+        }
+        col_offset += tr_w.n_basis;
+    }
+    t
+}
+
+/// Apply a basis transform T and recover segment currents I = T·a from
+/// basis coefficients `a`.
+fn basis_to_currents(t: &[Vec<f64>], a: &[Complex64]) -> Vec<Complex64> {
+    let n = t.len();
+    let mut currents = vec![Complex64::new(0.0, 0.0); n];
+    for (row, t_row) in t.iter().enumerate() {
+        for (col, &coeff) in t_row.iter().enumerate() {
+            if coeff != 0.0 {
+                currents[row] += a[col] * coeff;
+            }
+        }
+    }
+    currents
+}
+
+/// Solve `Z·I = V` using a sinusoidal basis applied independently to each wire
+/// chain described by `wire_endpoints`.
+///
+/// `wire_endpoints` is a slice of `(first, last)` inclusive segment index
+/// ranges, one per wire.  Each wire must contain at least two segments; if any
+/// wire has fewer the function falls back to `solve(z, v)`.
+///
+/// The global transform is block-diagonal: wire `k` with `n_k` segments
+/// contributes an `n_k × (n_k − 1)` sinusoidal block at offset
+/// `(first_k, col_offset_k)`.  Mutual coupling between wires is preserved
+/// because the full `Z` matrix is projected rather than solved per wire.
+pub fn solve_with_sinusoidal_basis_per_wire(
+    z: &ZMatrix,
+    v: &[Complex64],
+    wire_endpoints: &[(usize, usize)],
+) -> Result<Vec<Complex64>, SolveError> {
+    let n = z.n;
+    if v.len() != n {
+        return Err(SolveError::DimensionMismatch {
+            z_n: n,
+            v_len: v.len(),
+        });
+    }
+    if n < 2 {
+        return solve(z, v);
+    }
+    if wire_endpoints
+        .iter()
+        .any(|&(first, last)| last < first || last - first < 1)
+    {
+        return solve(z, v);
+    }
+    let global_t = build_block_sinusoidal_transform(n, wire_endpoints);
+    let m = global_t.first().map_or(0, Vec::len);
+    if m == 0 {
+        return solve(z, v);
+    }
+    let (mut proj_z, mut proj_v) = projected_system(z, v, &global_t);
+    let lambda = regularization_lambda(&proj_z, 1e-10, 1e-14);
+    for i in 0..m {
+        proj_z[i][i] += Complex64::new(lambda, 0.0);
+    }
+    let a_sol = solve_square_in_place(&mut proj_z, &mut proj_v)?;
+    Ok(basis_to_currents(&global_t, &a_sol))
+}
+
+/// Solve `Z·I = V` using a continuity basis applied independently to each wire
+/// chain described by `wire_endpoints`.
+///
+/// Semantics and fallback rules mirror [`solve_with_sinusoidal_basis_per_wire`].
+pub fn solve_with_continuity_basis_per_wire(
+    z: &ZMatrix,
+    v: &[Complex64],
+    wire_endpoints: &[(usize, usize)],
+) -> Result<Vec<Complex64>, SolveError> {
+    let n = z.n;
+    if v.len() != n {
+        return Err(SolveError::DimensionMismatch {
+            z_n: n,
+            v_len: v.len(),
+        });
+    }
+    if n < 2 {
+        return solve(z, v);
+    }
+    if wire_endpoints
+        .iter()
+        .any(|&(first, last)| last < first || last - first < 1)
+    {
+        return solve(z, v);
+    }
+    let global_t = build_block_continuity_transform(n, wire_endpoints);
+    let m = global_t.first().map_or(0, Vec::len);
+    if m == 0 {
+        return solve(z, v);
+    }
+    let (mut proj_z, mut proj_v) = projected_system(z, v, &global_t);
+    let lambda = regularization_lambda(&proj_z, 1e-10, 1e-14);
+    for i in 0..m {
+        proj_z[i][i] += Complex64::new(lambda, 0.0);
+    }
+    let a_sol = solve_square_in_place(&mut proj_z, &mut proj_v)?;
+    Ok(basis_to_currents(&global_t, &a_sol))
+}
+
 fn regularization_lambda(a: &[Vec<Complex64>], rel_scale: f64, floor: f64) -> f64 {
     if a.is_empty() {
         return floor;
@@ -610,5 +762,155 @@ mod tests {
             diff > 1e-6,
             "hallén solution should respond to RHS, diff={diff}"
         );
+    }
+
+    // ── per-wire block-transform tests ───────────────────────────────────────
+
+    /// Single wire chain: per-wire sinusoidal should give the same result as
+    /// the original single-chain solve.
+    #[test]
+    fn sinusoidal_per_wire_single_chain_matches_original() {
+        let n = 5usize;
+        let mut z = ZMatrix::new(n);
+        for i in 0..n {
+            for j in 0..n {
+                let diag = if i == j { c(10.0, 0.0) } else { c(0.3, 0.0) };
+                z.set_test(i, j, diag);
+            }
+        }
+        let v: Vec<Complex64> = (0..n).map(|i| c(i as f64 + 1.0, 0.0)).collect();
+        let wire_ep = vec![(0usize, n - 1)];
+
+        let result_single = solve_with_sinusoidal_basis(&z, &v).unwrap();
+        let result_per = solve_with_sinusoidal_basis_per_wire(&z, &v, &wire_ep).unwrap();
+
+        for k in 0..n {
+            assert!(
+                (result_single[k] - result_per[k]).norm() < 1e-10,
+                "k={k}: single={} per_wire={}",
+                result_single[k],
+                result_per[k]
+            );
+        }
+    }
+
+    /// Single wire chain: per-wire continuity should give the same result as
+    /// the original single-chain solve.
+    #[test]
+    fn continuity_per_wire_single_chain_matches_original() {
+        let n = 4usize;
+        let mut z = ZMatrix::new(n);
+        for i in 0..n {
+            for j in 0..n {
+                let val = if i == j { c(8.0, 0.0) } else { c(0.5, 0.0) };
+                z.set_test(i, j, val);
+            }
+        }
+        let v: Vec<Complex64> = (0..n).map(|i| c(1.0 + i as f64, 0.5)).collect();
+        let wire_ep = vec![(0usize, n - 1)];
+
+        let result_single = solve_with_continuity_basis(&z, &v).unwrap();
+        let result_per = solve_with_continuity_basis_per_wire(&z, &v, &wire_ep).unwrap();
+
+        for k in 0..n {
+            assert!(
+                (result_single[k] - result_per[k]).norm() < 1e-10,
+                "k={k}: single={} per_wire={}",
+                result_single[k],
+                result_per[k]
+            );
+        }
+    }
+
+    /// Two-wire block-diagonal: segments 0-2 form wire A, segments 3-5 form
+    /// wire B.  Block-diagonal Z (no cross-wire coupling) so each wire is
+    /// independent.  The per-wire result must match solving each wire alone.
+    #[test]
+    fn sinusoidal_per_wire_two_uncoupled_wires() {
+        let na = 3usize;
+        let nb = 3usize;
+        let n = na + nb;
+
+        let mut z_full = ZMatrix::new(n);
+        for i in 0..n {
+            for j in 0..n {
+                let same_block = (i < na) == (j < na);
+                let val = if i == j {
+                    c(10.0, 0.0)
+                } else if same_block {
+                    c(0.5, 0.0)
+                } else {
+                    c(0.0, 0.0)
+                };
+                z_full.set_test(i, j, val);
+            }
+        }
+        let v_full: Vec<Complex64> = (0..n).map(|i| c(i as f64 + 1.0, 0.0)).collect();
+        let wire_ep = vec![(0usize, na - 1), (na, n - 1)];
+
+        let result_full = solve_with_sinusoidal_basis_per_wire(&z_full, &v_full, &wire_ep).unwrap();
+
+        // Solve wire A alone.
+        let mut z_a = ZMatrix::new(na);
+        for i in 0..na {
+            for j in 0..na {
+                z_a.set_test(i, j, z_full.get(i, j));
+            }
+        }
+        let v_a: Vec<Complex64> = v_full[..na].to_vec();
+        let result_a = solve_with_sinusoidal_basis(&z_a, &v_a).unwrap();
+
+        // Solve wire B alone.
+        let mut z_b = ZMatrix::new(nb);
+        for i in 0..nb {
+            for j in 0..nb {
+                z_b.set_test(i, j, z_full.get(na + i, na + j));
+            }
+        }
+        let v_b: Vec<Complex64> = v_full[na..].to_vec();
+        let result_b = solve_with_sinusoidal_basis(&z_b, &v_b).unwrap();
+
+        for k in 0..na {
+            assert!(
+                (result_full[k] - result_a[k]).norm() < 1e-8,
+                "wire A k={k}: full={} alone={}",
+                result_full[k],
+                result_a[k]
+            );
+        }
+        for k in 0..nb {
+            assert!(
+                (result_full[na + k] - result_b[k]).norm() < 1e-8,
+                "wire B k={k}: full={} alone={}",
+                result_full[na + k],
+                result_b[k]
+            );
+        }
+    }
+
+    /// When a wire has only 1 segment (n_w < 2), per-wire functions fall back
+    /// to plain `solve` rather than panicking or returning wrong results.
+    #[test]
+    fn sinusoidal_per_wire_fallback_on_1seg_wire() {
+        let n = 3usize;
+        let mut z = ZMatrix::new(n);
+        for i in 0..n {
+            z.set_test(i, i, c(5.0, 0.0));
+        }
+        let v = vec![c(1.0, 0.0), c(2.0, 0.0), c(3.0, 0.0)];
+        // Wire B has only 1 segment → fallback to plain solve.
+        let wire_ep = vec![(0usize, 1), (2, 2)];
+        let result = solve_with_sinusoidal_basis_per_wire(&z, &v, &wire_ep).unwrap();
+        assert_eq!(result.len(), n);
+        // Check result matches plain solve (diagonal system → I[k] = V[k]/Z[k]).
+        for k in 0..n {
+            let expected = v[k] / c(5.0, 0.0);
+            assert!(
+                (result[k] - expected).norm() < 1e-10,
+                "k={k}: got={} expected={}",
+                result[k],
+                expected
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR enables continuity and sinusoidal basis solvers on multi-wire topologies by applying basis transforms per wire-chain instead of requiring a single global linear chain.

Previously, `--solver continuity` and `--solver sinusoidal` would hard-fallback to pulse on any non-single-chain geometry. With this change, those modes now run on multi-wire decks when each wire has at least 2 segments.

## What Changed
- Added shared wire endpoint extraction:
  - `wire_endpoints_from_segs` in `crates/nec_solver/src/geometry.rs`
- Added per-wire block-diagonal basis projection in `crates/nec_solver/src/linear.rs`:
  - `solve_with_sinusoidal_basis_per_wire`
  - `solve_with_continuity_basis_per_wire`
  - internal block transform builders for sinusoidal/continuity
- Updated exports in `crates/nec_solver/src/lib.rs`.
- Updated CLI solve routing in `apps/nec-cli/src/main.rs`:
  - removed legacy single-chain gate
  - continuity/sinusoidal now use per-wire solve paths
  - fallback to pulse only when topology is infeasible for basis projection (a wire has <2 segments)
- Updated CLI topology fallback tests in `apps/nec-cli/tests/topology_fallback.rs` to assert the new feasibility-based fallback warning and behavior.
- Reused the shared endpoint helper in `crates/nec_solver/src/excitation.rs` (removed duplicate local helper).

## Validation
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test --workspace`

All pass.

## Notable Behavior Delta
On `corpus/yagi-5elm-51seg.nec`:
- `--solver pulse` gives a clearly non-physical feedpoint (`Z ≈ -382.88 - j1116.97 Ω`)
- `--solver sinusoidal` now runs the per-wire sinusoidal path, then residual-gates and falls back to Hallen on this case, yielding (`Z ≈ 30.63 + j5.02 Ω`)

So this PR removes the blanket multi-wire pulse fallback for basis modes and replaces it with a topology-feasibility gate plus existing residual-quality gating.

## Scope Notes
- This does **not** solve the non-collinear loaded-element architectural limitation documented in `docs/solver-findings.md`.
- Focus is enabling basis-mode execution on multi-wire collinear/parallel topologies where the previous fallback was unnecessarily broad.