### PR TITLE
Add external impedance candidate gates

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -114,12 +114,32 @@ fn corpus_validation_cases_with_references() {
             .get("AxialRatio_absolute")
             .and_then(Value::as_f64)
             .unwrap_or(0.0001);
+        let external_r_abs = gates.get("ExternalR_absolute_ohm").and_then(Value::as_f64);
+        let external_x_abs = gates.get("ExternalX_absolute_ohm").and_then(Value::as_f64);
+        let external_r_rel_percent = gates.get("ExternalR_percent_rel").and_then(Value::as_f64);
+        let external_x_rel_percent = gates.get("ExternalX_percent_rel").and_then(Value::as_f64);
         let external_gain_abs_db = gates
             .get("ExternalGain_absolute_dB")
             .and_then(Value::as_f64);
         let external_axial_ratio_abs = gates
             .get("ExternalAxialRatio_absolute")
             .and_then(Value::as_f64);
+        let external_r_tol = if external_r_abs.is_some() || external_r_rel_percent.is_some() {
+            Some((
+                external_r_abs.unwrap_or(r_abs),
+                external_r_rel_percent.unwrap_or(r_rel_percent),
+            ))
+        } else {
+            None
+        };
+        let external_x_tol = if external_x_abs.is_some() || external_x_rel_percent.is_some() {
+            Some((
+                external_x_abs.unwrap_or(x_abs),
+                external_x_rel_percent.unwrap_or(x_rel_percent),
+            ))
+        } else {
+            None
+        };
 
         let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
             .arg("--solver")
@@ -214,6 +234,8 @@ fn corpus_validation_cases_with_references() {
                             break;
                         }
                         let (real, imag) = impedances[idx];
+                        let err_r = (real - ext_r).abs();
+                        let err_x = (imag - ext_x).abs();
                         eprintln!(
                             "corpus external delta: case='{}' source_{} dR={:+.6} dX={:+.6} (fnec-ext)",
                             case_name,
@@ -221,6 +243,33 @@ fn corpus_validation_cases_with_references() {
                             real - ext_r,
                             imag - ext_x
                         );
+
+                        if let Some((abs_floor, rel_percent)) = external_r_tol {
+                            let tol_r = tolerance_with_floor(*ext_r, abs_floor, rel_percent);
+                            assert!(
+                                err_r <= tol_r,
+                                "Case '{}' external source_{} R out of tolerance: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                case_name,
+                                idx + 1,
+                                real,
+                                ext_r,
+                                err_r,
+                                tol_r
+                            );
+                        }
+                        if let Some((abs_floor, rel_percent)) = external_x_tol {
+                            let tol_x = tolerance_with_floor(*ext_x, abs_floor, rel_percent);
+                            assert!(
+                                err_x <= tol_x,
+                                "Case '{}' external source_{} X out of tolerance: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                case_name,
+                                idx + 1,
+                                imag,
+                                ext_x,
+                                err_x,
+                                tol_x
+                            );
+                        }
                     }
                 }
             }
@@ -281,6 +330,8 @@ fn corpus_validation_cases_with_references() {
                         {
                             if idx < impedances.len() {
                                 let (real, imag) = impedances[idx];
+                                let err_r = (real - ext_r).abs();
+                                let err_x = (imag - ext_x).abs();
                                 eprintln!(
                                     "corpus external delta: case='{}' freq={:.3}MHz dR={:+.6} dX={:+.6} (fnec-ext)",
                                     case_name,
@@ -288,6 +339,35 @@ fn corpus_validation_cases_with_references() {
                                     real - ext_r,
                                     imag - ext_x
                                 );
+
+                                if let Some((abs_floor, rel_percent)) = external_r_tol {
+                                    let tol_r =
+                                        tolerance_with_floor(*ext_r, abs_floor, rel_percent);
+                                    assert!(
+                                        err_r <= tol_r,
+                                        "Case '{}' external freq {:.3} MHz R out of tolerance: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                        case_name,
+                                        freq_mhz,
+                                        real,
+                                        ext_r,
+                                        err_r,
+                                        tol_r
+                                    );
+                                }
+                                if let Some((abs_floor, rel_percent)) = external_x_tol {
+                                    let tol_x =
+                                        tolerance_with_floor(*ext_x, abs_floor, rel_percent);
+                                    assert!(
+                                        err_x <= tol_x,
+                                        "Case '{}' external freq {:.3} MHz X out of tolerance: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                                        case_name,
+                                        freq_mhz,
+                                        imag,
+                                        ext_x,
+                                        err_x,
+                                        tol_x
+                                    );
+                                }
                             }
                         }
                     }
@@ -333,12 +413,39 @@ fn corpus_validation_cases_with_references() {
                 ext_obj.get("real_ohm").and_then(Value::as_f64),
                 ext_obj.get("imag_ohm").and_then(Value::as_f64),
             ) {
+                let err_r = (real - ext_r).abs();
+                let err_x = (imag - ext_x).abs();
                 eprintln!(
                     "corpus external delta: case='{}' dR={:+.6} dX={:+.6} (fnec-ext)",
                     case_name,
                     real - ext_r,
                     imag - ext_x
                 );
+
+                if let Some((abs_floor, rel_percent)) = external_r_tol {
+                    let tol_r = tolerance_with_floor(ext_r, abs_floor, rel_percent);
+                    assert!(
+                        err_r <= tol_r,
+                        "Case '{}' external R out of tolerance: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                        case_name,
+                        real,
+                        ext_r,
+                        err_r,
+                        tol_r
+                    );
+                }
+                if let Some((abs_floor, rel_percent)) = external_x_tol {
+                    let tol_x = tolerance_with_floor(ext_x, abs_floor, rel_percent);
+                    assert!(
+                        err_x <= tol_x,
+                        "Case '{}' external X out of tolerance: got {:.6}, external {:.6}, err {:.6}, tol {:.6}",
+                        case_name,
+                        imag,
+                        ext_x,
+                        err_x,
+                        tol_x
+                    );
+                }
             }
         }
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -11,6 +11,10 @@ This directory contains the golden reference test corpus used to validate fnec-r
 
 Every NEC deck in this corpus is validated against a reference engine and the results are recorded in `corpus/reference-results.json`. CI runs `cargo test -p nec-cli --test corpus_validation` to ensure fnec-rust results remain within the tolerance matrix defined in `docs/requirements.md`.
 
+Optional external-candidate gates can be enabled per case in `tolerance_gates`:
+- Impedance candidates: `ExternalR_absolute_ohm`, `ExternalX_absolute_ohm`, `ExternalR_percent_rel`, `ExternalX_percent_rel`
+- RP candidates: `ExternalGain_absolute_dB`, `ExternalAxialRatio_absolute`
+
 ## Corpus cases
 
 ### 1. `dipole-freesp-51seg.nec` — Half-wave dipole, free space

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -37,6 +37,7 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: corpus validation now logs external-reference deltas for RP sample rows, and `dipole-freesp-rp-51seg` carries a first `nec2c` pattern candidate for parity tracking.
 	- 2026-04-25 progress: `dipole-xaxis-rp-grid-51seg` now also carries `nec2c` external RP samples, so the observational parity path covers both current RP corpus decks.
 	- 2026-04-25 progress: RP corpus cases can now promote those external pattern candidates into CI gates with optional `ExternalGain_absolute_dB` / `ExternalAxialRatio_absolute` thresholds.
+	- 2026-04-25 progress: corpus validation now also supports optional external impedance gates (`ExternalR_absolute_ohm`, `ExternalX_absolute_ohm`, `ExternalR_percent_rel`, `ExternalX_percent_rel`) for scalar, source, and FR candidate deltas.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@ All notable documentation process changes are recorded here.
 - Corpus validation now also records external-reference deltas for RP pattern samples when `external_reference_candidate.pattern_samples` is present.
 - Added `nec2c` external RP sample candidates for the multi-phi x-axis corpus case so parity tracking now covers both current RP decks.
 - RP corpus cases can now opt into external-pattern CI gates via `ExternalGain_absolute_dB` and `ExternalAxialRatio_absolute` in `tolerance_gates`.
+- Corpus validation now also supports optional external impedance CI gates (`ExternalR_*`/`ExternalX_*`) for scalar, multi-source, and frequency-sweep candidates.
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
- add optional external impedance gates for scalar, source, and frequency candidate deltas in corpus validation
- keep all new impedance gates opt-in via tolerance_gates (`ExternalR_*` / `ExternalX_*`)
- document the new external impedance gate keys in corpus docs and release notes

## Validation
- cargo fmt --all --check
- cargo test -p nec-cli --test corpus_validation -- --nocapture