### PR TITLE
Track external RP parity candidates

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -407,6 +407,30 @@ fn corpus_validation_cases_with_references() {
                     axial_ratio_abs
                 );
             }
+
+            if let Some(ext_obj) = case_obj
+                .get("external_reference_candidate")
+                .and_then(Value::as_object)
+            {
+                let ext_pattern_samples = collect_external_pattern_samples(ext_obj);
+                for sample in &ext_pattern_samples {
+                    if let Some(row) = pattern_rows.iter().find(|row| {
+                        (row.theta_deg - sample.theta_deg).abs() < 1e-9
+                            && (row.phi_deg - sample.phi_deg).abs() < 1e-9
+                    }) {
+                        eprintln!(
+                            "corpus external delta: case='{}' pattern theta={:.4} phi={:.4} dGain={:+.4} dGainV={:+.4} dGainH={:+.4} dAxialRatio={:+.4} (fnec-ext)",
+                            case_name,
+                            sample.theta_deg,
+                            sample.phi_deg,
+                            row.gain_db - sample.gain_db,
+                            row.gain_v_db - sample.gain_v_db,
+                            row.gain_h_db - sample.gain_h_db,
+                            row.axial_ratio - sample.axial_ratio,
+                        );
+                    }
+                }
+            }
         }
 
         validated += 1;
@@ -510,6 +534,27 @@ fn collect_external_frequency_points(ext: &Map<String, Value>) -> Vec<(f64, f64,
 
 fn collect_expected_pattern_samples(case_obj: &Map<String, Value>) -> Vec<PatternSample> {
     let Some(samples) = case_obj.get("pattern_samples").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    samples
+        .iter()
+        .filter_map(|sample| {
+            let sample = sample.as_object()?;
+            Some(PatternSample {
+                theta_deg: sample.get("theta_deg")?.as_f64()?,
+                phi_deg: sample.get("phi_deg")?.as_f64()?,
+                gain_db: sample.get("gain_db")?.as_f64()?,
+                gain_v_db: sample.get("gain_v_db")?.as_f64()?,
+                gain_h_db: sample.get("gain_h_db")?.as_f64()?,
+                axial_ratio: sample.get("axial_ratio")?.as_f64()?,
+            })
+        })
+        .collect()
+}
+
+fn collect_external_pattern_samples(ext: &Map<String, Value>) -> Vec<PatternSample> {
+    let Some(samples) = ext.get("pattern_samples").and_then(Value::as_array) else {
         return Vec::new();
     };
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -39,6 +39,67 @@
         "real_ohm": 74.242874,
         "imag_ohm": 13.899516
       },
+      "external_reference_candidate": {
+        "source": "nec2c 1.3.1 on Arch Linux (deck copy with RP integer field normalized)",
+        "pattern_samples": [
+          {
+            "theta_deg": 0.0,
+            "phi_deg": 0.0,
+            "gain_db": -999.99,
+            "gain_v_db": -999.99,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 30.0,
+            "phi_deg": 0.0,
+            "gain_db": -5.49,
+            "gain_v_db": -5.49,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 60.0,
+            "phi_deg": 0.0,
+            "gain_db": 0.38,
+            "gain_v_db": 0.38,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 90.0,
+            "phi_deg": 0.0,
+            "gain_db": 2.17,
+            "gain_v_db": 2.17,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 120.0,
+            "phi_deg": 0.0,
+            "gain_db": 0.38,
+            "gain_v_db": 0.38,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 150.0,
+            "phi_deg": 0.0,
+            "gain_db": -5.49,
+            "gain_v_db": -5.49,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 180.0,
+            "phi_deg": 0.0,
+            "gain_db": -999.99,
+            "gain_v_db": -999.99,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          }
+        ]
+      },
       "pattern_samples": [
         {
           "theta_deg": 0.0,
@@ -105,7 +166,7 @@
         "Gain_absolute_dB": 0.05,
         "AxialRatio_absolute": 0.0001
       },
-      "status": "Regression reference locks RP execution path and radiation-pattern table contract"
+      "status": "Regression reference locks RP execution path and radiation-pattern table contract; nec2c external pattern samples captured for parity tracking"
     },
     "dipole-xaxis-rp-grid-51seg": {
       "deck_file": "dipole-xaxis-rp-grid-51seg.nec",
@@ -119,6 +180,75 @@
       "feedpoint_impedance": {
         "real_ohm": 74.242874,
         "imag_ohm": 13.899516
+      },
+      "external_reference_candidate": {
+        "source": "nec2c 1.3.1 on Arch Linux (deck copy with RP integer field normalized)",
+        "pattern_samples": [
+          {
+            "theta_deg": 0.0,
+            "phi_deg": 0.0,
+            "gain_db": 2.17,
+            "gain_v_db": 2.17,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 45.0,
+            "phi_deg": 0.0,
+            "gain_db": -1.92,
+            "gain_v_db": -1.92,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 90.0,
+            "phi_deg": 0.0,
+            "gain_db": -999.99,
+            "gain_v_db": -999.99,
+            "gain_h_db": -999.99,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 0.0,
+            "phi_deg": 90.0,
+            "gain_db": 2.17,
+            "gain_v_db": -999.99,
+            "gain_h_db": 2.17,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 45.0,
+            "phi_deg": 90.0,
+            "gain_db": 2.17,
+            "gain_v_db": -999.99,
+            "gain_h_db": 2.17,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 90.0,
+            "phi_deg": 90.0,
+            "gain_db": 2.17,
+            "gain_v_db": -999.99,
+            "gain_h_db": 2.17,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 0.0,
+            "phi_deg": 270.0,
+            "gain_db": 2.17,
+            "gain_v_db": -999.99,
+            "gain_h_db": 2.17,
+            "axial_ratio": 0.0
+          },
+          {
+            "theta_deg": 90.0,
+            "phi_deg": 270.0,
+            "gain_db": 2.17,
+            "gain_v_db": -999.99,
+            "gain_h_db": 2.17,
+            "axial_ratio": 0.0
+          }
+        ]
       },
       "pattern_samples": [
         {
@@ -194,7 +324,7 @@
         "Gain_absolute_dB": 0.05,
         "AxialRatio_absolute": 0.0001
       },
-      "status": "Regression reference locks multi-phi RP table support on a non-z-axis dipole"
+      "status": "Regression reference locks multi-phi RP table support on a non-z-axis dipole; nec2c external pattern samples captured for parity tracking"
     },
     "dipole-freesp-gm-inplace-shifted": {
       "deck_file": "dipole-freesp-gm-inplace-shifted.nec",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -34,6 +34,8 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: RP corpus validation now also gates `GAIN_V_DB`, `GAIN_H_DB`, and `AXIAL_RATIO` for stored sample angles, not only total `GAIN_DB`.
 	- 2026-04-25 progress: RP corpus validation angle coverage increased from 2 sample angles to 7 (`0°, 30°, 60°, 90°, 120°, 150°, 180°` at `φ=0°`).
 	- 2026-04-25 progress: added `corpus/dipole-xaxis-rp-grid-51seg.nec` to lock multi-phi RP behavior on an x-axis dipole with representative `(theta, phi)` samples.
+	- 2026-04-25 progress: corpus validation now logs external-reference deltas for RP sample rows, and `dipole-freesp-rp-51seg` carries a first `nec2c` pattern candidate for parity tracking.
+	- 2026-04-25 progress: `dipole-xaxis-rp-grid-51seg` now also carries `nec2c` external RP samples, so the observational parity path covers both current RP corpus decks.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ All notable documentation process changes are recorded here.
 - Corpus validation now also checks the stored vertical/horizontal gain columns and axial ratio for locked RP sample angles.
 - RP corpus angle coverage was expanded from 2 locked sample angles to 7 locked angles across the theta sweep.
 - Added a second RP corpus case with non-z-axis geometry and multi-phi sample locking to validate true azimuth-cut coverage.
+- Corpus validation now also records external-reference deltas for RP pattern samples when `external_reference_candidate.pattern_samples` is present.
+- Added `nec2c` external RP sample candidates for the multi-phi x-axis corpus case so parity tracking now covers both current RP decks.
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
- log external-reference deltas for RP pattern samples in corpus validation
- add nec2c external RP sample candidates for both current RP corpus decks
- update backlog and changelog notes for RP parity tracking

## Validation
- cargo test -p nec-cli --test corpus_validation -- --nocapture