### PR TITLE
Expand RP corpus angle sample coverage

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -69,9 +69,14 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Same feedpoint impedance as `dipole-freesp-51seg`
 - Z_in = 74.242874 + j13.899516 Ω
 - Pattern table present with 19 points (`RADIATION_PATTERN`, `N_POINTS 19`)
-- Numeric pattern samples locked in corpus validation:
+- Numeric pattern samples locked in corpus validation across 7 theta points (`0°, 30°, 60°, 90°, 120°, 150°, 180°` at `φ=0°`):
   - θ = 0°, φ = 0° → `GAIN_DB=-999.99`, `GAIN_V_DB=-999.99`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
+  - θ = 30°, φ = 0° → `GAIN_DB=-5.4220`, `GAIN_V_DB=-5.4220`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
+  - θ = 60°, φ = 0° → `GAIN_DB=0.3910`, `GAIN_V_DB=0.3910`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
   - θ = 90°, φ = 0° → `GAIN_DB=2.1483`, `GAIN_V_DB=2.1483`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
+  - θ = 120°, φ = 0° → `GAIN_DB=0.3910`, `GAIN_V_DB=0.3910`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
+  - θ = 150°, φ = 0° → `GAIN_DB=-5.4220`, `GAIN_V_DB=-5.4220`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
+  - θ = 180°, φ = 0° → `GAIN_DB=-999.99`, `GAIN_V_DB=-999.99`, `GAIN_H_DB=-999.99`, `AXIAL_RATIO=0.0`
 
 **Tolerance gates**:
 - Same as `dipole-freesp-51seg` for impedance

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -49,10 +49,50 @@
           "axial_ratio": 0.0
         },
         {
+          "theta_deg": 30.0,
+          "phi_deg": 0.0,
+          "gain_db": -5.422,
+          "gain_v_db": -5.422,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 60.0,
+          "phi_deg": 0.0,
+          "gain_db": 0.391,
+          "gain_v_db": 0.391,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
           "theta_deg": 90.0,
           "phi_deg": 0.0,
           "gain_db": 2.1483,
           "gain_v_db": 2.1483,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 120.0,
+          "phi_deg": 0.0,
+          "gain_db": 0.391,
+          "gain_v_db": 0.391,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 150.0,
+          "phi_deg": 0.0,
+          "gain_db": -5.422,
+          "gain_v_db": -5.422,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 180.0,
+          "phi_deg": 0.0,
+          "gain_db": -999.99,
+          "gain_v_db": -999.99,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -32,6 +32,7 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: RP cards are now executed in the CLI report path with a `RADIATION_PATTERN` section (`THETA PHI GAIN_DB GAIN_V_DB GAIN_H_DB AXIAL_RATIO`), and regression coverage was added via `corpus/dipole-freesp-rp-51seg.nec` plus report-contract tests.
 	- 2026-04-25 progress: `apps/nec-cli/tests/corpus_validation.rs` now parses `RADIATION_PATTERN` rows and tolerance-gates stored RP sample gains from `corpus/reference-results.json`.
 	- 2026-04-25 progress: RP corpus validation now also gates `GAIN_V_DB`, `GAIN_H_DB`, and `AXIAL_RATIO` for stored sample angles, not only total `GAIN_DB`.
+	- 2026-04-25 progress: RP corpus validation angle coverage increased from 2 sample angles to 7 (`0°, 30°, 60°, 90°, 120°, 150°, 180°` at `φ=0°`).
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ All notable documentation process changes are recorded here.
 - Updated support and CLI docs to mark RP pattern output as implemented in the text-report path (with remaining export/near-field scope still deferred).
 - Corpus validation now numerically checks stored RP pattern samples instead of only asserting pattern-table presence.
 - Corpus validation now also checks the stored vertical/horizontal gain columns and axial ratio for locked RP sample angles.
+- RP corpus angle coverage was expanded from 2 locked sample angles to 7 locked angles across the theta sweep.
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
Expands RP corpus regression coverage from two locked angles to seven locked theta samples across the sweep.

## What Changed
- Updated corpus/reference-results.json RP pattern_samples for dipole-freesp-rp-51seg to lock:
  - theta = 0, 30, 60, 90, 120, 150, 180 (phi = 0)
- Kept existing tolerance model and sample fields (GAIN_DB, GAIN_V_DB, GAIN_H_DB, AXIAL_RATIO).
- Updated documentation to reflect broader locked-angle coverage:
  - corpus/README.md
  - docs/changelog.md
  - docs/backlog.md

## Validation
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- cargo fmt --all -- --check
- cargo test --workspace

All pass.

## Scope Notes
- This change broadens angle coverage only for the existing RP corpus case.
- It does not yet add external-reference parity gating for pattern values.
