### PR TITLE
Gate RP pattern components in corpus validation

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -13,6 +13,9 @@ struct PatternSample {
     theta_deg: f64,
     phi_deg: f64,
     gain_db: f64,
+    gain_v_db: f64,
+    gain_h_db: f64,
+    axial_ratio: f64,
 }
 
 #[test]
@@ -107,6 +110,10 @@ fn corpus_validation_cases_with_references() {
             .get("Gain_absolute_dB")
             .and_then(Value::as_f64)
             .unwrap_or(0.05);
+        let axial_ratio_abs = gates
+            .get("AxialRatio_absolute")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0001);
 
         let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
             .arg("--solver")
@@ -352,6 +359,9 @@ fn corpus_validation_cases_with_references() {
                     });
 
                 let err_gain = (row.gain_db - sample.gain_db).abs();
+                let err_gain_v = (row.gain_v_db - sample.gain_v_db).abs();
+                let err_gain_h = (row.gain_h_db - sample.gain_h_db).abs();
+                let err_axial_ratio = (row.axial_ratio - sample.axial_ratio).abs();
                 assert!(
                     err_gain <= gain_abs_db,
                     "Case '{}' pattern gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, expected {:.6}, err {:.6}, tol {:.6}",
@@ -362,6 +372,39 @@ fn corpus_validation_cases_with_references() {
                     sample.gain_db,
                     err_gain,
                     gain_abs_db
+                );
+                assert!(
+                    err_gain_v <= gain_abs_db,
+                    "Case '{}' pattern vertical gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, expected {:.6}, err {:.6}, tol {:.6}",
+                    case_name,
+                    sample.theta_deg,
+                    sample.phi_deg,
+                    row.gain_v_db,
+                    sample.gain_v_db,
+                    err_gain_v,
+                    gain_abs_db
+                );
+                assert!(
+                    err_gain_h <= gain_abs_db,
+                    "Case '{}' pattern horizontal gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, expected {:.6}, err {:.6}, tol {:.6}",
+                    case_name,
+                    sample.theta_deg,
+                    sample.phi_deg,
+                    row.gain_h_db,
+                    sample.gain_h_db,
+                    err_gain_h,
+                    gain_abs_db
+                );
+                assert!(
+                    err_axial_ratio <= axial_ratio_abs,
+                    "Case '{}' pattern axial ratio out of tolerance at theta={:.4} phi={:.4}: got {:.6}, expected {:.6}, err {:.6}, tol {:.6}",
+                    case_name,
+                    sample.theta_deg,
+                    sample.phi_deg,
+                    row.axial_ratio,
+                    sample.axial_ratio,
+                    err_axial_ratio,
+                    axial_ratio_abs
                 );
             }
         }
@@ -478,6 +521,9 @@ fn collect_expected_pattern_samples(case_obj: &Map<String, Value>) -> Vec<Patter
                 theta_deg: sample.get("theta_deg")?.as_f64()?,
                 phi_deg: sample.get("phi_deg")?.as_f64()?,
                 gain_db: sample.get("gain_db")?.as_f64()?,
+                gain_v_db: sample.get("gain_v_db")?.as_f64()?,
+                gain_h_db: sample.get("gain_h_db")?.as_f64()?,
+                axial_ratio: sample.get("axial_ratio")?.as_f64()?,
             })
         })
         .collect()
@@ -550,11 +596,23 @@ fn parse_pattern_rows(stdout: &str) -> Vec<PatternSample> {
         let Ok(gain_db) = parts[2].parse::<f64>() else {
             continue;
         };
+        let Ok(gain_v_db) = parts[3].parse::<f64>() else {
+            continue;
+        };
+        let Ok(gain_h_db) = parts[4].parse::<f64>() else {
+            continue;
+        };
+        let Ok(axial_ratio) = parts[5].parse::<f64>() else {
+            continue;
+        };
 
         rows.push(PatternSample {
             theta_deg,
             phi_deg,
             gain_db,
+            gain_v_db,
+            gain_h_db,
+            axial_ratio,
         });
     }
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -70,12 +70,13 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Z_in = 74.242874 + j13.899516 Ω
 - Pattern table present with 19 points (`RADIATION_PATTERN`, `N_POINTS 19`)
 - Numeric pattern samples locked in corpus validation:
-  - θ = 0°, φ = 0° → -999.99 dB
-  - θ = 90°, φ = 0° → 2.1428 dBi
+  - θ = 0°, φ = 0° → `GAIN_DB=-999.99`, `GAIN_V_DB=-999.99`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
+  - θ = 90°, φ = 0° → `GAIN_DB=2.1483`, `GAIN_V_DB=2.1483`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
 
 **Tolerance gates**:
 - Same as `dipole-freesp-51seg` for impedance
-- Pattern samples: ≤ 0.05 dB absolute on stored `GAIN_DB` values
+- Pattern gain fields: ≤ 0.05 dB absolute on stored `GAIN_DB`, `GAIN_V_DB`, and `GAIN_H_DB` values
+- Axial ratio: ≤ 0.0001 absolute on stored `AXIAL_RATIO` values
 
 **Why this case**: It locks RP execution into corpus and report-contract testing without adding new solver-option surface area.
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -43,12 +43,18 @@
         {
           "theta_deg": 0.0,
           "phi_deg": 0.0,
-          "gain_db": -999.99
+          "gain_db": -999.99,
+          "gain_v_db": -999.99,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
         },
         {
           "theta_deg": 90.0,
           "phi_deg": 0.0,
-          "gain_db": 2.1428
+          "gain_db": 2.1483,
+          "gain_v_db": 2.1483,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
         }
       ],
       "tolerance_gates": {
@@ -56,7 +62,8 @@
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
-        "Gain_absolute_dB": 0.05
+        "Gain_absolute_dB": 0.05,
+        "AxialRatio_absolute": 0.0001
       },
       "status": "Regression reference locks RP execution path and radiation-pattern table contract"
     },

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -31,6 +31,7 @@ last_updated: 2026-04-24
 	- 2026-04-24 progress: benchmark-compare workflow now publishes skip reasons and a compare-result preview in the Actions job summary for quick PR review.
 	- 2026-04-25 progress: RP cards are now executed in the CLI report path with a `RADIATION_PATTERN` section (`THETA PHI GAIN_DB GAIN_V_DB GAIN_H_DB AXIAL_RATIO`), and regression coverage was added via `corpus/dipole-freesp-rp-51seg.nec` plus report-contract tests.
 	- 2026-04-25 progress: `apps/nec-cli/tests/corpus_validation.rs` now parses `RADIATION_PATTERN` rows and tolerance-gates stored RP sample gains from `corpus/reference-results.json`.
+	- 2026-04-25 progress: RP corpus validation now also gates `GAIN_V_DB`, `GAIN_H_DB`, and `AXIAL_RATIO` for stored sample angles, not only total `GAIN_DB`.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ All notable documentation process changes are recorded here.
 
 - Updated support and CLI docs to mark RP pattern output as implemented in the text-report path (with remaining export/near-field scope still deferred).
 - Corpus validation now numerically checks stored RP pattern samples instead of only asserting pattern-table presence.
+- Corpus validation now also checks the stored vertical/horizontal gain columns and axial ratio for locked RP sample angles.
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
Extends RP corpus validation from total gain only to all currently reported pattern columns for the locked sample angles.

## What Changed
- Extended `apps/nec-cli/tests/corpus_validation.rs` to parse and validate:
  - `GAIN_DB`
  - `GAIN_V_DB`
  - `GAIN_H_DB`
  - `AXIAL_RATIO`
- Updated the stored RP regression samples in `corpus/reference-results.json` to the current printed values for:
  - θ = 0°, φ = 0°
  - θ = 90°, φ = 0°
- Added `AxialRatio_absolute` tolerance gate for the RP corpus case.
- Updated supporting corpus and tracking docs:
  - `corpus/README.md`
  - `docs/changelog.md`
  - `docs/backlog.md`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p nec-cli --test corpus_validation -- --nocapture`
- `cargo test --workspace`

All pass.

## Scope Notes
- This still validates only the two stored sample angles in the RP corpus case.
- It does not yet add broader angle coverage or external-reference parity for pattern values.
