### PR TITLE
Seed external impedance gates on sweep case

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practi
 	- Multi-wire Hallen: per-wire homogeneous constants and endpoint constraints; correct passive-wire (zero) RHS
 - Segment current distribution table in CLI output (`CURRENTS` section after feedpoint table)
 - RP radiation-pattern execution in CLI output (`RADIATION_PATTERN` section with theta/phi gain rows)
-- Corpus validation can track and optionally gate external RP parity candidates recorded in `corpus/reference-results.json`
+- Corpus validation can track and optionally gate external parity candidates (RP and impedance) recorded in `corpus/reference-results.json`
 - Pulse-basis, continuity-basis, and sinusoidal-tapered Pocklington solvers (EXPERIMENTAL — known to diverge for thin wires)
 	- `sinusoidal` now falls back to Hallen on single collinear chains when its residual budget is exceeded, so the CLI avoids returning misleading impedances for that path
 - CLI binary `fnec` with selectable solver and RHS modes

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -202,6 +202,7 @@ Optional external-candidate gates can be enabled per case in `tolerance_gates`:
 
 **Tolerance gates**:
 - Each frequency point: R, X within 0.1% relative
+- External impedance candidate gate (enabled in corpus JSON): `ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`
 - Trend validation: impedance curve must be smooth (no discontinuities), resonance near 14.2 MHz
 
 **Why this case**: Frequency sweeps are standard analysis. Validates that the solver scales correctly across frequency and produces physically sensible results.

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -458,9 +458,11 @@
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
-        "X_absolute_ohm": 0.05
+        "X_absolute_ohm": 0.05,
+        "ExternalR_absolute_ohm": 15.0,
+        "ExternalX_absolute_ohm": 50.0
       },
-      "status": "fnec now solves all FR points and CI-gates the full sweep using Hallen regression values. External NEC2DXS500+XQ candidates retained for future parity tightening."
+      "status": "fnec now solves all FR points and CI-gates the full sweep using Hallen regression values. External NEC2DXS500+XQ candidates are now also gated with absolute external R/X thresholds for parity tightening."
     },
     "multi-source": {
       "deck_file": "multi-source.nec",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -38,6 +38,7 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: `dipole-xaxis-rp-grid-51seg` now also carries `nec2c` external RP samples, so the observational parity path covers both current RP corpus decks.
 	- 2026-04-25 progress: RP corpus cases can now promote those external pattern candidates into CI gates with optional `ExternalGain_absolute_dB` / `ExternalAxialRatio_absolute` thresholds.
 	- 2026-04-25 progress: corpus validation now also supports optional external impedance gates (`ExternalR_absolute_ohm`, `ExternalX_absolute_ohm`, `ExternalR_percent_rel`, `ExternalX_percent_rel`) for scalar, source, and FR candidate deltas.
+	- 2026-04-25 progress: `frequency-sweep-dipole` now enables the first external impedance candidate gates with `ExternalR_absolute_ohm=15.0` and `ExternalX_absolute_ohm=50.0`.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,7 @@ All notable documentation process changes are recorded here.
 - Added `nec2c` external RP sample candidates for the multi-phi x-axis corpus case so parity tracking now covers both current RP decks.
 - RP corpus cases can now opt into external-pattern CI gates via `ExternalGain_absolute_dB` and `ExternalAxialRatio_absolute` in `tolerance_gates`.
 - Corpus validation now also supports optional external impedance CI gates (`ExternalR_*`/`ExternalX_*`) for scalar, multi-source, and frequency-sweep candidates.
+- Enabled the first external impedance CI-gated case (`frequency-sweep-dipole`) with absolute candidate thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`).
 
 ## 0.2.0 — 2026-05-01
 


### PR DESCRIPTION
## Summary
- enable external impedance candidate gates on frequency-sweep-dipole
- use absolute thresholds derived from observed external deltas (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`)
- update README/corpus/docs notes to reflect the first enabled impedance-gated case

## Validation
- cargo fmt --all --check
- cargo test -p nec-cli --test corpus_validation -- --nocapture