### PR TITLE
Gate external RP parity candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practi
 	- Multi-wire Hallen: per-wire homogeneous constants and endpoint constraints; correct passive-wire (zero) RHS
 - Segment current distribution table in CLI output (`CURRENTS` section after feedpoint table)
 - RP radiation-pattern execution in CLI output (`RADIATION_PATTERN` section with theta/phi gain rows)
+- Corpus validation can track and optionally gate external RP parity candidates recorded in `corpus/reference-results.json`
 - Pulse-basis, continuity-basis, and sinusoidal-tapered Pocklington solvers (EXPERIMENTAL — known to diverge for thin wires)
 	- `sinusoidal` now falls back to Hallen on single collinear chains when its residual budget is exceeded, so the CLI avoids returning misleading impedances for that path
 - CLI binary `fnec` with selectable solver and RHS modes

--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -114,7 +114,9 @@ fn corpus_validation_cases_with_references() {
             .get("AxialRatio_absolute")
             .and_then(Value::as_f64)
             .unwrap_or(0.0001);
-        let external_gain_abs_db = gates.get("ExternalGain_absolute_dB").and_then(Value::as_f64);
+        let external_gain_abs_db = gates
+            .get("ExternalGain_absolute_dB")
+            .and_then(Value::as_f64);
         let external_axial_ratio_abs = gates
             .get("ExternalAxialRatio_absolute")
             .and_then(Value::as_f64);

--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -114,6 +114,10 @@ fn corpus_validation_cases_with_references() {
             .get("AxialRatio_absolute")
             .and_then(Value::as_f64)
             .unwrap_or(0.0001);
+        let external_gain_abs_db = gates.get("ExternalGain_absolute_dB").and_then(Value::as_f64);
+        let external_axial_ratio_abs = gates
+            .get("ExternalAxialRatio_absolute")
+            .and_then(Value::as_f64);
 
         let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
             .arg("--solver")
@@ -418,6 +422,10 @@ fn corpus_validation_cases_with_references() {
                         (row.theta_deg - sample.theta_deg).abs() < 1e-9
                             && (row.phi_deg - sample.phi_deg).abs() < 1e-9
                     }) {
+                        let err_gain = (row.gain_db - sample.gain_db).abs();
+                        let err_gain_v = (row.gain_v_db - sample.gain_v_db).abs();
+                        let err_gain_h = (row.gain_h_db - sample.gain_h_db).abs();
+                        let err_axial_ratio = (row.axial_ratio - sample.axial_ratio).abs();
                         eprintln!(
                             "corpus external delta: case='{}' pattern theta={:.4} phi={:.4} dGain={:+.4} dGainV={:+.4} dGainH={:+.4} dAxialRatio={:+.4} (fnec-ext)",
                             case_name,
@@ -428,6 +436,56 @@ fn corpus_validation_cases_with_references() {
                             row.gain_h_db - sample.gain_h_db,
                             row.axial_ratio - sample.axial_ratio,
                         );
+
+                        if let Some(tol) = external_gain_abs_db {
+                            assert!(
+                                err_gain <= tol,
+                                "Case '{}' external pattern gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                case_name,
+                                sample.theta_deg,
+                                sample.phi_deg,
+                                row.gain_db,
+                                sample.gain_db,
+                                err_gain,
+                                tol
+                            );
+                            assert!(
+                                err_gain_v <= tol,
+                                "Case '{}' external pattern vertical gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                case_name,
+                                sample.theta_deg,
+                                sample.phi_deg,
+                                row.gain_v_db,
+                                sample.gain_v_db,
+                                err_gain_v,
+                                tol
+                            );
+                            assert!(
+                                err_gain_h <= tol,
+                                "Case '{}' external pattern horizontal gain out of tolerance at theta={:.4} phi={:.4}: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                case_name,
+                                sample.theta_deg,
+                                sample.phi_deg,
+                                row.gain_h_db,
+                                sample.gain_h_db,
+                                err_gain_h,
+                                tol
+                            );
+                        }
+
+                        if let Some(tol) = external_axial_ratio_abs {
+                            assert!(
+                                err_axial_ratio <= tol,
+                                "Case '{}' external pattern axial ratio out of tolerance at theta={:.4} phi={:.4}: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                case_name,
+                                sample.theta_deg,
+                                sample.phi_deg,
+                                row.axial_ratio,
+                                sample.axial_ratio,
+                                err_axial_ratio,
+                                tol
+                            );
+                        }
                     }
                 }
             }

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -82,6 +82,7 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Same as `dipole-freesp-51seg` for impedance
 - Pattern gain fields: ≤ 0.05 dB absolute on stored `GAIN_DB`, `GAIN_V_DB`, and `GAIN_H_DB` values
 - Axial ratio: ≤ 0.0001 absolute on stored `AXIAL_RATIO` values
+- External RP candidate gates: optional `ExternalGain_absolute_dB` / `ExternalAxialRatio_absolute` keys can additionally CI-gate `external_reference_candidate.pattern_samples` when present
 
 **Why this case**: It locks RP execution into corpus and report-contract testing without adding new solver-option surface area.
 
@@ -109,6 +110,7 @@ Every NEC deck in this corpus is validated against a reference engine and the re
 - Same as `dipole-freesp-51seg` for impedance
 - Pattern gain fields: ≤ 0.05 dB absolute on stored `GAIN_DB`, `GAIN_V_DB`, and `GAIN_H_DB` values
 - Axial ratio: ≤ 0.0001 absolute on stored `AXIAL_RATIO` values
+- External RP candidate gates: optional `ExternalGain_absolute_dB` / `ExternalAxialRatio_absolute` keys can additionally CI-gate `external_reference_candidate.pattern_samples` when present
 
 **Why this case**: It proves the RP regression path across multiple phi cuts on a non-z-axis geometry, which is a stronger check than the azimuth-invariant baseline dipole.
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -164,7 +164,9 @@
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
         "Gain_absolute_dB": 0.05,
-        "AxialRatio_absolute": 0.0001
+        "AxialRatio_absolute": 0.0001,
+        "ExternalGain_absolute_dB": 0.1,
+        "ExternalAxialRatio_absolute": 0.0001
       },
       "status": "Regression reference locks RP execution path and radiation-pattern table contract; nec2c external pattern samples captured for parity tracking"
     },
@@ -322,7 +324,9 @@
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
         "Gain_absolute_dB": 0.05,
-        "AxialRatio_absolute": 0.0001
+        "AxialRatio_absolute": 0.0001,
+        "ExternalGain_absolute_dB": 0.1,
+        "ExternalAxialRatio_absolute": 0.0001
       },
       "status": "Regression reference locks multi-phi RP table support on a non-z-axis dipole; nec2c external pattern samples captured for parity tracking"
     },

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -36,6 +36,7 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: added `corpus/dipole-xaxis-rp-grid-51seg.nec` to lock multi-phi RP behavior on an x-axis dipole with representative `(theta, phi)` samples.
 	- 2026-04-25 progress: corpus validation now logs external-reference deltas for RP sample rows, and `dipole-freesp-rp-51seg` carries a first `nec2c` pattern candidate for parity tracking.
 	- 2026-04-25 progress: `dipole-xaxis-rp-grid-51seg` now also carries `nec2c` external RP samples, so the observational parity path covers both current RP corpus decks.
+	- 2026-04-25 progress: RP corpus cases can now promote those external pattern candidates into CI gates with optional `ExternalGain_absolute_dB` / `ExternalAxialRatio_absolute` thresholds.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ All notable documentation process changes are recorded here.
 - Added a second RP corpus case with non-z-axis geometry and multi-phi sample locking to validate true azimuth-cut coverage.
 - Corpus validation now also records external-reference deltas for RP pattern samples when `external_reference_candidate.pattern_samples` is present.
 - Added `nec2c` external RP sample candidates for the multi-phi x-axis corpus case so parity tracking now covers both current RP decks.
+- RP corpus cases can now opt into external-pattern CI gates via `ExternalGain_absolute_dB` and `ExternalAxialRatio_absolute` in `tolerance_gates`.
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
- add optional external RP gain and axial-ratio gates to corpus validation
- enable those external gates for the two current RP corpus decks
- document the new tolerance-gate keys in README and corpus docs

## Validation
- cargo test -p nec-cli --test corpus_validation -- --nocapture