### PR TITLE
Gate RP pattern samples in corpus validation

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -8,6 +8,13 @@ use std::process::Command;
 
 use serde_json::{Map, Value};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PatternSample {
+    theta_deg: f64,
+    phi_deg: f64,
+    gain_db: f64,
+}
+
 #[test]
 fn corpus_validation_cases_with_references() {
     // Test file is inside apps/nec-cli; walk up to workspace root.
@@ -63,6 +70,7 @@ fn corpus_validation_cases_with_references() {
         let expected_imag = feed.get("imag_ohm").and_then(Value::as_f64);
         let expected_sources = collect_expected_sources(case_obj, feed);
         let expected_freq_points = collect_expected_frequency_points(feed);
+        let expected_pattern_samples = collect_expected_pattern_samples(case_obj);
 
         let expected_scalar = match (expected_real, expected_imag) {
             (Some(r), Some(x)) => (r, x),
@@ -95,6 +103,10 @@ fn corpus_validation_cases_with_references() {
             .get("X_percent_rel")
             .and_then(Value::as_f64)
             .unwrap_or(0.1);
+        let gain_abs_db = gates
+            .get("Gain_absolute_dB")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.05);
 
         let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
             .arg("--solver")
@@ -132,6 +144,7 @@ fn corpus_validation_cases_with_references() {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let impedances = parse_impedance_lines(&stdout);
+        let pattern_rows = parse_pattern_rows(&stdout);
         assert!(
             !impedances.is_empty(),
             "No impedance rows found in fnec output for case '{}':\n{}",
@@ -316,6 +329,43 @@ fn corpus_validation_cases_with_references() {
             }
         }
 
+        if !expected_pattern_samples.is_empty() {
+            assert!(
+                !pattern_rows.is_empty(),
+                "Case '{}' expected radiation-pattern rows, got none:\n{}",
+                case_name,
+                stdout
+            );
+
+            for sample in &expected_pattern_samples {
+                let row = pattern_rows
+                    .iter()
+                    .find(|row| {
+                        (row.theta_deg - sample.theta_deg).abs() < 1e-9
+                            && (row.phi_deg - sample.phi_deg).abs() < 1e-9
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Case '{}' missing pattern sample at theta={:.4} phi={:.4}",
+                            case_name, sample.theta_deg, sample.phi_deg
+                        )
+                    });
+
+                let err_gain = (row.gain_db - sample.gain_db).abs();
+                assert!(
+                    err_gain <= gain_abs_db,
+                    "Case '{}' pattern gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, expected {:.6}, err {:.6}, tol {:.6}",
+                    case_name,
+                    sample.theta_deg,
+                    sample.phi_deg,
+                    row.gain_db,
+                    sample.gain_db,
+                    err_gain,
+                    gain_abs_db
+                );
+            }
+        }
+
         validated += 1;
     }
 
@@ -415,6 +465,24 @@ fn collect_external_frequency_points(ext: &Map<String, Value>) -> Vec<(f64, f64,
     out
 }
 
+fn collect_expected_pattern_samples(case_obj: &Map<String, Value>) -> Vec<PatternSample> {
+    let Some(samples) = case_obj.get("pattern_samples").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    samples
+        .iter()
+        .filter_map(|sample| {
+            let sample = sample.as_object()?;
+            Some(PatternSample {
+                theta_deg: sample.get("theta_deg")?.as_f64()?,
+                phi_deg: sample.get("phi_deg")?.as_f64()?,
+                gain_db: sample.get("gain_db")?.as_f64()?,
+            })
+        })
+        .collect()
+}
+
 fn parse_impedance_lines(stdout: &str) -> Vec<(f64, f64)> {
     let mut rows = Vec::new();
     for line in stdout.lines() {
@@ -444,6 +512,52 @@ fn parse_impedance_lines(stdout: &str) -> Vec<(f64, f64)> {
             rows.push((real, imag));
         }
     }
+    rows
+}
+
+fn parse_pattern_rows(stdout: &str) -> Vec<PatternSample> {
+    let mut rows = Vec::new();
+    let mut in_pattern = false;
+
+    for line in stdout.lines() {
+        if line == "RADIATION_PATTERN" {
+            in_pattern = true;
+            continue;
+        }
+        if !in_pattern {
+            continue;
+        }
+        if line.is_empty() {
+            break;
+        }
+        if line.starts_with("N_POINTS ")
+            || line == "THETA PHI GAIN_DB GAIN_V_DB GAIN_H_DB AXIAL_RATIO"
+        {
+            continue;
+        }
+
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 6 {
+            continue;
+        }
+
+        let Ok(theta_deg) = parts[0].parse::<f64>() else {
+            continue;
+        };
+        let Ok(phi_deg) = parts[1].parse::<f64>() else {
+            continue;
+        };
+        let Ok(gain_db) = parts[2].parse::<f64>() else {
+            continue;
+        };
+
+        rows.push(PatternSample {
+            theta_deg,
+            phi_deg,
+            gain_db,
+        });
+    }
+
     rows
 }
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -69,8 +69,13 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Same feedpoint impedance as `dipole-freesp-51seg`
 - Z_in = 74.242874 + j13.899516 Ω
 - Pattern table present with 19 points (`RADIATION_PATTERN`, `N_POINTS 19`)
+- Numeric pattern samples locked in corpus validation:
+  - θ = 0°, φ = 0° → -999.99 dB
+  - θ = 90°, φ = 0° → 2.1428 dBi
 
-**Tolerance gates**: Same as `dipole-freesp-51seg` for impedance.
+**Tolerance gates**:
+- Same as `dipole-freesp-51seg` for impedance
+- Pattern samples: ≤ 0.05 dB absolute on stored `GAIN_DB` values
 
 **Why this case**: It locks RP execution into corpus and report-contract testing without adding new solver-option surface area.
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -55,7 +55,8 @@
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
-        "X_absolute_ohm": 0.05
+        "X_absolute_ohm": 0.05,
+        "Gain_absolute_dB": 0.05
       },
       "status": "Regression reference locks RP execution path and radiation-pattern table contract"
     },

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -30,6 +30,7 @@ last_updated: 2026-04-24
 	- 2026-04-24 progress: added `.github/workflows/benchmark-compare.yml` to run benchmark delta gates in PRs when benchmark CSV inputs are present, with manual dispatch overrides.
 	- 2026-04-24 progress: benchmark-compare workflow now publishes skip reasons and a compare-result preview in the Actions job summary for quick PR review.
 	- 2026-04-25 progress: RP cards are now executed in the CLI report path with a `RADIATION_PATTERN` section (`THETA PHI GAIN_DB GAIN_V_DB GAIN_H_DB AXIAL_RATIO`), and regression coverage was added via `corpus/dipole-freesp-rp-51seg.nec` plus report-contract tests.
+	- 2026-04-25 progress: `apps/nec-cli/tests/corpus_validation.rs` now parses `RADIATION_PATTERN` rows and tolerance-gates stored RP sample gains from `corpus/reference-results.json`.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ All notable documentation process changes are recorded here.
 ### Changed
 
 - Updated support and CLI docs to mark RP pattern output as implemented in the text-report path (with remaining export/near-field scope still deferred).
+- Corpus validation now numerically checks stored RP pattern samples instead of only asserting pattern-table presence.
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
Adds numeric RP pattern-sample gating to corpus validation so the RP regression case checks actual gain values instead of only report-section presence.

## What Changed
- Extended `apps/nec-cli/tests/corpus_validation.rs` to:
  - parse `RADIATION_PATTERN` rows from report output
  - read `pattern_samples` from `corpus/reference-results.json`
  - assert stored `GAIN_DB` values within tolerance for matching `(theta, phi)` points
- Added explicit `Gain_absolute_dB` tolerance for the RP corpus case in `corpus/reference-results.json`.
- Updated corpus and tracking docs:
  - `corpus/README.md`
  - `docs/changelog.md`
  - `docs/backlog.md`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p nec-cli --test corpus_validation -- --nocapture`
- `cargo test --workspace`

All pass.

## Scope Notes
- This change only gates the total-gain `GAIN_DB` samples currently stored in the corpus.
- It does not yet add corpus tolerance checks for `GAIN_V_DB`, `GAIN_H_DB`, or `AXIAL_RATIO`.
