### PR TITLE
Add benchmark mode matrix and second impedance gate seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +61,7 @@ dependencies = [
  "nec_report",
  "nec_solver",
  "num-complex",
+ "rayon",
  "serde_json",
 ]
 
@@ -123,6 +155,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "nec-cli"
 version = "0.2.0"
 dependencies = [
+ "nec_accel",
  "nec_model",
  "nec_parser",
  "nec_project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ nec_project = { path = "crates/nec_project" }
 
 # External crates
 num-complex = "0.4"
+rayon = "1"

--- a/apps/nec-cli/Cargo.toml
+++ b/apps/nec-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 nec_parser  = { workspace = true }
 nec_model   = { workspace = true }
+nec_accel   = { workspace = true }
 nec_project = { workspace = true }
 nec_report  = { workspace = true }
 nec_solver  = { workspace = true }

--- a/apps/nec-cli/Cargo.toml
+++ b/apps/nec-cli/Cargo.toml
@@ -21,6 +21,7 @@ nec_project = { workspace = true }
 nec_report  = { workspace = true }
 nec_solver  = { workspace = true }
 num-complex = { workspace = true }
+rayon       = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -101,15 +101,27 @@ fn steer_execution_mode_by_profile(
     }
 }
 
-fn warn_compatibility_profile(profile: CompatibilityProfile, execution_mode: ExecutionMode) {
+fn warn_compatibility_profile(
+    profile: CompatibilityProfile,
+    requested_execution_mode: ExecutionMode,
+    effective_execution_mode: ExecutionMode,
+    exec_flag_explicitly_set: bool,
+) {
     if profile != CompatibilityProfile::FourNec2DropIn {
         return;
     }
 
-    eprintln!(
-        "warning: 4nec2 drop-in compatibility profile detected by binary name; default execution path is steered to exec={} unless --exec is explicitly provided",
-        execution_mode.as_diag_str()
-    );
+    if exec_flag_explicitly_set {
+        eprintln!(
+            "warning: 4nec2 drop-in compatibility profile detected by binary name; preserving explicit --exec={}",
+            requested_execution_mode.as_diag_str()
+        );
+    } else {
+        eprintln!(
+            "warning: 4nec2 drop-in compatibility profile detected by binary name; default execution path steered to exec={}",
+            effective_execution_mode.as_diag_str()
+        );
+    }
 }
 
 fn parse_args(
@@ -625,9 +637,18 @@ fn main() -> ExitCode {
             }
         };
 
-    execution_mode =
-        steer_execution_mode_by_profile(execution_mode, profile, exec_flag_explicitly_set);
-    warn_compatibility_profile(profile, execution_mode);
+    let requested_execution_mode = execution_mode;
+    execution_mode = steer_execution_mode_by_profile(
+        requested_execution_mode,
+        profile,
+        exec_flag_explicitly_set,
+    );
+    warn_compatibility_profile(
+        profile,
+        requested_execution_mode,
+        execution_mode,
+        exec_flag_explicitly_set,
+    );
 
     if hallen_allow_non_collinear && solver_mode != SolverMode::Hallen {
         eprintln!(

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
+use nec_accel::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
 use nec_model::card::Card;
 use nec_parser::parse;
 use nec_report::{render_text_report, CurrentRow, FeedpointRow, PatternRow, ReportInput};
@@ -153,9 +154,13 @@ fn warn_execution_mode_fallback(execution_mode: ExecutionMode) {
     match execution_mode {
         ExecutionMode::Cpu => {}
         ExecutionMode::Hybrid => {}
-        ExecutionMode::Gpu => eprintln!(
-            "warning: --exec gpu requested, but GPU solve kernels are not yet wired; using CPU solve path"
-        ),
+        ExecutionMode::Gpu => {
+            if let DispatchDecision::FallbackToCpu { reason } =
+                dispatch_frequency_point(AccelRequestKind::GpuOnly, 0.0)
+            {
+                eprintln!("warning: --exec gpu requested, but {reason}; using CPU solve path");
+            }
+        }
     }
 }
 
@@ -669,13 +674,6 @@ fn main() -> ExitCode {
     {
         let lane_plan = build_hybrid_lane_plan(freqs_hz.len());
 
-        if !lane_plan.gpu_candidate_indices.is_empty() {
-            eprintln!(
-                    "warning: --exec hybrid scheduled {} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback",
-                    lane_plan.gpu_candidate_indices.len()
-                );
-        }
-
         let mut solved = Vec::with_capacity(freqs_hz.len());
 
         let cpu_results: Vec<(usize, Result<FrequencySolveResult, String>)> = lane_plan
@@ -686,12 +684,42 @@ fn main() -> ExitCode {
             .collect();
         solved.extend(cpu_results);
 
-        let gpu_fallback_results: Vec<(usize, Result<FrequencySolveResult, String>)> = lane_plan
+        let gpu_dispatch: Vec<(usize, DispatchDecision)> = lane_plan
             .gpu_candidate_indices
             .iter()
             .copied()
-            .map(|idx| (idx, solve_one(freqs_hz[idx])))
+            .map(|idx| {
+                (
+                    idx,
+                    dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, freqs_hz[idx]),
+                )
+            })
             .collect();
+
+        let gpu_fallback_count = gpu_dispatch
+            .iter()
+            .filter(|(_, decision)| matches!(decision, DispatchDecision::FallbackToCpu { .. }))
+            .count();
+        if gpu_fallback_count > 0 {
+            eprintln!(
+                "warning: --exec hybrid scheduled {gpu_fallback_count} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback"
+            );
+        }
+
+        let gpu_fallback_results: Vec<(usize, Result<FrequencySolveResult, String>)> =
+            gpu_dispatch
+                .into_iter()
+                .map(|(idx, decision)| match decision {
+                    DispatchDecision::FallbackToCpu { .. } => (idx, solve_one(freqs_hz[idx])),
+                    DispatchDecision::RunOnGpu => (
+                        idx,
+                        Err(
+                            "internal error: GPU dispatch selected, but GPU solve path is not wired in nec-cli"
+                                .to_string(),
+                        ),
+                    ),
+                })
+                .collect();
         solved.extend(gpu_fallback_results);
 
         solved

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
-use nec_accel::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
+use nec_accel::{
+    dispatch_frequency_point, execute_frequency_point, AccelRequestKind, DispatchDecision,
+    ExecutionPath,
+};
 use nec_model::card::Card;
 use nec_parser::parse;
 use nec_report::{render_text_report, CurrentRow, FeedpointRow, PatternRow, ReportInput};
@@ -154,13 +157,16 @@ fn warn_execution_mode_fallback(execution_mode: ExecutionMode) {
     match execution_mode {
         ExecutionMode::Cpu => {}
         ExecutionMode::Hybrid => {}
-        ExecutionMode::Gpu => {
-            if let DispatchDecision::FallbackToCpu { reason } =
-                dispatch_frequency_point(AccelRequestKind::GpuOnly, 0.0)
-            {
+        ExecutionMode::Gpu => match dispatch_frequency_point(AccelRequestKind::GpuOnly, 0.0) {
+            DispatchDecision::FallbackToCpu { reason } => {
                 eprintln!("warning: --exec gpu requested, but {reason}; using CPU solve path");
             }
-        }
+            DispatchDecision::RunOnGpu => {
+                eprintln!(
+                        "warning: --exec gpu dispatched to accelerator stub backend; solving with CPU emulation"
+                    );
+            }
+        },
     }
 }
 
@@ -696,14 +702,27 @@ fn main() -> ExitCode {
             })
             .collect();
 
-        let gpu_fallback_count = gpu_dispatch
+        let gpu_fallback_results: Vec<(
+            usize,
+            ExecutionPath,
+            Result<FrequencySolveResult, String>,
+        )> = gpu_dispatch
+            .into_iter()
+            .map(|(idx, decision)| {
+                let (path, result) = execute_frequency_point(decision, || solve_one(freqs_hz[idx]));
+                (idx, path, result)
+            })
+            .collect();
+
+        let gpu_fallback_count = gpu_fallback_results
             .iter()
-            .filter(|(_, decision)| matches!(decision, DispatchDecision::FallbackToCpu { .. }))
+            .filter(|(_, path, _)| matches!(path, ExecutionPath::CpuFallback))
             .count();
-        let gpu_stub_count = gpu_dispatch
+        let gpu_stub_count = gpu_fallback_results
             .iter()
-            .filter(|(_, decision)| matches!(decision, DispatchDecision::RunOnGpu))
+            .filter(|(_, path, _)| matches!(path, ExecutionPath::GpuStubEmulation))
             .count();
+
         if gpu_fallback_count > 0 {
             eprintln!(
                 "warning: --exec hybrid scheduled {gpu_fallback_count} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback"
@@ -715,14 +734,11 @@ fn main() -> ExitCode {
             );
         }
 
-        let gpu_fallback_results: Vec<(usize, Result<FrequencySolveResult, String>)> = gpu_dispatch
-            .into_iter()
-            .map(|(idx, decision)| match decision {
-                DispatchDecision::FallbackToCpu { .. } => (idx, solve_one(freqs_hz[idx])),
-                DispatchDecision::RunOnGpu => (idx, solve_one(freqs_hz[idx])),
-            })
-            .collect();
-        solved.extend(gpu_fallback_results);
+        solved.extend(
+            gpu_fallback_results
+                .into_iter()
+                .map(|(idx, _, result)| (idx, result)),
+        );
 
         solved
     } else {

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -700,26 +700,28 @@ fn main() -> ExitCode {
             .iter()
             .filter(|(_, decision)| matches!(decision, DispatchDecision::FallbackToCpu { .. }))
             .count();
+        let gpu_stub_count = gpu_dispatch
+            .iter()
+            .filter(|(_, decision)| matches!(decision, DispatchDecision::RunOnGpu))
+            .count();
         if gpu_fallback_count > 0 {
             eprintln!(
                 "warning: --exec hybrid scheduled {gpu_fallback_count} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback"
             );
         }
+        if gpu_stub_count > 0 {
+            eprintln!(
+                "warning: --exec hybrid dispatched {gpu_stub_count} frequency point(s) to accelerator stub backend; solving with CPU emulation"
+            );
+        }
 
-        let gpu_fallback_results: Vec<(usize, Result<FrequencySolveResult, String>)> =
-            gpu_dispatch
-                .into_iter()
-                .map(|(idx, decision)| match decision {
-                    DispatchDecision::FallbackToCpu { .. } => (idx, solve_one(freqs_hz[idx])),
-                    DispatchDecision::RunOnGpu => (
-                        idx,
-                        Err(
-                            "internal error: GPU dispatch selected, but GPU solve path is not wired in nec-cli"
-                                .to_string(),
-                        ),
-                    ),
-                })
-                .collect();
+        let gpu_fallback_results: Vec<(usize, Result<FrequencySolveResult, String>)> = gpu_dispatch
+            .into_iter()
+            .map(|(idx, decision)| match decision {
+                DispatchDecision::FallbackToCpu { .. } => (idx, solve_one(freqs_hz[idx])),
+                DispatchDecision::RunOnGpu => (idx, solve_one(freqs_hz[idx])),
+            })
+            .collect();
         solved.extend(gpu_fallback_results);
 
         solved

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -13,6 +13,7 @@ use nec_solver::{
     wire_endpoints_from_segs, FarFieldPoint, GroundModel, ZMatrix,
 };
 use num_complex::Complex64;
+use rayon::prelude::*;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -311,6 +312,214 @@ fn frequencies_from_fr(deck: &nec_model::deck::NecDeck) -> Vec<f64> {
     out
 }
 
+struct FrequencySolveResult {
+    report: String,
+    diag_line: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn solve_frequency_point(
+    deck: &nec_model::deck::NecDeck,
+    segs: &[nec_solver::Segment],
+    wire_endpoints: &[(usize, usize)],
+    per_wire_basis_feasible: bool,
+    v_vec: &[Complex64],
+    ground: &GroundModel,
+    pattern_points: &[FarFieldPoint],
+    solver_mode: SolverMode,
+    pulse_rhs_mode: PulseRhsMode,
+    execution_mode: ExecutionMode,
+    hallen_allow_non_collinear: bool,
+    freq_hz: f64,
+) -> Result<FrequencySolveResult, String> {
+    let v_vec_pulse = match pulse_rhs_mode {
+        PulseRhsMode::Raw => v_vec.to_vec(),
+        PulseRhsMode::Nec2 => scale_excitation_for_pulse_rhs(v_vec, freq_hz),
+    };
+
+    let mut z_mat = match solver_mode {
+        SolverMode::Hallen => assemble_z_matrix_with_ground(segs, freq_hz, ground),
+        SolverMode::Pulse | SolverMode::Continuity | SolverMode::Sinusoidal => {
+            assemble_pocklington_matrix(segs, freq_hz)
+        }
+    };
+
+    let (load_vec, load_warnings) = build_loads(deck, segs, freq_hz);
+    for warning in &load_warnings {
+        eprintln!("warning: {warning}");
+    }
+    z_mat.add_to_diagonal(&load_vec);
+
+    let (i_vec, diag_abs, diag_rel, diag_label) = match solver_mode {
+        SolverMode::Hallen => {
+            let hallen_rhs =
+                build_hallen_rhs_with_options(deck, segs, freq_hz, hallen_allow_non_collinear)
+                    .map_err(|e| e.to_string())?;
+            let sol = solve_hallen(
+                &z_mat,
+                &hallen_rhs.rhs,
+                &hallen_rhs.cos_vec,
+                &hallen_rhs.wire_endpoints,
+            )
+            .map_err(|e| e.to_string())?;
+            let (a, r) = residual_hallen(
+                &z_mat,
+                &sol.currents,
+                &sol.c_hom_per_wire,
+                &hallen_rhs.cos_vec,
+                &hallen_rhs.rhs,
+                &hallen_rhs.wire_endpoints,
+            );
+            (sol.currents, a, r, "hallen")
+        }
+        SolverMode::Pulse => {
+            let i = solve(&z_mat, &v_vec_pulse).map_err(|e| e.to_string())?;
+            let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
+            (i, a, r, "pulse")
+        }
+        SolverMode::Continuity => {
+            if !per_wire_basis_feasible {
+                eprintln!(
+                    "warning: continuity solver requires >=2 segments per wire; falling back to pulse"
+                );
+                let i = solve(&z_mat, &v_vec_pulse).map_err(|e| e.to_string())?;
+                let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
+                (i, a, r, "continuity->pulse")
+            } else {
+                let i = solve_with_continuity_basis_per_wire(&z_mat, &v_vec_pulse, wire_endpoints)
+                    .map_err(|e| e.to_string())?;
+                let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
+                if r <= CONTINUITY_REL_RESIDUAL_MAX {
+                    (i, a, r, "continuity")
+                } else {
+                    eprintln!(
+                        "warning: continuity residual {:.3e} > {:.3e}; falling back to pulse",
+                        r, CONTINUITY_REL_RESIDUAL_MAX
+                    );
+                    let i2 = solve(&z_mat, &v_vec_pulse).map_err(|e| e.to_string())?;
+                    let (a2, r2) = residual_zi_minus_v(&z_mat, &i2, &v_vec_pulse);
+                    (i2, a2, r2, "continuity->pulse(residual)")
+                }
+            }
+        }
+        SolverMode::Sinusoidal => {
+            if !per_wire_basis_feasible {
+                eprintln!(
+                    "warning: sinusoidal solver requires >=2 segments per wire; falling back to pulse"
+                );
+                let i = solve(&z_mat, &v_vec_pulse).map_err(|e| e.to_string())?;
+                let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
+                (i, a, r, "sinusoidal->pulse")
+            } else {
+                let i = solve_with_sinusoidal_basis_per_wire(&z_mat, &v_vec_pulse, wire_endpoints)
+                    .map_err(|e| e.to_string())?;
+                let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
+                if r <= SINUSOIDAL_REL_RESIDUAL_MAX {
+                    (i, a, r, "sinusoidal")
+                } else {
+                    eprintln!(
+                        "warning: sinusoidal residual {:.3e} > {:.3e}; falling back to hallen",
+                        r, SINUSOIDAL_REL_RESIDUAL_MAX
+                    );
+                    let hallen_rhs = build_hallen_rhs_with_options(
+                        deck,
+                        segs,
+                        freq_hz,
+                        hallen_allow_non_collinear,
+                    )
+                    .map_err(|e| e.to_string())?;
+                    let mut hallen_z = assemble_z_matrix_with_ground(segs, freq_hz, ground);
+                    hallen_z.add_to_diagonal(&load_vec);
+                    let sol = solve_hallen(
+                        &hallen_z,
+                        &hallen_rhs.rhs,
+                        &hallen_rhs.cos_vec,
+                        &hallen_rhs.wire_endpoints,
+                    )
+                    .map_err(|e| e.to_string())?;
+                    let (a2, r2) = residual_hallen(
+                        &hallen_z,
+                        &sol.currents,
+                        &sol.c_hom_per_wire,
+                        &hallen_rhs.cos_vec,
+                        &hallen_rhs.rhs,
+                        &hallen_rhs.wire_endpoints,
+                    );
+                    (sol.currents, a2, r2, "sinusoidal->hallen(residual)")
+                }
+            }
+        }
+    };
+
+    let mut rows: Vec<FeedpointRow> = Vec::new();
+    for (idx, seg) in segs.iter().enumerate() {
+        let v = v_vec[idx];
+        if v.norm() < 1e-30 {
+            continue;
+        }
+        let i = i_vec[idx];
+        let v_source = v * seg.length;
+        let z_in = if i.norm() > 1e-60 {
+            v_source / i
+        } else {
+            v_source
+        };
+        rows.push(FeedpointRow {
+            tag: seg.tag as usize,
+            seg: seg.tag_index as usize,
+            v_source,
+            current: i,
+            z_in,
+        });
+    }
+
+    let current_table: Vec<CurrentRow> = segs
+        .iter()
+        .enumerate()
+        .map(|(idx, seg)| CurrentRow {
+            tag: seg.tag as usize,
+            seg: seg.tag_index as usize,
+            current: i_vec[idx],
+        })
+        .collect();
+
+    let pattern_table: Vec<PatternRow> = if pattern_points.is_empty() {
+        Vec::new()
+    } else {
+        let results = compute_radiation_pattern(segs, &i_vec, freq_hz, pattern_points);
+        results
+            .iter()
+            .map(|r| PatternRow {
+                theta_deg: r.theta_deg,
+                phi_deg: r.phi_deg,
+                gain_total_dbi: r.gain_total_dbi,
+                gain_theta_dbi: r.gain_theta_dbi,
+                gain_phi_dbi: r.gain_phi_dbi,
+                axial_ratio: r.axial_ratio,
+            })
+            .collect()
+    };
+
+    let report = render_text_report(&ReportInput {
+        solver_mode: diag_label,
+        pulse_rhs: pulse_rhs_mode.as_contract_str(),
+        frequency_hz: freq_hz,
+        rows: &rows,
+        current_table: &current_table,
+        pattern_table: &pattern_table,
+    });
+    let diag_line = format!(
+        "diag: mode={diag_label} pulse_rhs={:?} exec={} freq_mhz={:.6} abs_res={:.6e} rel_res={:.6e}",
+        pulse_rhs_mode,
+        execution_mode.as_diag_str(),
+        freq_hz / 1e6,
+        diag_abs,
+        diag_rel
+    );
+
+    Ok(FrequencySolveResult { report, diag_line })
+}
+
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
 
@@ -399,287 +608,72 @@ fn main() -> ExitCode {
     let ground = ground_model_from_deck(deck);
     warn_deferred_ground_model(&ground);
 
-    for (fidx, freq_hz) in freqs_hz.iter().copied().enumerate() {
-        let v_vec_pulse = match pulse_rhs_mode {
-            PulseRhsMode::Raw => v_vec.clone(),
-            PulseRhsMode::Nec2 => scale_excitation_for_pulse_rhs(&v_vec, freq_hz),
-        };
-
-        let mut z_mat = match solver_mode {
-            SolverMode::Hallen => assemble_z_matrix_with_ground(&segs, freq_hz, &ground),
-            SolverMode::Pulse | SolverMode::Continuity | SolverMode::Sinusoidal => {
-                assemble_pocklington_matrix(&segs, freq_hz)
-            }
-        };
-
-        let (load_vec, load_warnings) = build_loads(deck, &segs, freq_hz);
-        for warning in &load_warnings {
-            eprintln!("warning: {warning}");
-        }
-        z_mat.add_to_diagonal(&load_vec);
-
-        let (i_vec, diag_abs, diag_rel, diag_label) = match solver_mode {
-            SolverMode::Hallen => {
-                let hallen_rhs = match build_hallen_rhs_with_options(
-                    deck,
-                    &segs,
-                    freq_hz,
-                    hallen_allow_non_collinear,
-                ) {
-                    Ok(h) => h,
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        return ExitCode::FAILURE;
-                    }
-                };
-                match solve_hallen(
-                    &z_mat,
-                    &hallen_rhs.rhs,
-                    &hallen_rhs.cos_vec,
-                    &hallen_rhs.wire_endpoints,
-                ) {
-                    Ok(sol) => {
-                        let (a, r) = residual_hallen(
-                            &z_mat,
-                            &sol.currents,
-                            &sol.c_hom_per_wire,
-                            &hallen_rhs.cos_vec,
-                            &hallen_rhs.rhs,
-                            &hallen_rhs.wire_endpoints,
-                        );
-                        (sol.currents, a, r, "hallen")
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        return ExitCode::FAILURE;
-                    }
-                }
-            }
-            SolverMode::Pulse => match solve(&z_mat, &v_vec_pulse) {
-                Ok(i) => {
-                    let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
-                    (i, a, r, "pulse")
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    return ExitCode::FAILURE;
-                }
-            },
-            SolverMode::Continuity => {
-                if !per_wire_basis_feasible {
-                    eprintln!(
-                        "warning: continuity solver requires >=2 segments per wire; falling back to pulse"
-                    );
-                    match solve(&z_mat, &v_vec_pulse) {
-                        Ok(i) => {
-                            let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
-                            (i, a, r, "continuity->pulse")
-                        }
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            return ExitCode::FAILURE;
-                        }
-                    }
-                } else {
-                    match solve_with_continuity_basis_per_wire(
-                        &z_mat,
-                        &v_vec_pulse,
-                        &wire_endpoints,
-                    ) {
-                        Ok(i) => {
-                            let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
-                            if r <= CONTINUITY_REL_RESIDUAL_MAX {
-                                (i, a, r, "continuity")
-                            } else {
-                                eprintln!(
-                                    "warning: continuity residual {:.3e} > {:.3e}; falling back to pulse",
-                                    r, CONTINUITY_REL_RESIDUAL_MAX
-                                );
-                                match solve(&z_mat, &v_vec_pulse) {
-                                    Ok(i2) => {
-                                        let (a2, r2) =
-                                            residual_zi_minus_v(&z_mat, &i2, &v_vec_pulse);
-                                        (i2, a2, r2, "continuity->pulse(residual)")
-                                    }
-                                    Err(e) => {
-                                        eprintln!("error: {e}");
-                                        return ExitCode::FAILURE;
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            return ExitCode::FAILURE;
-                        }
-                    }
-                }
-            }
-            SolverMode::Sinusoidal => {
-                if !per_wire_basis_feasible {
-                    eprintln!(
-                        "warning: sinusoidal solver requires >=2 segments per wire; falling back to pulse"
-                    );
-                    match solve(&z_mat, &v_vec_pulse) {
-                        Ok(i) => {
-                            let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
-                            (i, a, r, "sinusoidal->pulse")
-                        }
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            return ExitCode::FAILURE;
-                        }
-                    }
-                } else {
-                    match solve_with_sinusoidal_basis_per_wire(
-                        &z_mat,
-                        &v_vec_pulse,
-                        &wire_endpoints,
-                    ) {
-                        Ok(i) => {
-                            let (a, r) = residual_zi_minus_v(&z_mat, &i, &v_vec_pulse);
-                            if r <= SINUSOIDAL_REL_RESIDUAL_MAX {
-                                (i, a, r, "sinusoidal")
-                            } else {
-                                eprintln!(
-                                    "warning: sinusoidal residual {:.3e} > {:.3e}; falling back to hallen",
-                                    r, SINUSOIDAL_REL_RESIDUAL_MAX
-                                );
-                                let hallen_rhs = match build_hallen_rhs_with_options(
-                                    deck,
-                                    &segs,
-                                    freq_hz,
-                                    hallen_allow_non_collinear,
-                                ) {
-                                    Ok(h) => h,
-                                    Err(e) => {
-                                        eprintln!("error: {e}");
-                                        return ExitCode::FAILURE;
-                                    }
-                                };
-                                let mut hallen_z =
-                                    assemble_z_matrix_with_ground(&segs, freq_hz, &ground);
-                                hallen_z.add_to_diagonal(&load_vec);
-                                match solve_hallen(
-                                    &hallen_z,
-                                    &hallen_rhs.rhs,
-                                    &hallen_rhs.cos_vec,
-                                    &hallen_rhs.wire_endpoints,
-                                ) {
-                                    Ok(sol) => {
-                                        let (a2, r2) = residual_hallen(
-                                            &hallen_z,
-                                            &sol.currents,
-                                            &sol.c_hom_per_wire,
-                                            &hallen_rhs.cos_vec,
-                                            &hallen_rhs.rhs,
-                                            &hallen_rhs.wire_endpoints,
-                                        );
-                                        (sol.currents, a2, r2, "sinusoidal->hallen(residual)")
-                                    }
-                                    Err(e) => {
-                                        eprintln!("error: {e}");
-                                        return ExitCode::FAILURE;
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            return ExitCode::FAILURE;
-                        }
-                    }
-                }
-            }
-        };
-
-        let mut rows: Vec<FeedpointRow> = Vec::new();
-        for (idx, seg) in segs.iter().enumerate() {
-            let v = v_vec[idx];
-            if v.norm() < 1e-30 {
-                continue;
-            }
-            let i = i_vec[idx];
-            let v_source = v * seg.length;
-            let z_in = if i.norm() > 1e-60 {
-                v_source / i
+    let pattern_points: Vec<FarFieldPoint> = deck
+        .cards
+        .iter()
+        .filter_map(|c| {
+            if let Card::Rp(rp) = c {
+                Some(rp_card_points(
+                    rp.n_theta, rp.n_phi, rp.theta0, rp.phi0, rp.d_theta, rp.d_phi,
+                ))
             } else {
-                v_source
-            };
-            rows.push(FeedpointRow {
-                tag: seg.tag as usize,
-                seg: seg.tag_index as usize,
-                v_source,
-                current: i,
-                z_in,
-            });
-        }
+                None
+            }
+        })
+        .flatten()
+        .collect();
+
+    let solve_one = |freq_hz: f64| {
+        solve_frequency_point(
+            deck,
+            &segs,
+            &wire_endpoints,
+            per_wire_basis_feasible,
+            &v_vec,
+            &ground,
+            &pattern_points,
+            solver_mode,
+            pulse_rhs_mode,
+            execution_mode,
+            hallen_allow_non_collinear,
+            freq_hz,
+        )
+    };
+
+    let solved: Vec<(usize, Result<FrequencySolveResult, String>)> =
+        if matches!(execution_mode, ExecutionMode::Hybrid) && freqs_hz.len() > 1 {
+            freqs_hz
+                .par_iter()
+                .copied()
+                .enumerate()
+                .map(|(idx, freq_hz)| (idx, solve_one(freq_hz)))
+                .collect()
+        } else {
+            freqs_hz
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(idx, freq_hz)| (idx, solve_one(freq_hz)))
+                .collect()
+        };
+
+    let mut solved = solved;
+    solved.sort_by_key(|(idx, _)| *idx);
+
+    for (fidx, result) in solved {
+        let solved_point = match result {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
 
         if fidx > 0 {
             println!();
         }
-
-        let current_table: Vec<CurrentRow> = segs
-            .iter()
-            .enumerate()
-            .map(|(idx, seg)| CurrentRow {
-                tag: seg.tag as usize,
-                seg: seg.tag_index as usize,
-                current: i_vec[idx],
-            })
-            .collect();
-
-        // Collect RP cards and compute radiation pattern if any are present.
-        let pattern_points: Vec<FarFieldPoint> = deck
-            .cards
-            .iter()
-            .filter_map(|c| {
-                if let Card::Rp(rp) = c {
-                    Some(rp_card_points(
-                        rp.n_theta, rp.n_phi, rp.theta0, rp.phi0, rp.d_theta, rp.d_phi,
-                    ))
-                } else {
-                    None
-                }
-            })
-            .flatten()
-            .collect();
-
-        let pattern_table: Vec<PatternRow> = if pattern_points.is_empty() {
-            Vec::new()
-        } else {
-            let results = compute_radiation_pattern(&segs, &i_vec, freq_hz, &pattern_points);
-            results
-                .iter()
-                .map(|r| PatternRow {
-                    theta_deg: r.theta_deg,
-                    phi_deg: r.phi_deg,
-                    gain_total_dbi: r.gain_total_dbi,
-                    gain_theta_dbi: r.gain_theta_dbi,
-                    gain_phi_dbi: r.gain_phi_dbi,
-                    axial_ratio: r.axial_ratio,
-                })
-                .collect()
-        };
-
-        let report = render_text_report(&ReportInput {
-            solver_mode: diag_label,
-            pulse_rhs: pulse_rhs_mode.as_contract_str(),
-            frequency_hz: freq_hz,
-            rows: &rows,
-            current_table: &current_table,
-            pattern_table: &pattern_table,
-        });
-        print!("{report}");
-
-        eprintln!(
-            "diag: mode={diag_label} pulse_rhs={:?} exec={} freq_mhz={:.6} abs_res={:.6e} rel_res={:.6e}",
-            pulse_rhs_mode,
-            execution_mode.as_diag_str(),
-            freq_hz / 1e6,
-            diag_abs,
-            diag_rel
-        );
+        print!("{}", solved_point.report);
+        eprintln!("{}", solved_point.diag_line);
     }
 
     ExitCode::SUCCESS

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -45,7 +45,7 @@ impl ExecutionMode {
     fn as_diag_str(self) -> &'static str {
         match self {
             ExecutionMode::Cpu => "cpu",
-            ExecutionMode::Hybrid => "hybrid(cpu-fallback)",
+            ExecutionMode::Hybrid => "hybrid",
             ExecutionMode::Gpu => "gpu(cpu-fallback)",
         }
     }
@@ -152,9 +152,7 @@ fn parse_args(
 fn warn_execution_mode_fallback(execution_mode: ExecutionMode) {
     match execution_mode {
         ExecutionMode::Cpu => {}
-        ExecutionMode::Hybrid => eprintln!(
-            "warning: --exec hybrid requested, but CPU+GPU split kernels are not yet wired; using CPU solve path"
-        ),
+        ExecutionMode::Hybrid => {}
         ExecutionMode::Gpu => eprintln!(
             "warning: --exec gpu requested, but GPU solve kernels are not yet wired; using CPU solve path"
         ),

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -18,6 +18,7 @@ use nec_solver::{
 };
 use num_complex::Complex64;
 use rayon::prelude::*;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -45,6 +46,12 @@ enum ExecutionMode {
     Gpu,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompatibilityProfile {
+    Native,
+    FourNec2DropIn,
+}
+
 impl ExecutionMode {
     fn as_diag_str(self) -> &'static str {
         match self {
@@ -62,6 +69,47 @@ impl PulseRhsMode {
             PulseRhsMode::Nec2 => "Nec2",
         }
     }
+}
+
+fn detect_compatibility_profile(argv0: &str) -> CompatibilityProfile {
+    let stem = Path::new(argv0)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if stem.contains("nec2dxs") || stem.contains("4nec2") {
+        CompatibilityProfile::FourNec2DropIn
+    } else {
+        CompatibilityProfile::Native
+    }
+}
+
+fn steer_execution_mode_by_profile(
+    execution_mode: ExecutionMode,
+    profile: CompatibilityProfile,
+    exec_flag_explicitly_set: bool,
+) -> ExecutionMode {
+    if exec_flag_explicitly_set {
+        return execution_mode;
+    }
+
+    match profile {
+        CompatibilityProfile::Native => execution_mode,
+        // In drop-in mode prefer throughput when caller did not force an exec mode.
+        CompatibilityProfile::FourNec2DropIn => ExecutionMode::Hybrid,
+    }
+}
+
+fn warn_compatibility_profile(profile: CompatibilityProfile, execution_mode: ExecutionMode) {
+    if profile != CompatibilityProfile::FourNec2DropIn {
+        return;
+    }
+
+    eprintln!(
+        "warning: 4nec2 drop-in compatibility profile detected by binary name; default execution path is steered to exec={} unless --exec is explicitly provided",
+        execution_mode.as_diag_str()
+    );
 }
 
 fn parse_args(
@@ -555,6 +603,8 @@ fn solve_frequency_point(
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
+    let profile = detect_compatibility_profile(args.first().map(String::as_str).unwrap_or("fnec"));
+    let exec_flag_explicitly_set = args.iter().any(|arg| arg == "--exec");
 
     if args.len() < 2 {
         eprintln!("fnec {}", env!("CARGO_PKG_VERSION"));
@@ -564,7 +614,7 @@ fn main() -> ExitCode {
         return ExitCode::from(2);
     }
 
-    let (solver_mode, pulse_rhs_mode, execution_mode, hallen_allow_non_collinear, path) =
+    let (solver_mode, pulse_rhs_mode, mut execution_mode, hallen_allow_non_collinear, path) =
         match parse_args(&args) {
             Ok(v) => v,
             Err(e) => {
@@ -574,6 +624,10 @@ fn main() -> ExitCode {
                 return ExitCode::from(2);
             }
         };
+
+    execution_mode =
+        steer_execution_mode_by_profile(execution_mode, profile, exec_flag_explicitly_set);
+    warn_compatibility_profile(profile, execution_mode);
 
     if hallen_allow_non_collinear && solver_mode != SolverMode::Hallen {
         eprintln!(
@@ -770,4 +824,56 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        detect_compatibility_profile, steer_execution_mode_by_profile, CompatibilityProfile,
+        ExecutionMode,
+    };
+
+    #[test]
+    fn detects_fournec2_dropin_profile_by_kernel_name() {
+        assert_eq!(
+            detect_compatibility_profile("/tmp/nec2dxs500"),
+            CompatibilityProfile::FourNec2DropIn
+        );
+        assert_eq!(
+            detect_compatibility_profile("C:/tools/4nec2-kernel"),
+            CompatibilityProfile::FourNec2DropIn
+        );
+    }
+
+    #[test]
+    fn keeps_native_profile_for_default_binary_name() {
+        assert_eq!(
+            detect_compatibility_profile("/usr/bin/fnec"),
+            CompatibilityProfile::Native
+        );
+    }
+
+    #[test]
+    fn dropin_profile_steers_default_exec_to_hybrid() {
+        assert_eq!(
+            steer_execution_mode_by_profile(
+                ExecutionMode::Cpu,
+                CompatibilityProfile::FourNec2DropIn,
+                false,
+            ),
+            ExecutionMode::Hybrid
+        );
+    }
+
+    #[test]
+    fn explicit_exec_flag_prevents_profile_steering() {
+        assert_eq!(
+            steer_execution_mode_by_profile(
+                ExecutionMode::Gpu,
+                CompatibilityProfile::FourNec2DropIn,
+                true,
+            ),
+            ExecutionMode::Gpu
+        );
+    }
 }

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -33,6 +33,23 @@ enum PulseRhsMode {
     Nec2,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExecutionMode {
+    Cpu,
+    Hybrid,
+    Gpu,
+}
+
+impl ExecutionMode {
+    fn as_diag_str(self) -> &'static str {
+        match self {
+            ExecutionMode::Cpu => "cpu",
+            ExecutionMode::Hybrid => "hybrid(cpu-fallback)",
+            ExecutionMode::Gpu => "gpu(cpu-fallback)",
+        }
+    }
+}
+
 impl PulseRhsMode {
     fn as_contract_str(self) -> &'static str {
         match self {
@@ -42,9 +59,12 @@ impl PulseRhsMode {
     }
 }
 
-fn parse_args(args: &[String]) -> Result<(SolverMode, PulseRhsMode, bool, PathBuf), String> {
+fn parse_args(
+    args: &[String],
+) -> Result<(SolverMode, PulseRhsMode, ExecutionMode, bool, PathBuf), String> {
     let mut solver_mode = SolverMode::Hallen;
     let mut pulse_rhs_mode = PulseRhsMode::Nec2;
+    let mut execution_mode = ExecutionMode::Cpu;
     let mut hallen_allow_non_collinear = false;
     let mut deck_path: Option<PathBuf> = None;
 
@@ -86,6 +106,22 @@ fn parse_args(args: &[String]) -> Result<(SolverMode, PulseRhsMode, bool, PathBu
                     }
                 };
             }
+            "--exec" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("missing value after --exec (expected: cpu|hybrid|gpu)".to_string());
+                }
+                execution_mode = match args[i].as_str() {
+                    "cpu" => ExecutionMode::Cpu,
+                    "hybrid" => ExecutionMode::Hybrid,
+                    "gpu" => ExecutionMode::Gpu,
+                    other => {
+                        return Err(format!(
+                            "invalid --exec value '{other}' (expected: cpu|hybrid|gpu)"
+                        ))
+                    }
+                };
+            }
             "--allow-noncollinear-hallen" => {
                 hallen_allow_non_collinear = true;
             }
@@ -106,9 +142,22 @@ fn parse_args(args: &[String]) -> Result<(SolverMode, PulseRhsMode, bool, PathBu
     Ok((
         solver_mode,
         pulse_rhs_mode,
+        execution_mode,
         hallen_allow_non_collinear,
         path,
     ))
+}
+
+fn warn_execution_mode_fallback(execution_mode: ExecutionMode) {
+    match execution_mode {
+        ExecutionMode::Cpu => {}
+        ExecutionMode::Hybrid => eprintln!(
+            "warning: --exec hybrid requested, but CPU+GPU split kernels are not yet wired; using CPU solve path"
+        ),
+        ExecutionMode::Gpu => eprintln!(
+            "warning: --exec gpu requested, but GPU solve kernels are not yet wired; using CPU solve path"
+        ),
+    }
 }
 
 fn l2_norm(v: &[Complex64]) -> f64 {
@@ -268,20 +317,21 @@ fn main() -> ExitCode {
     if args.len() < 2 {
         eprintln!("fnec {}", env!("CARGO_PKG_VERSION"));
         eprintln!(
-            "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--allow-noncollinear-hallen] <deck.nec>"
+            "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--allow-noncollinear-hallen] <deck.nec>"
         );
         return ExitCode::from(2);
     }
 
-    let (solver_mode, pulse_rhs_mode, hallen_allow_non_collinear, path) = match parse_args(&args) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("fnec {}", env!("CARGO_PKG_VERSION"));
-            eprintln!("Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--allow-noncollinear-hallen] <deck.nec>");
-            eprintln!("error: {e}");
-            return ExitCode::from(2);
-        }
-    };
+    let (solver_mode, pulse_rhs_mode, execution_mode, hallen_allow_non_collinear, path) =
+        match parse_args(&args) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("fnec {}", env!("CARGO_PKG_VERSION"));
+                eprintln!("Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--allow-noncollinear-hallen] <deck.nec>");
+                eprintln!("error: {e}");
+                return ExitCode::from(2);
+            }
+        };
 
     if hallen_allow_non_collinear && solver_mode != SolverMode::Hallen {
         eprintln!(
@@ -294,6 +344,8 @@ fn main() -> ExitCode {
             "warning: --allow-noncollinear-hallen enables an EXPERIMENTAL Hallen RHS projection on non-collinear geometries; results may be inaccurate"
         );
     }
+
+    warn_execution_mode_fallback(execution_mode);
 
     let input = match std::fs::read_to_string(&path) {
         Ok(s) => s,
@@ -621,8 +673,9 @@ fn main() -> ExitCode {
         print!("{report}");
 
         eprintln!(
-            "diag: mode={diag_label} pulse_rhs={:?} freq_mhz={:.6} abs_res={:.6e} rel_res={:.6e}",
+            "diag: mode={diag_label} pulse_rhs={:?} exec={} freq_mhz={:.6} abs_res={:.6e} rel_res={:.6e}",
             pulse_rhs_mode,
+            execution_mode.as_diag_str(),
             freq_hz / 1e6,
             diag_abs,
             diag_rel

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -310,6 +310,30 @@ fn frequencies_from_fr(deck: &nec_model::deck::NecDeck) -> Vec<f64> {
     out
 }
 
+struct HybridLanePlan {
+    cpu_indices: Vec<usize>,
+    gpu_candidate_indices: Vec<usize>,
+}
+
+fn build_hybrid_lane_plan(freq_count: usize) -> HybridLanePlan {
+    let mut cpu_indices = Vec::new();
+    let mut gpu_candidate_indices = Vec::new();
+
+    for idx in 0..freq_count {
+        // Interleaving preserves broad frequency spread in both lanes.
+        if idx % 2 == 0 {
+            cpu_indices.push(idx);
+        } else {
+            gpu_candidate_indices.push(idx);
+        }
+    }
+
+    HybridLanePlan {
+        cpu_indices,
+        gpu_candidate_indices,
+    }
+}
+
 struct FrequencySolveResult {
     report: String,
     diag_line: String,
@@ -638,22 +662,47 @@ fn main() -> ExitCode {
         )
     };
 
-    let solved: Vec<(usize, Result<FrequencySolveResult, String>)> =
-        if matches!(execution_mode, ExecutionMode::Hybrid) && freqs_hz.len() > 1 {
-            freqs_hz
-                .par_iter()
-                .copied()
-                .enumerate()
-                .map(|(idx, freq_hz)| (idx, solve_one(freq_hz)))
-                .collect()
-        } else {
-            freqs_hz
-                .iter()
-                .copied()
-                .enumerate()
-                .map(|(idx, freq_hz)| (idx, solve_one(freq_hz)))
-                .collect()
-        };
+    let solved: Vec<(usize, Result<FrequencySolveResult, String>)> = if matches!(
+        execution_mode,
+        ExecutionMode::Hybrid
+    ) && freqs_hz.len() > 1
+    {
+        let lane_plan = build_hybrid_lane_plan(freqs_hz.len());
+
+        if !lane_plan.gpu_candidate_indices.is_empty() {
+            eprintln!(
+                    "warning: --exec hybrid scheduled {} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback",
+                    lane_plan.gpu_candidate_indices.len()
+                );
+        }
+
+        let mut solved = Vec::with_capacity(freqs_hz.len());
+
+        let cpu_results: Vec<(usize, Result<FrequencySolveResult, String>)> = lane_plan
+            .cpu_indices
+            .par_iter()
+            .copied()
+            .map(|idx| (idx, solve_one(freqs_hz[idx])))
+            .collect();
+        solved.extend(cpu_results);
+
+        let gpu_fallback_results: Vec<(usize, Result<FrequencySolveResult, String>)> = lane_plan
+            .gpu_candidate_indices
+            .iter()
+            .copied()
+            .map(|idx| (idx, solve_one(freqs_hz[idx])))
+            .collect();
+        solved.extend(gpu_fallback_results);
+
+        solved
+    } else {
+        freqs_hz
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(idx, freq_hz)| (idx, solve_one(freq_hz)))
+            .collect()
+    };
 
     let mut solved = solved;
     solved.sort_by_key(|(idx, _)| *idx);

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -40,10 +40,10 @@ fn hybrid_exec_mode_runs_frequency_sweep_with_ordered_reports() {
     );
 
     assert!(
-        stderr.contains("warning: --exec hybrid requested"),
-        "expected hybrid fallback warning in stderr, got:\n{stderr}"
+        !stderr.contains("warning: --exec hybrid requested"),
+        "did not expect hybrid fallback warning in stderr, got:\n{stderr}"
     );
-    assert_diag_field(&stderr, "exec", "hybrid(cpu-fallback)");
+    assert_diag_field(&stderr, "exec", "hybrid");
 
     // Verify report ordering remains ascending by FR sweep points.
     let expected_order = [

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::symlink;
 
 mod common;
 
@@ -22,6 +22,13 @@ fn create_dropin_alias(alias_name: &str) -> PathBuf {
     let source = PathBuf::from(env!("CARGO_BIN_EXE_fnec"));
     let alias = make_dropin_alias_path(alias_name);
 
+    #[cfg(unix)]
+    {
+        if symlink(&source, &alias).is_ok() {
+            return alias;
+        }
+    }
+
     if fs::hard_link(&source, &alias).is_ok() {
         return alias;
     }
@@ -33,17 +40,6 @@ fn create_dropin_alias(alias_name: &str) -> PathBuf {
             alias.display()
         )
     });
-
-    #[cfg(unix)]
-    {
-        let mut perms = fs::metadata(&alias)
-            .unwrap_or_else(|e| panic!("failed to read alias metadata '{}': {e}", alias.display()))
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&alias, perms).unwrap_or_else(|e| {
-            panic!("failed to mark alias executable '{}': {e}", alias.display())
-        });
-    }
 
     alias
 }
@@ -245,5 +241,43 @@ fn explicit_exec_overrides_dropin_filename_steering() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("preserving explicit --exec=cpu"),
+        "expected explicit exec preservation warning in stderr, got:\n{stderr}"
+    );
     assert_diag_field(&stderr, "exec", "cpu");
+}
+
+#[test]
+fn filename_steering_also_detects_4nec2_alias_names() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("4nec2-kernel");
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to run drop-in alias '{}' for 4nec2 detection test: {e}",
+                alias.display()
+            )
+        });
+
+    let _ = fs::remove_file(&alias);
+
+    assert!(
+        output.status.success(),
+        "fnec drop-in alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("drop-in compatibility profile detected by binary name"),
+        "expected compatibility-profile warning in stderr, got:\n{stderr}"
+    );
+    assert_diag_field(&stderr, "exec", "hybrid");
 }

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -66,3 +66,42 @@ fn hybrid_exec_mode_runs_frequency_sweep_with_ordered_reports() {
         cursor += rel + marker.len();
     }
 }
+
+#[test]
+fn hybrid_exec_mode_accepts_accelerator_stub_dispatch_path() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/frequency-sweep-dipole.nec");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("hybrid")
+        .env("FNEC_ACCEL_STUB_GPU", "1")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for hybrid exec stub test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("GPU-candidate lane"),
+        "did not expect GPU-candidate fallback warning in stub path, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("accelerator stub backend"),
+        "expected accelerator stub warning in stderr, got:\n{stderr}"
+    );
+    assert_diag_field(&stderr, "exec", "hybrid");
+
+    // Contract remains unchanged: one ordered report block per FR point.
+    assert_eq!(stdout.matches("FNEC FEEDPOINT REPORT").count(), 5);
+    assert_eq!(stdout.matches("FREQ_MHZ ").count(), 5);
+}

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -105,3 +105,36 @@ fn hybrid_exec_mode_accepts_accelerator_stub_dispatch_path() {
     assert_eq!(stdout.matches("FNEC FEEDPOINT REPORT").count(), 5);
     assert_eq!(stdout.matches("FREQ_MHZ ").count(), 5);
 }
+
+#[test]
+fn gpu_exec_mode_accepts_accelerator_stub_dispatch_path() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("gpu")
+        .env("FNEC_ACCEL_STUB_GPU", "1")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for gpu exec stub test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: --exec gpu dispatched to accelerator stub backend"),
+        "expected gpu stub dispatch warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("warning: --exec gpu requested"),
+        "did not expect gpu fallback-request warning in stub path, got:\n{stderr}"
+    );
+    assert_diag_field(&stderr, "exec", "gpu(cpu-fallback)");
+}

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -1,9 +1,52 @@
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 mod common;
 
 use common::assert_diag_field;
+
+fn make_dropin_alias_path(alias_name: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    std::env::temp_dir().join(format!("fnec-dropin-alias-{alias_name}-{now}"))
+}
+
+fn create_dropin_alias(alias_name: &str) -> PathBuf {
+    let source = PathBuf::from(env!("CARGO_BIN_EXE_fnec"));
+    let alias = make_dropin_alias_path(alias_name);
+
+    if fs::hard_link(&source, &alias).is_ok() {
+        return alias;
+    }
+
+    fs::copy(&source, &alias).unwrap_or_else(|e| {
+        panic!(
+            "failed to create drop-in alias by copy from '{}' to '{}': {e}",
+            source.display(),
+            alias.display()
+        )
+    });
+
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(&alias)
+            .unwrap_or_else(|e| panic!("failed to read alias metadata '{}': {e}", alias.display()))
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&alias, perms).unwrap_or_else(|e| {
+            panic!("failed to mark alias executable '{}': {e}", alias.display())
+        });
+    }
+
+    alias
+}
 
 #[test]
 fn hybrid_exec_mode_runs_frequency_sweep_with_ordered_reports() {
@@ -137,4 +180,70 @@ fn gpu_exec_mode_accepts_accelerator_stub_dispatch_path() {
         "did not expect gpu fallback-request warning in stub path, got:\n{stderr}"
     );
     assert_diag_field(&stderr, "exec", "gpu(cpu-fallback)");
+}
+
+#[test]
+fn filename_steering_sets_default_exec_for_dropin_alias() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("nec2dxs500");
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to run drop-in alias '{}' for filename steering test: {e}",
+                alias.display()
+            )
+        });
+
+    let _ = fs::remove_file(&alias);
+
+    assert!(
+        output.status.success(),
+        "fnec drop-in alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("drop-in compatibility profile detected by binary name"),
+        "expected compatibility-profile warning in stderr, got:\n{stderr}"
+    );
+    assert_diag_field(&stderr, "exec", "hybrid");
+}
+
+#[test]
+fn explicit_exec_overrides_dropin_filename_steering() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("nec2dxs3k0");
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("cpu")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to run drop-in alias '{}' for explicit exec override test: {e}",
+                alias.display()
+            )
+        });
+
+    let _ = fs::remove_file(&alias);
+
+    assert!(
+        output.status.success(),
+        "fnec drop-in alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_diag_field(&stderr, "exec", "cpu");
 }

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -40,8 +40,12 @@ fn hybrid_exec_mode_runs_frequency_sweep_with_ordered_reports() {
     );
 
     assert!(
-        !stderr.contains("warning: --exec hybrid requested"),
-        "did not expect hybrid fallback warning in stderr, got:\n{stderr}"
+        stderr.contains("warning: --exec hybrid scheduled"),
+        "expected hybrid lane fallback warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("GPU-candidate lane"),
+        "expected GPU-candidate lane warning details in stderr, got:\n{stderr}"
     );
     assert_diag_field(&stderr, "exec", "hybrid");
 

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+mod common;
+
+use common::assert_diag_field;
+
+#[test]
+fn hybrid_exec_mode_runs_frequency_sweep_with_ordered_reports() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/frequency-sweep-dipole.nec");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("hybrid")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for hybrid exec sweep test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let report_blocks = stdout.matches("FNEC FEEDPOINT REPORT").count();
+    let freq_headers = stdout.matches("FREQ_MHZ ").count();
+    assert_eq!(
+        report_blocks, 5,
+        "expected 5 report blocks, got {report_blocks}"
+    );
+    assert_eq!(
+        freq_headers, 5,
+        "expected 5 FREQ_MHZ headers, got {freq_headers}"
+    );
+
+    assert!(
+        stderr.contains("warning: --exec hybrid requested"),
+        "expected hybrid fallback warning in stderr, got:\n{stderr}"
+    );
+    assert_diag_field(&stderr, "exec", "hybrid(cpu-fallback)");
+
+    // Verify report ordering remains ascending by FR sweep points.
+    let expected_order = [
+        "FREQ_MHZ 10.000000",
+        "FREQ_MHZ 12.000000",
+        "FREQ_MHZ 14.000000",
+        "FREQ_MHZ 16.000000",
+        "FREQ_MHZ 18.000000",
+    ];
+
+    let mut cursor = 0usize;
+    for marker in expected_order {
+        let rel = stdout[cursor..]
+            .find(marker)
+            .unwrap_or_else(|| panic!("missing frequency marker '{marker}' in stdout:\n{stdout}"));
+        cursor += rel + marker.len();
+    }
+}

--- a/apps/nec-cli/tests/topology_fallback.rs
+++ b/apps/nec-cli/tests/topology_fallback.rs
@@ -75,6 +75,22 @@ fn run_solver_on_reference_dipole_with_pulse_rhs(
         })
 }
 
+fn run_solver_on_reference_dipole_with_exec(solver: &str, exec_mode: &str) -> std::process::Output {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+
+    Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg(solver)
+        .arg("--exec")
+        .arg(exec_mode)
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!("Failed to run fnec for solver '{solver}' with exec-mode '{exec_mode}': {e}")
+        })
+}
+
 fn run_hallen_on_loaded_case(allow_noncollinear_hallen: bool) -> std::process::Output {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let deck_path = workspace_root.join("corpus/dipole-loaded.nec");
@@ -172,6 +188,47 @@ fn pulse_rhs_flag_is_reflected_in_diag_field() {
     );
     let nec2_stderr = String::from_utf8_lossy(&nec2.stderr);
     assert_diag_field(&nec2_stderr, "pulse_rhs", "Nec2");
+}
+
+#[test]
+fn exec_mode_defaults_to_cpu_in_diag_field() {
+    let output = run_solver_on_reference_dipole("hallen");
+    assert!(
+        output.status.success(),
+        "fnec failed for hallen/default-exec: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_diag_field(&stderr, "exec", "cpu");
+}
+
+#[test]
+fn hybrid_and_gpu_exec_modes_are_reflected_and_warn_cpu_fallback() {
+    let hybrid = run_solver_on_reference_dipole_with_exec("hallen", "hybrid");
+    assert!(
+        hybrid.status.success(),
+        "fnec failed for hallen/hybrid: {}",
+        String::from_utf8_lossy(&hybrid.stderr)
+    );
+    let hybrid_stderr = String::from_utf8_lossy(&hybrid.stderr);
+    assert!(
+        hybrid_stderr.contains("warning: --exec hybrid requested"),
+        "expected hybrid fallback warning in stderr, got:\n{hybrid_stderr}"
+    );
+    assert_diag_field(&hybrid_stderr, "exec", "hybrid(cpu-fallback)");
+
+    let gpu = run_solver_on_reference_dipole_with_exec("hallen", "gpu");
+    assert!(
+        gpu.status.success(),
+        "fnec failed for hallen/gpu: {}",
+        String::from_utf8_lossy(&gpu.stderr)
+    );
+    let gpu_stderr = String::from_utf8_lossy(&gpu.stderr);
+    assert!(
+        gpu_stderr.contains("warning: --exec gpu requested"),
+        "expected gpu fallback warning in stderr, got:\n{gpu_stderr}"
+    );
+    assert_diag_field(&gpu_stderr, "exec", "gpu(cpu-fallback)");
 }
 
 #[test]

--- a/apps/nec-cli/tests/topology_fallback.rs
+++ b/apps/nec-cli/tests/topology_fallback.rs
@@ -203,7 +203,7 @@ fn exec_mode_defaults_to_cpu_in_diag_field() {
 }
 
 #[test]
-fn hybrid_and_gpu_exec_modes_are_reflected_and_warn_cpu_fallback() {
+fn hybrid_exec_is_reflected_without_fallback_warning_and_gpu_warns_cpu_fallback() {
     let hybrid = run_solver_on_reference_dipole_with_exec("hallen", "hybrid");
     assert!(
         hybrid.status.success(),
@@ -212,10 +212,10 @@ fn hybrid_and_gpu_exec_modes_are_reflected_and_warn_cpu_fallback() {
     );
     let hybrid_stderr = String::from_utf8_lossy(&hybrid.stderr);
     assert!(
-        hybrid_stderr.contains("warning: --exec hybrid requested"),
-        "expected hybrid fallback warning in stderr, got:\n{hybrid_stderr}"
+        !hybrid_stderr.contains("warning: --exec hybrid requested"),
+        "did not expect hybrid fallback warning in stderr, got:\n{hybrid_stderr}"
     );
-    assert_diag_field(&hybrid_stderr, "exec", "hybrid(cpu-fallback)");
+    assert_diag_field(&hybrid_stderr, "exec", "hybrid");
 
     let gpu = run_solver_on_reference_dipole_with_exec("hallen", "gpu");
     assert!(

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -138,6 +138,7 @@ Optional external-candidate gates can be enabled per case in `tolerance_gates`:
 - CI currently gates the GN=1 regression value and prints external deltas when candidate values are present.
 
 **Tolerance gates**: Same as dipole-freesp (R, X, current).
+- External impedance candidate gate (enabled in corpus JSON): `ExternalR_absolute_ohm=10.0`, `ExternalX_absolute_ohm=30.0`
 
 **Why this case**: Ground effects are critical for practical antennas. Validates GN=1 perfect-ground image-method behavior.
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -373,9 +373,11 @@
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
-        "X_absolute_ohm": 0.05
+        "X_absolute_ohm": 0.05,
+        "ExternalR_absolute_ohm": 10.0,
+        "ExternalX_absolute_ohm": 30.0
       },
-      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy; xnec2c/4nec2 parity capture remains pending."
+      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy, and now CI-gated with absolute external R/X thresholds."
     },
     "yagi-5elm-51seg": {
       "deck_file": "yagi-5elm-51seg.nec",

--- a/crates/nec_accel/src/lib.rs
+++ b/crates/nec_accel/src/lib.rs
@@ -1,2 +1,47 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccelRequestKind {
+    HybridGpuCandidate,
+    GpuOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchDecision {
+    RunOnGpu,
+    FallbackToCpu { reason: &'static str },
+}
+
+pub fn dispatch_frequency_point(_request: AccelRequestKind, _freq_hz: f64) -> DispatchDecision {
+    DispatchDecision::FallbackToCpu {
+        reason: "GPU kernels are not yet wired",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
+
+    #[test]
+    fn hybrid_gpu_candidate_dispatch_falls_back_to_cpu_for_now() {
+        let decision = dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, 14.2e6);
+        assert!(matches!(
+            decision,
+            DispatchDecision::FallbackToCpu {
+                reason: "GPU kernels are not yet wired"
+            }
+        ));
+    }
+
+    #[test]
+    fn gpu_only_dispatch_falls_back_to_cpu_for_now() {
+        let decision = dispatch_frequency_point(AccelRequestKind::GpuOnly, 14.2e6);
+        assert!(matches!(
+            decision,
+            DispatchDecision::FallbackToCpu {
+                reason: "GPU kernels are not yet wired"
+            }
+        ));
+    }
+}

--- a/crates/nec_accel/src/lib.rs
+++ b/crates/nec_accel/src/lib.rs
@@ -13,6 +13,12 @@ pub enum DispatchDecision {
     FallbackToCpu { reason: &'static str },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionPath {
+    CpuFallback,
+    GpuStubEmulation,
+}
+
 const ACCEL_STUB_GPU_ENV: &str = "FNEC_ACCEL_STUB_GPU";
 
 fn stub_gpu_enabled() -> bool {
@@ -31,11 +37,29 @@ pub fn dispatch_frequency_point(_request: AccelRequestKind, _freq_hz: f64) -> Di
     }
 }
 
+pub fn execute_frequency_point<T, F>(
+    decision: DispatchDecision,
+    cpu_emulated_solve: F,
+) -> (ExecutionPath, Result<T, String>)
+where
+    F: FnOnce() -> Result<T, String>,
+{
+    match decision {
+        DispatchDecision::FallbackToCpu { .. } => {
+            (ExecutionPath::CpuFallback, cpu_emulated_solve())
+        }
+        DispatchDecision::RunOnGpu => (ExecutionPath::GpuStubEmulation, cpu_emulated_solve()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
 
-    use super::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
+    use super::{
+        dispatch_frequency_point, execute_frequency_point, AccelRequestKind, DispatchDecision,
+        ExecutionPath,
+    };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -77,5 +101,27 @@ mod tests {
 
         assert!(matches!(hybrid, DispatchDecision::RunOnGpu));
         assert!(matches!(gpu_only, DispatchDecision::RunOnGpu));
+    }
+
+    #[test]
+    fn execute_frequency_point_marks_fallback_path() {
+        let (path, result) = execute_frequency_point(
+            DispatchDecision::FallbackToCpu {
+                reason: "GPU kernels are not yet wired",
+            },
+            || Ok::<usize, String>(42),
+        );
+
+        assert_eq!(path, ExecutionPath::CpuFallback);
+        assert!(matches!(result, Ok(42)));
+    }
+
+    #[test]
+    fn execute_frequency_point_marks_stub_emulation_path() {
+        let (path, result) =
+            execute_frequency_point(DispatchDecision::RunOnGpu, || Ok::<usize, String>(7));
+
+        assert_eq!(path, ExecutionPath::GpuStubEmulation);
+        assert!(matches!(result, Ok(7)));
     }
 }

--- a/crates/nec_accel/src/lib.rs
+++ b/crates/nec_accel/src/lib.rs
@@ -13,7 +13,19 @@ pub enum DispatchDecision {
     FallbackToCpu { reason: &'static str },
 }
 
+const ACCEL_STUB_GPU_ENV: &str = "FNEC_ACCEL_STUB_GPU";
+
+fn stub_gpu_enabled() -> bool {
+    std::env::var_os(ACCEL_STUB_GPU_ENV)
+        .and_then(|v| v.into_string().ok())
+        .is_some_and(|v| v == "1")
+}
+
 pub fn dispatch_frequency_point(_request: AccelRequestKind, _freq_hz: f64) -> DispatchDecision {
+    if stub_gpu_enabled() {
+        return DispatchDecision::RunOnGpu;
+    }
+
     DispatchDecision::FallbackToCpu {
         reason: "GPU kernels are not yet wired",
     }
@@ -21,10 +33,16 @@ pub fn dispatch_frequency_point(_request: AccelRequestKind, _freq_hz: f64) -> Di
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn hybrid_gpu_candidate_dispatch_falls_back_to_cpu_for_now() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        std::env::remove_var("FNEC_ACCEL_STUB_GPU");
         let decision = dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, 14.2e6);
         assert!(matches!(
             decision,
@@ -36,6 +54,8 @@ mod tests {
 
     #[test]
     fn gpu_only_dispatch_falls_back_to_cpu_for_now() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        std::env::remove_var("FNEC_ACCEL_STUB_GPU");
         let decision = dispatch_frequency_point(AccelRequestKind::GpuOnly, 14.2e6);
         assert!(matches!(
             decision,
@@ -43,5 +63,19 @@ mod tests {
                 reason: "GPU kernels are not yet wired"
             }
         ));
+    }
+
+    #[test]
+    fn stub_gpu_env_enables_run_on_gpu_dispatch() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        std::env::set_var("FNEC_ACCEL_STUB_GPU", "1");
+
+        let hybrid = dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, 14.2e6);
+        let gpu_only = dispatch_frequency_point(AccelRequestKind::GpuOnly, 14.2e6);
+
+        std::env::remove_var("FNEC_ACCEL_STUB_GPU");
+
+        assert!(matches!(hybrid, DispatchDecision::RunOnGpu));
+        assert!(matches!(gpu_only, DispatchDecision::RunOnGpu));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,9 +95,10 @@ The following projects are useful comparative references for algorithms, behavio
 - yeti01/nec2: https://github.com/yeti01/nec2
 - tmolteno/necpp: https://github.com/tmolteno/necpp
 - KJ7LNW/xnec2c-optimize: https://github.com/KJ7LNW/xnec2c-optimize
+- GNU NEC (SourceForge): https://sourceforge.net/projects/gnu-nec/
 - NEC-5 Validation Manual (Burke, 2019): https://ipo.llnl.gov/sites/default/files/2020-07/NEC5%20Validation%20Manual%20092419.pdf
 
-These references are supplementary, but not irrelevant. 4nec2 compatibility remains the primary product target, xnec2c remains the main NEC2 parity reference corpus source, xnec2c-optimize remains a key baseline for external optimizer-loop ergonomics, yeti01/nec2 remains a useful baseline for clean open NEC2 batch execution, necpp remains a useful baseline for library-oriented automation and geometry diagnostics, and the NEC-5 Validation Manual is used to structure higher-difficulty validation classes.
+These references are supplementary, but not irrelevant. 4nec2 compatibility remains the primary product target, xnec2c remains the main NEC2 parity reference corpus source, xnec2c-optimize remains a key baseline for external optimizer-loop ergonomics, yeti01/nec2 and GNU NEC remain useful baselines for clean open NEC2 batch execution, necpp remains a useful baseline for library-oriented automation and geometry diagnostics, and the NEC-5 Validation Manual is used to structure higher-difficulty validation classes.
 
 ## Documentation process constraints
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,7 +41,7 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: `frequency-sweep-dipole` now enables the first external impedance candidate gates with `ExternalR_absolute_ohm=15.0` and `ExternalX_absolute_ohm=50.0`.
 	- 2026-04-26 progress: `dipole-ground-51seg` now also enables external impedance candidate gates with `ExternalR_absolute_ohm=10.0` and `ExternalX_absolute_ohm=30.0`.
 	- 2026-04-26 progress: roadmap now explicitly requires CPU single-threaded, CPU multithreaded, and GPU benchmark modes across all target classes.
-	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; `hybrid`/`gpu` currently run CPU fallback while exposing real-application mode selection.
+	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; initial scaffold path exposed real-application mode selection before hybrid runtime work.
 	- 2026-04-26 progress: `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (parallel per-frequency solves with ordered output), while `--exec gpu` remains CPU fallback scaffolding.
 
 ## Parity-driven backlog items

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -82,3 +82,12 @@ last_updated: 2026-04-24
 - [ ] **PAR-011 / 4nec2 solver-binary drop-in compatibility mode / Owner: CLI+Runtime / Target: Phase 4-5 / Issue: #24**
 	Resolution criteria: filename-steered compatibility profile detects known 4nec2 kernel binary names, preserves expected invocation/report contracts for drop-in operation, and demonstrates multithreaded kernel replacement throughput gains against single-thread external baseline.
 	- 2026-04-26 assessment: deferred from Phase 2-3 to Phase 4-5 after reviewing real NEC2MP replacement artifacts (`nec2dxs500/1K5/3k0/5k0/8k0/11k` variants plus external install procedure docs). Full drop-in parity likely requires Windows-specific replacement semantics, binary-name matrix handling, and compatibility validation against external tool expectations beyond current CLI contract scope.
+	- Discovery checklist (capture before implementation starts):
+		- Binary-name matrix: confirm exact accepted executable names/casing and segment-limit mapping (`nec2dxs500.exe`, `nec2dxs1K5.exe`, `nec2dxs3k0.exe`, `nec2dxs5k0.exe`, `nec2dxs8k0.exe`, `nec2dxs11k.exe`).
+		- Install contract: document required replacement/copy steps in Windows 4nec2 installation paths and whether side-by-side binary variants are expected.
+		- Invocation contract: capture argv shape, working-directory expectations, stdin/stdout/stderr behavior, exit-code semantics, and timeout/error handling expected by 4nec2.
+		- File side effects: enumerate all expected temporary/input/output files and lifecycle rules (create/overwrite/delete) during external-kernel execution.
+		- Dependency surface: verify companion DLL/runtime requirements (if any) and loader-path assumptions in both portable and installed setups.
+		- Compatibility fixtures: archive representative external-kernel call traces and outputs for each binary variant as regression fixtures.
+		- Benchmark method: define throughput comparison protocol against the legacy single-thread kernel on identical decks, with per-variant segment-count bands.
+		- Reference sources: index `nec2mp-readme.pdf` notes and the cited URL (`http://users.otenet.gr/~jmsp`) into a short evidence memo for future PAR-011 kickoff.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -90,4 +90,4 @@ last_updated: 2026-04-24
 		- Dependency surface: verify companion DLL/runtime requirements (if any) and loader-path assumptions in both portable and installed setups.
 		- Compatibility fixtures: archive representative external-kernel call traces and outputs for each binary variant as regression fixtures.
 		- Benchmark method: define throughput comparison protocol against the legacy single-thread kernel on identical decks, with per-variant segment-count bands.
-		- Reference sources: index `nec2mp-readme.pdf` notes and the cited URL (`http://users.otenet.gr/~jmsp`) into a short evidence memo for future PAR-011 kickoff.
+		- Reference sources: index `nec2mp-readme.pdf` notes, the cited URL (`http://users.otenet.gr/~jmsp`), and GNU NEC SourceForge project notes (`https://sourceforge.net/projects/gnu-nec/`) into a short evidence memo for future PAR-011 kickoff.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,6 +41,7 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: `frequency-sweep-dipole` now enables the first external impedance candidate gates with `ExternalR_absolute_ohm=15.0` and `ExternalX_absolute_ohm=50.0`.
 	- 2026-04-26 progress: `dipole-ground-51seg` now also enables external impedance candidate gates with `ExternalR_absolute_ohm=10.0` and `ExternalX_absolute_ohm=30.0`.
 	- 2026-04-26 progress: roadmap now explicitly requires CPU single-threaded, CPU multithreaded, and GPU benchmark modes across all target classes.
+	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; `hybrid`/`gpu` currently run CPU fallback while exposing real-application mode selection.
 
 ## Parity-driven backlog items
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -78,3 +78,6 @@ last_updated: 2026-04-24
 
 - [ ] **PAR-010 / Distributed authenticated cluster execution mode / Owner: Core+Automation / Target: Phase 4-5 / Issue: #23**
 	Resolution criteria: architecture decision doc approved (auth model, trust boundary, transport, failure semantics); authenticated node discovery implemented with capability cache; work-content/result cache implemented with deterministic cache keys and invalidation policy; SSH-backed bootstrap flow documented and demonstrated on at least 2 worker nodes.
+
+- [ ] **PAR-011 / 4nec2 solver-binary drop-in compatibility mode / Owner: CLI+Runtime / Target: Phase 2-3 / Issue: #24**
+	Resolution criteria: filename-steered compatibility profile detects known 4nec2 kernel binary names, preserves expected invocation/report contracts for drop-in operation, and demonstrates multithreaded kernel replacement throughput gains against single-thread external baseline.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -43,6 +43,7 @@ last_updated: 2026-04-24
 	- 2026-04-26 progress: roadmap now explicitly requires CPU single-threaded, CPU multithreaded, and GPU benchmark modes across all target classes.
 	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; initial scaffold path exposed real-application mode selection before hybrid runtime work.
 	- 2026-04-26 progress: `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (parallel per-frequency solves with ordered output), while `--exec gpu` remains CPU fallback scaffolding.
+	- 2026-04-26 progress: hybrid GPU-candidate lane routing now calls `nec_accel::dispatch_frequency_point(...)` before CPU fallback, establishing the first concrete accelerator integration seam.
 
 ## Parity-driven backlog items
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -39,6 +39,8 @@ last_updated: 2026-04-24
 	- 2026-04-25 progress: RP corpus cases can now promote those external pattern candidates into CI gates with optional `ExternalGain_absolute_dB` / `ExternalAxialRatio_absolute` thresholds.
 	- 2026-04-25 progress: corpus validation now also supports optional external impedance gates (`ExternalR_absolute_ohm`, `ExternalX_absolute_ohm`, `ExternalR_percent_rel`, `ExternalX_percent_rel`) for scalar, source, and FR candidate deltas.
 	- 2026-04-25 progress: `frequency-sweep-dipole` now enables the first external impedance candidate gates with `ExternalR_absolute_ohm=15.0` and `ExternalX_absolute_ohm=50.0`.
+	- 2026-04-26 progress: `dipole-ground-51seg` now also enables external impedance candidate gates with `ExternalR_absolute_ohm=10.0` and `ExternalX_absolute_ohm=30.0`.
+	- 2026-04-26 progress: roadmap now explicitly requires CPU single-threaded, CPU multithreaded, and GPU benchmark modes across all target classes.
 
 ## Parity-driven backlog items
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -42,6 +42,7 @@ last_updated: 2026-04-24
 	- 2026-04-26 progress: `dipole-ground-51seg` now also enables external impedance candidate gates with `ExternalR_absolute_ohm=10.0` and `ExternalX_absolute_ohm=30.0`.
 	- 2026-04-26 progress: roadmap now explicitly requires CPU single-threaded, CPU multithreaded, and GPU benchmark modes across all target classes.
 	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; `hybrid`/`gpu` currently run CPU fallback while exposing real-application mode selection.
+	- 2026-04-26 progress: `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (parallel per-frequency solves with ordered output), while `--exec gpu` remains CPU fallback scaffolding.
 
 ## Parity-driven backlog items
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -44,7 +44,7 @@ last_updated: 2026-04-24
 	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; initial scaffold path exposed real-application mode selection before hybrid runtime work.
 	- 2026-04-26 progress: `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (parallel per-frequency solves with ordered output), while `--exec gpu` remains CPU fallback scaffolding.
 	- 2026-04-26 progress: hybrid GPU-candidate lane routing now calls `nec_accel::dispatch_frequency_point(...)` before CPU fallback, establishing the first concrete accelerator integration seam.
-	- 2026-04-26 progress: `DispatchDecision::RunOnGpu` is now handled non-fatally in CLI hybrid runs via an accelerator stub branch (`FNEC_ACCEL_STUB_GPU=1`) that preserves report/diag contracts while using CPU emulation.
+	- 2026-04-26 progress: `DispatchDecision::RunOnGpu` is now handled non-fatally in CLI hybrid and gpu execution flows via an accelerator stub branch (`FNEC_ACCEL_STUB_GPU=1`) that preserves report/diag contracts while using CPU emulation.
 
 ## Parity-driven backlog items
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -44,6 +44,7 @@ last_updated: 2026-04-24
 	- 2026-04-26 progress: CLI execution-mode plumbing landed with `--exec <cpu|hybrid|gpu>` and diag `exec=...`; initial scaffold path exposed real-application mode selection before hybrid runtime work.
 	- 2026-04-26 progress: `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (parallel per-frequency solves with ordered output), while `--exec gpu` remains CPU fallback scaffolding.
 	- 2026-04-26 progress: hybrid GPU-candidate lane routing now calls `nec_accel::dispatch_frequency_point(...)` before CPU fallback, establishing the first concrete accelerator integration seam.
+	- 2026-04-26 progress: `DispatchDecision::RunOnGpu` is now handled non-fatally in CLI hybrid runs via an accelerator stub branch (`FNEC_ACCEL_STUB_GPU=1`) that preserves report/diag contracts while using CPU emulation.
 
 ## Parity-driven backlog items
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -79,5 +79,6 @@ last_updated: 2026-04-24
 - [ ] **PAR-010 / Distributed authenticated cluster execution mode / Owner: Core+Automation / Target: Phase 4-5 / Issue: #23**
 	Resolution criteria: architecture decision doc approved (auth model, trust boundary, transport, failure semantics); authenticated node discovery implemented with capability cache; work-content/result cache implemented with deterministic cache keys and invalidation policy; SSH-backed bootstrap flow documented and demonstrated on at least 2 worker nodes.
 
-- [ ] **PAR-011 / 4nec2 solver-binary drop-in compatibility mode / Owner: CLI+Runtime / Target: Phase 2-3 / Issue: #24**
+- [ ] **PAR-011 / 4nec2 solver-binary drop-in compatibility mode / Owner: CLI+Runtime / Target: Phase 4-5 / Issue: #24**
 	Resolution criteria: filename-steered compatibility profile detects known 4nec2 kernel binary names, preserves expected invocation/report contracts for drop-in operation, and demonstrates multithreaded kernel replacement throughput gains against single-thread external baseline.
+	- 2026-04-26 assessment: deferred from Phase 2-3 to Phase 4-5 after reviewing real NEC2MP replacement artifacts (`nec2dxs500/1K5/3k0/5k0/8k0/11k` variants plus external install procedure docs). Full drop-in parity likely requires Windows-specific replacement semantics, binary-name matrix handling, and compatibility validation against external tool expectations beyond current CLI contract scope.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,7 @@ All notable documentation process changes are recorded here.
 - Roadmap now defines a required benchmark-mode matrix across all target classes: CPU single-threaded, CPU multithreaded, and GPU offload.
 - CLI now accepts `--exec <cpu|hybrid|gpu>` for real runs; `hybrid`/`gpu` are scaffolded execution modes that currently fall back to CPU with explicit diagnostics.
 - `--exec hybrid` now performs coarse-grain multithreaded FR sweep solving (parallel per-frequency solve with ordered report output); GPU execution remains scaffolded.
+- `--exec hybrid` now uses split-lane FR scheduling (CPU-parallel lane + GPU-candidate lane) with deterministic ordered report output; GPU-candidate lane points currently emit explicit fallback warnings and execute on CPU until GPU kernels are wired.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,7 @@ All notable documentation process changes are recorded here.
 - Added an opt-in accelerator stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) so `DispatchDecision::RunOnGpu` can be exercised end-to-end in CLI hybrid and gpu execution flows without changing output contracts.
 - Added a tracked parity item for filename-steered 4nec2 solver-binary drop-in compatibility mode, including contract-preservation and throughput validation goals.
 - Retargeted 4nec2 external-kernel drop-in compatibility work to a farther-future window (Phase 4-5) after assessing real NEC2MP replacement artifacts and integration scope.
+- Expanded PAR-011 with an implementation discovery checklist (binary-name matrix, install/invocation contract, file side effects, dependency surface, fixtures, and benchmark protocol) to reduce future re-research cost.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@ All notable documentation process changes are recorded here.
 - `--exec hybrid` now performs coarse-grain multithreaded FR sweep solving (parallel per-frequency solve with ordered report output); GPU execution remains scaffolded.
 - `--exec hybrid` now uses split-lane FR scheduling (CPU-parallel lane + GPU-candidate lane) with deterministic ordered report output; GPU-candidate lane points currently emit explicit fallback warnings and execute on CPU until GPU kernels are wired.
 - Hybrid and GPU-mode fallback routing now flows through a concrete `nec_accel` dispatch API (`dispatch_frequency_point`) so future GPU kernel wiring has a stable integration seam.
+- Added an opt-in accelerator stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) so `DispatchDecision::RunOnGpu` can be exercised end-to-end in CLI hybrid sweeps without changing output contracts.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,8 @@ All notable documentation process changes are recorded here.
 - RP corpus cases can now opt into external-pattern CI gates via `ExternalGain_absolute_dB` and `ExternalAxialRatio_absolute` in `tolerance_gates`.
 - Corpus validation now also supports optional external impedance CI gates (`ExternalR_*`/`ExternalX_*`) for scalar, multi-source, and frequency-sweep candidates.
 - Enabled the first external impedance CI-gated case (`frequency-sweep-dipole`) with absolute candidate thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`).
+- Enabled a second external impedance CI-gated case (`dipole-ground-51seg`) with absolute candidate thresholds (`ExternalR_absolute_ohm=10.0`, `ExternalX_absolute_ohm=30.0`).
+- Roadmap now defines a required benchmark-mode matrix across all target classes: CPU single-threaded, CPU multithreaded, and GPU offload.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,7 +35,7 @@ All notable documentation process changes are recorded here.
 - `--exec hybrid` now performs coarse-grain multithreaded FR sweep solving (parallel per-frequency solve with ordered report output); GPU execution remains scaffolded.
 - `--exec hybrid` now uses split-lane FR scheduling (CPU-parallel lane + GPU-candidate lane) with deterministic ordered report output; GPU-candidate lane points currently emit explicit fallback warnings and execute on CPU until GPU kernels are wired.
 - Hybrid and GPU-mode fallback routing now flows through a concrete `nec_accel` dispatch API (`dispatch_frequency_point`) so future GPU kernel wiring has a stable integration seam.
-- Added an opt-in accelerator stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) so `DispatchDecision::RunOnGpu` can be exercised end-to-end in CLI hybrid sweeps without changing output contracts.
+- Added an opt-in accelerator stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) so `DispatchDecision::RunOnGpu` can be exercised end-to-end in CLI hybrid and gpu execution flows without changing output contracts.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,7 @@ All notable documentation process changes are recorded here.
 - Hybrid and GPU-mode fallback routing now flows through a concrete `nec_accel` dispatch API (`dispatch_frequency_point`) so future GPU kernel wiring has a stable integration seam.
 - Added an opt-in accelerator stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) so `DispatchDecision::RunOnGpu` can be exercised end-to-end in CLI hybrid and gpu execution flows without changing output contracts.
 - Added a tracked parity item for filename-steered 4nec2 solver-binary drop-in compatibility mode, including contract-preservation and throughput validation goals.
+- Retargeted 4nec2 external-kernel drop-in compatibility work to a farther-future window (Phase 4-5) after assessing real NEC2MP replacement artifacts and integration scope.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ All notable documentation process changes are recorded here.
 - RP card execution is now wired into the CLI report path.
 - Text reports now include a `RADIATION_PATTERN` section when one or more `RP` cards are present.
 - Added corpus regression deck `corpus/dipole-freesp-rp-51seg.nec` and contract coverage for pattern-table rendering.
+- Added a collaboration efficiency guide with rate-limit-aware prompting patterns at `docs/copilot-efficiency-guide.md`.
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@ All notable documentation process changes are recorded here.
 - Enabled a second external impedance CI-gated case (`dipole-ground-51seg`) with absolute candidate thresholds (`ExternalR_absolute_ohm=10.0`, `ExternalX_absolute_ohm=30.0`).
 - Roadmap now defines a required benchmark-mode matrix across all target classes: CPU single-threaded, CPU multithreaded, and GPU offload.
 - CLI now accepts `--exec <cpu|hybrid|gpu>` for real runs; `hybrid`/`gpu` are scaffolded execution modes that currently fall back to CPU with explicit diagnostics.
+- `--exec hybrid` now performs coarse-grain multithreaded FR sweep solving (parallel per-frequency solve with ordered report output); GPU execution remains scaffolded.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@ All notable documentation process changes are recorded here.
 - `--exec hybrid` now uses split-lane FR scheduling (CPU-parallel lane + GPU-candidate lane) with deterministic ordered report output; GPU-candidate lane points currently emit explicit fallback warnings and execute on CPU until GPU kernels are wired.
 - Hybrid and GPU-mode fallback routing now flows through a concrete `nec_accel` dispatch API (`dispatch_frequency_point`) so future GPU kernel wiring has a stable integration seam.
 - Added an opt-in accelerator stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) so `DispatchDecision::RunOnGpu` can be exercised end-to-end in CLI hybrid and gpu execution flows without changing output contracts.
+- Added a tracked parity item for filename-steered 4nec2 solver-binary drop-in compatibility mode, including contract-preservation and throughput validation goals.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,7 @@ All notable documentation process changes are recorded here.
 - CLI now accepts `--exec <cpu|hybrid|gpu>` for real runs; `hybrid`/`gpu` are scaffolded execution modes that currently fall back to CPU with explicit diagnostics.
 - `--exec hybrid` now performs coarse-grain multithreaded FR sweep solving (parallel per-frequency solve with ordered report output); GPU execution remains scaffolded.
 - `--exec hybrid` now uses split-lane FR scheduling (CPU-parallel lane + GPU-candidate lane) with deterministic ordered report output; GPU-candidate lane points currently emit explicit fallback warnings and execute on CPU until GPU kernels are wired.
+- Hybrid and GPU-mode fallback routing now flows through a concrete `nec_accel` dispatch API (`dispatch_frequency_point`) so future GPU kernel wiring has a stable integration seam.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ All notable documentation process changes are recorded here.
 - Enabled the first external impedance CI-gated case (`frequency-sweep-dipole`) with absolute candidate thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`).
 - Enabled a second external impedance CI-gated case (`dipole-ground-51seg`) with absolute candidate thresholds (`ExternalR_absolute_ohm=10.0`, `ExternalX_absolute_ohm=30.0`).
 - Roadmap now defines a required benchmark-mode matrix across all target classes: CPU single-threaded, CPU multithreaded, and GPU offload.
+- CLI now accepts `--exec <cpu|hybrid|gpu>` for real runs; `hybrid`/`gpu` are scaffolded execution modes that currently fall back to CPU with explicit diagnostics.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,8 @@ All notable documentation process changes are recorded here.
 - Retargeted 4nec2 external-kernel drop-in compatibility work to a farther-future window (Phase 4-5) after assessing real NEC2MP replacement artifacts and integration scope.
 - Expanded PAR-011 with an implementation discovery checklist (binary-name matrix, install/invocation contract, file side effects, dependency surface, fixtures, and benchmark protocol) to reduce future re-research cost.
 - Added GNU NEC (`https://sourceforge.net/projects/gnu-nec/`) as an additional open-source reference candidate in architecture and PAR-011 source notes.
+- Refined filename-steered 4nec2 compatibility warnings to explicitly report whether execution was auto-steered or an explicit `--exec` value was preserved.
+- Extended drop-in compatibility contract tests to cover both `nec2dxs*` and `4nec2*` alias-name detection paths.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,7 @@ All notable documentation process changes are recorded here.
 - Added a tracked parity item for filename-steered 4nec2 solver-binary drop-in compatibility mode, including contract-preservation and throughput validation goals.
 - Retargeted 4nec2 external-kernel drop-in compatibility work to a farther-future window (Phase 4-5) after assessing real NEC2MP replacement artifacts and integration scope.
 - Expanded PAR-011 with an implementation discovery checklist (binary-name matrix, install/invocation contract, file side effects, dependency surface, fixtures, and benchmark protocol) to reduce future re-research cost.
+- Added GNU NEC (`https://sourceforge.net/projects/gnu-nec/`) as an additional open-source reference candidate in architecture and PAR-011 source notes.
 
 ## 0.2.0 — 2026-05-01
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -20,6 +20,12 @@ fnec [--solver <hallen|pulse|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [-
 
 Exit codes: **0** success, **1** I/O or solver error, **2** usage error.
 
+Compatibility profile note:
+
+- The CLI now includes a filename-steered compatibility profile scaffold for 4nec2-style external kernel replacement workflows.
+- If the executable name contains `nec2dxs` or `4nec2`, default execution is steered to `--exec hybrid` unless `--exec` is explicitly provided.
+- This currently changes execution-mode defaulting only; argument/output contract compatibility work remains tracked in backlog parity item `PAR-011`.
+
 ## Options
 
 | Option | Values | Default | Description |

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -24,6 +24,7 @@ Compatibility profile note:
 
 - The CLI now includes a filename-steered compatibility profile scaffold for 4nec2-style external kernel replacement workflows.
 - If the executable name contains `nec2dxs` or `4nec2`, default execution is steered to `--exec hybrid` unless `--exec` is explicitly provided.
+- Diagnostics explicitly distinguish the two cases: "default execution path steered" vs "preserving explicit --exec=...".
 - This currently changes execution-mode defaulting only; argument/output contract compatibility work remains tracked in backlog parity item `PAR-011`.
 
 ## Options

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -15,7 +15,7 @@ Diagnostics are written to stderr.
 ## Synopsis
 
 ```
-fnec [--solver <hallen|pulse|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--allow-noncollinear-hallen] <deck.nec>
+fnec [--solver <hallen|pulse|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--allow-noncollinear-hallen] <deck.nec>
 ```
 
 Exit codes: **0** success, **1** I/O or solver error, **2** usage error.
@@ -26,6 +26,7 @@ Exit codes: **0** success, **1** I/O or solver error, **2** usage error.
 |--------|--------|---------|-------------|
 | `--solver` | `hallen` \| `pulse` \| `continuity` \| `sinusoidal` | `hallen` | MoM solver to use (see below) |
 | `--pulse-rhs` | `raw` \| `nec2` | `nec2` | RHS scaling for pulse/continuity modes |
+| `--exec` | `cpu` \| `hybrid` \| `gpu` | `cpu` | Execution backend preference. `hybrid`/`gpu` are scaffolded and currently fall back to CPU kernels with explicit diagnostics |
 | `--allow-noncollinear-hallen` | flag | off | Experimental: allow Hallen RHS projection on non-collinear wire topologies instead of hard fail |
 
 ## Solver modes
@@ -132,13 +133,14 @@ Formatting and ordering rules:
 A diagnostic line is always printed after the solve:
 
 ```
-diag: mode=hallen pulse_rhs=Nec2 freq_mhz=14.200000 abs_res=3.456789e-10 rel_res=2.345678e-08
+diag: mode=hallen pulse_rhs=Nec2 exec=cpu freq_mhz=14.200000 abs_res=3.456789e-10 rel_res=2.345678e-08
 ```
 
 | Field | Description |
 |-------|-------------|
 | `mode` | Effective solver path used (may differ from `--solver` if fallback occurred) |
 | `pulse_rhs` | Active `--pulse-rhs` setting |
+| `exec` | Effective execution mode (`cpu`, `hybrid(cpu-fallback)`, `gpu(cpu-fallback)`) |
 | `freq_mhz` | Frequency point solved for this report block |
 | `abs_res` | Absolute L2 residual ‖Ax − b‖ |
 | `rel_res` | Relative L2 residual ‖Ax − b‖ / ‖b‖ |
@@ -194,3 +196,4 @@ EN
 - The Hallén solver rejects non-collinear wire topologies by default. Use `--allow-noncollinear-hallen` only for experimental exploration.
 - Only EX type 0 (voltage source) is implemented.  EX type 5 (current source / NEC `qdsrc`) is not yet supported.
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
+- `--exec hybrid` and `--exec gpu` are now accepted in real application runs, but currently emit fallback diagnostics and execute the CPU solve path.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -197,5 +197,5 @@ EN
 - Only EX type 0 (voltage source) is implemented.  EX type 5 (current source / NEC `qdsrc`) is not yet supported.
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
 - `--exec hybrid` now runs split-lane FR scheduling (CPU-parallel lane plus GPU-candidate lane) and keeps output emitted in frequency order.
-- Hybrid currently prints an explicit warning when GPU-candidate lane points are present, because those points still run on CPU fallback until GPU kernels are wired.
+- Hybrid GPU-candidate lane points are first routed through the `nec_accel` dispatch interface and currently print an explicit warning because they still run on CPU fallback until GPU kernels are wired.
 - `--exec gpu` is accepted in real application runs, currently emits fallback diagnostics, and executes the CPU solve path.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -198,5 +198,5 @@ EN
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
 - `--exec hybrid` now runs split-lane FR scheduling (CPU-parallel lane plus GPU-candidate lane) and keeps output emitted in frequency order.
 - Hybrid GPU-candidate lane points are first routed through the `nec_accel` dispatch interface and currently print an explicit warning because they still run on CPU fallback until GPU kernels are wired.
-- For integration testing only, setting `FNEC_ACCEL_STUB_GPU=1` enables an accelerator stub dispatch path; hybrid then reports stub dispatch usage while still solving via CPU emulation.
-- `--exec gpu` is accepted in real application runs, currently emits fallback diagnostics, and executes the CPU solve path.
+- For integration testing only, setting `FNEC_ACCEL_STUB_GPU=1` enables an accelerator stub dispatch path; hybrid and gpu modes then report stub dispatch usage while still solving via CPU emulation.
+- `--exec gpu` is accepted in real application runs and executes the CPU solve path today, reporting either explicit fallback diagnostics or accelerator-stub dispatch diagnostics depending on dispatch outcome.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -140,7 +140,7 @@ diag: mode=hallen pulse_rhs=Nec2 exec=cpu freq_mhz=14.200000 abs_res=3.456789e-1
 |-------|-------------|
 | `mode` | Effective solver path used (may differ from `--solver` if fallback occurred) |
 | `pulse_rhs` | Active `--pulse-rhs` setting |
-| `exec` | Effective execution mode (`cpu`, `hybrid(cpu-fallback)`, `gpu(cpu-fallback)`) |
+| `exec` | Effective execution mode (`cpu`, `hybrid`, `gpu(cpu-fallback)`) |
 | `freq_mhz` | Frequency point solved for this report block |
 | `abs_res` | Absolute L2 residual ‖Ax − b‖ |
 | `rel_res` | Relative L2 residual ‖Ax − b‖ / ‖b‖ |

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -26,7 +26,7 @@ Exit codes: **0** success, **1** I/O or solver error, **2** usage error.
 |--------|--------|---------|-------------|
 | `--solver` | `hallen` \| `pulse` \| `continuity` \| `sinusoidal` | `hallen` | MoM solver to use (see below) |
 | `--pulse-rhs` | `raw` \| `nec2` | `nec2` | RHS scaling for pulse/continuity modes |
-| `--exec` | `cpu` \| `hybrid` \| `gpu` | `cpu` | Execution backend preference. `hybrid`/`gpu` are scaffolded and currently fall back to CPU kernels with explicit diagnostics |
+| `--exec` | `cpu` \| `hybrid` \| `gpu` | `cpu` | Execution backend preference. `hybrid` enables coarse-grain multithreaded FR sweep solving on CPU while GPU kernels are scaffolded; `gpu` currently falls back to CPU kernels with explicit diagnostics |
 | `--allow-noncollinear-hallen` | flag | off | Experimental: allow Hallen RHS projection on non-collinear wire topologies instead of hard fail |
 
 ## Solver modes
@@ -196,4 +196,5 @@ EN
 - The Hallén solver rejects non-collinear wire topologies by default. Use `--allow-noncollinear-hallen` only for experimental exploration.
 - Only EX type 0 (voltage source) is implemented.  EX type 5 (current source / NEC `qdsrc`) is not yet supported.
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
-- `--exec hybrid` and `--exec gpu` are now accepted in real application runs, but currently emit fallback diagnostics and execute the CPU solve path.
+- `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (frequency points solved in parallel, output emitted in frequency order) while GPU kernels remain scaffolded.
+- `--exec gpu` is accepted in real application runs, currently emits fallback diagnostics, and executes the CPU solve path.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -26,7 +26,7 @@ Exit codes: **0** success, **1** I/O or solver error, **2** usage error.
 |--------|--------|---------|-------------|
 | `--solver` | `hallen` \| `pulse` \| `continuity` \| `sinusoidal` | `hallen` | MoM solver to use (see below) |
 | `--pulse-rhs` | `raw` \| `nec2` | `nec2` | RHS scaling for pulse/continuity modes |
-| `--exec` | `cpu` \| `hybrid` \| `gpu` | `cpu` | Execution backend preference. `hybrid` enables coarse-grain multithreaded FR sweep solving on CPU while GPU kernels are scaffolded; `gpu` currently falls back to CPU kernels with explicit diagnostics |
+| `--exec` | `cpu` \| `hybrid` \| `gpu` | `cpu` | Execution backend preference. `hybrid` uses split-lane FR scheduling (CPU-parallel lane + GPU-candidate lane) with deterministic ordered output; GPU-candidate lane points currently fall back to CPU with explicit diagnostics until GPU kernels are wired. `gpu` currently falls back to CPU kernels with explicit diagnostics |
 | `--allow-noncollinear-hallen` | flag | off | Experimental: allow Hallen RHS projection on non-collinear wire topologies instead of hard fail |
 
 ## Solver modes
@@ -196,5 +196,6 @@ EN
 - The Hallén solver rejects non-collinear wire topologies by default. Use `--allow-noncollinear-hallen` only for experimental exploration.
 - Only EX type 0 (voltage source) is implemented.  EX type 5 (current source / NEC `qdsrc`) is not yet supported.
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
-- `--exec hybrid` now runs coarse-grain multithreaded FR sweeps (frequency points solved in parallel, output emitted in frequency order) while GPU kernels remain scaffolded.
+- `--exec hybrid` now runs split-lane FR scheduling (CPU-parallel lane plus GPU-candidate lane) and keeps output emitted in frequency order.
+- Hybrid currently prints an explicit warning when GPU-candidate lane points are present, because those points still run on CPU fallback until GPU kernels are wired.
 - `--exec gpu` is accepted in real application runs, currently emits fallback diagnostics, and executes the CPU solve path.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -198,4 +198,5 @@ EN
 - GPU acceleration (`nec_accel`) is scaffolded but not yet wired into the solve path.
 - `--exec hybrid` now runs split-lane FR scheduling (CPU-parallel lane plus GPU-candidate lane) and keeps output emitted in frequency order.
 - Hybrid GPU-candidate lane points are first routed through the `nec_accel` dispatch interface and currently print an explicit warning because they still run on CPU fallback until GPU kernels are wired.
+- For integration testing only, setting `FNEC_ACCEL_STUB_GPU=1` enables an accelerator stub dispatch path; hybrid then reports stub dispatch usage while still solving via CPU emulation.
 - `--exec gpu` is accepted in real application runs, currently emits fallback diagnostics, and executes the CPU solve path.

--- a/docs/copilot-efficiency-guide.md
+++ b/docs/copilot-efficiency-guide.md
@@ -1,0 +1,136 @@
+---
+project: fnec-rust
+doc: docs/copilot-efficiency-guide.md
+status: living
+last_updated: 2026-04-26
+---
+
+# Copilot Efficiency Guide (Rate-Limit Friendly)
+
+This guide is based on how we worked in this branch: many short "continue" steps, frequent validate/commit cycles, and broad scope over multiple slices.
+
+## Main idea
+
+You get the best throughput when each request contains one complete work packet:
+
+- scope
+- acceptance criteria
+- validation depth
+- git action expectation
+
+That reduces back-and-forth turns, which is the biggest driver of hitting chat limits.
+
+## What to do differently (based on our recent workflow)
+
+1. Bundle multiple "continue" steps into one explicit packet.
+- Instead of: continue
+- Use: implement X and Y, update docs A and B, run tests T1 and T2, commit and push.
+
+2. Decide validation level per slice up front.
+- Say one of: targeted tests only, full cargo test, or no tests for docs-only.
+- This avoids repeated clarification and reruns.
+
+3. Set commit strategy in the same prompt.
+- Example choices: one commit now, split into two commits, or stage changes but do not commit.
+
+4. Include stop conditions.
+- Example: do at most one fix loop if tests fail, then report blockers.
+
+5. Give priority and defer list in one shot.
+- Example: do A now, record B in backlog, do not implement B this week.
+
+6. Reuse templates for recurring requests.
+- Same structure means fewer mistakes and fewer correction turns.
+
+## Prompt templates that save turns
+
+## Template A: Implementation slice
+
+Goal:
+Implement <feature> in <files/components>.
+
+Requirements:
+- Keep output/report contract unchanged.
+- Update docs: <list>.
+- Add tests: <list>.
+
+Validation:
+- Run: <commands/tests>.
+- If failing: one repair pass, then report remaining blockers.
+
+Git:
+- Commit message: <message>.
+- Push to current branch.
+
+## Template B: Docs-only slice
+
+Goal:
+Update docs for <topic>.
+
+Requirements:
+- Update <files>.
+- Keep wording consistent with current behavior.
+- Add rationale paragraph for defer/priority changes.
+
+Validation:
+- No build/tests required unless docs checks are needed.
+
+Git:
+- Commit and push.
+
+## Template C: Assessment request
+
+Goal:
+Assess implementation effort for <idea>.
+
+Evidence:
+- Use these sources: <paths/urls>.
+
+Output:
+- Effort level (low/medium/high)
+- Top risks
+- Recommended phase target
+- Exact docs updates to backlog and roadmap
+
+Then apply the docs updates and push.
+
+## High-impact habits for rate-limit avoidance
+
+1. Ask for bigger chunks, fewer turns.
+- One strong prompt can replace many small "continue" prompts.
+
+2. Separate exploration and implementation intentionally.
+- If you want analysis only, say analysis only.
+- Otherwise I will implement immediately.
+
+3. Declare strict boundaries early.
+- Mention no-go areas (for example no large refactor, no API changes, no new deps).
+
+4. Ask for concise output format.
+- Example: "return only changed files, test result summary, commit SHA".
+
+5. Request batching behavior explicitly.
+- Example: "do all steps end-to-end before replying".
+
+## Recommended default command you can reuse
+
+Use this single-line style for most work packets:
+
+Implement <task>, update <docs>, run <validation scope>, fix failures once, then commit with "<message>" and push.
+
+## Suggested operating cadence
+
+- Use small number of larger slices (2-4 per session) instead of many tiny slices.
+- Reserve separate turns for major direction changes only.
+- Ask for one final summary after each slice.
+
+## Collaboration expectations
+
+I can be fastest when you provide:
+
+- concrete desired outcome
+- exact constraints
+- validation level
+- git intention
+
+If any of those are missing, I can still proceed, but it usually costs extra turns.

--- a/docs/pr-summary-feat-external-impedance-gate-seed-2.md
+++ b/docs/pr-summary-feat-external-impedance-gate-seed-2.md
@@ -1,0 +1,62 @@
+---
+project: fnec-rust
+doc: docs/pr-summary-feat-external-impedance-gate-seed-2.md
+status: living
+last_updated: 2026-04-26
+---
+
+# PR Summary: feat/external-impedance-gate-seed-2
+
+## Branch goal
+
+Deliver the execution-mode and external-parity groundwork while preserving report contracts and test stability:
+
+- optional external impedance/parity gating enablement in corpus flow
+- CLI execution modes (`cpu`, `hybrid`, `gpu`) with explicit diagnostics
+- hybrid sweep runtime progression from scaffold to real split-lane execution
+- accelerator dispatch seam and stub execution policy integration
+- deferred-but-tracked drop-in compatibility roadmap with early filename-steered scaffold
+
+## Major delivered changes
+
+1. Hybrid/GPU execution progression
+- Added CLI execution-mode scaffold and diagnostics.
+- Added coarse-grain hybrid FR sweep execution with deterministic ordered output.
+- Added split-lane hybrid scheduling (CPU lane + GPU-candidate lane).
+- Centralized accelerator execution policy in `nec_accel`.
+- Added stub dispatch path (`FNEC_ACCEL_STUB_GPU=1`) and non-fatal RunOnGpu handling.
+
+2. Compatibility scaffolding and contract hardening
+- Added filename-steered drop-in compatibility profile for `nec2dxs*` and `4nec2*` names.
+- Added contract tests for alias-based steering and explicit `--exec` override behavior.
+- Refined compatibility warnings to distinguish:
+  - auto-steered default mode
+  - preserved explicit `--exec`
+
+3. Validation and reference-planning updates
+- Extended docs/backlog/roadmap/changelog for deferred drop-in parity scope.
+- Added reference candidates and PAR-011 discovery checklist.
+- Added collaboration efficiency guide for rate-limit-aware workflow.
+
+## Test evidence
+
+Latest branch verification:
+
+- `cargo fmt --all --check` passed
+- `cargo check` passed
+- `cargo test` passed (workspace-wide)
+- `cargo test -p nec-cli --test exec_modes -- --nocapture` passed
+
+## Risk notes
+
+- `PAR-011` full 4nec2 drop-in parity remains intentionally deferred (Phase 4-5) due to Windows replacement workflow/invocation-compat scope.
+- Current drop-in implementation is a scaffold and should not be marketed as full external-kernel compatibility yet.
+- Accelerator RunOnGpu path currently uses CPU emulation under stub policy until real kernels are wired.
+
+## Merge readiness checklist
+
+- [x] Branch clean after tests
+- [x] Formatting and compile checks pass
+- [x] Workspace tests pass
+- [x] CLI compatibility tests pass
+- [x] Documentation updated for delivered behavior and deferred scope

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,6 +208,7 @@ Required benchmark outputs per target/mode:
 | CP-009 | NEC-5 | **MEDIUM** | NEC-5-class robustness is the longer-term path to claiming "better than NEC-2/4" instead of just "compatible with" | Create explicit Phase 5 architecture decision on surfaces and mixed-potential methods |
 | CP-010 | xnec2c-optimize | **MEDIUM** | Open-source users already have a practical optimizer loop with repeatable objective-driven tuning workflows | Add optimizer-loop compatibility criteria (CLI/API contracts, objective I/O stability, convergence-study support) in Phase 3-4 |
 | CP-011 | HPC scheduler + cluster workflows | **MEDIUM** | Serious sweep and optimization studies need distributed execution, trust boundaries, and repeat-run caching that local-only acceleration cannot provide | Add authenticated distributed mode with discovery and caching in Phase 4-5, with SSH-backed deployment path first |
+| CP-012 | 4nec2 external kernel binary workflow | **MEDIUM** | Users can keep mature 4nec2 UX while swapping in a faster kernel only if invocation compatibility is preserved | Add filename-steered solver-binary drop-in compatibility mode and validate contract parity with representative 4nec2 kernel-call scenarios |
 
 ## Commercial benchmark acquisition policy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/roadmap.md
 status: living
-last_updated: 2026-04-25
+last_updated: 2026-04-26
 ---
 
 # Roadmap
@@ -147,6 +147,27 @@ fnec-rust is not aiming for "good enough for a Rust rewrite". The target is to b
 ## Phase 5: Performance scaling
 
 **Goals**: GPU acceleration from postprocessing to solver kernel.
+
+### Benchmark mode matrix (all targets)
+
+To prevent regressions and keep performance claims comparable, benchmarking must run in three modes on every supported target class:
+
+- **CPU single-threaded**: deterministic baseline (`RAYON_NUM_THREADS=1` or equivalent) for direct algorithmic comparison.
+- **CPU multithreaded**: throughput mode using target-default thread count and an explicit fixed-thread variant for reproducibility.
+- **GPU offload**: accelerator path (where available) with framework/runtime metadata captured in benchmark artifacts.
+
+Target classes for this matrix:
+
+- Desktop/workstation (`x86_64` Linux, Windows, macOS)
+- SBC/edge (`aarch64` Raspberry Pi class)
+- Remote worker/cluster nodes used by distributed execution mode
+
+Required benchmark outputs per target/mode:
+
+- wall-clock runtime, solver/kernel time split, and memory footprint
+- problem-size metadata (segments, wires, frequency points, solver mode)
+- run metadata (CPU model, GPU model, driver/runtime, thread count)
+- regression deltas vs last accepted baseline
 
 **Key deliverables**:
 - [ ] GPU acceleration for postprocessing (pattern interpolation, report generation).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,7 +208,7 @@ Required benchmark outputs per target/mode:
 | CP-009 | NEC-5 | **MEDIUM** | NEC-5-class robustness is the longer-term path to claiming "better than NEC-2/4" instead of just "compatible with" | Create explicit Phase 5 architecture decision on surfaces and mixed-potential methods |
 | CP-010 | xnec2c-optimize | **MEDIUM** | Open-source users already have a practical optimizer loop with repeatable objective-driven tuning workflows | Add optimizer-loop compatibility criteria (CLI/API contracts, objective I/O stability, convergence-study support) in Phase 3-4 |
 | CP-011 | HPC scheduler + cluster workflows | **MEDIUM** | Serious sweep and optimization studies need distributed execution, trust boundaries, and repeat-run caching that local-only acceleration cannot provide | Add authenticated distributed mode with discovery and caching in Phase 4-5, with SSH-backed deployment path first |
-| CP-012 | 4nec2 external kernel binary workflow | **MEDIUM** | Users can keep mature 4nec2 UX while swapping in a faster kernel only if invocation compatibility is preserved | Add filename-steered solver-binary drop-in compatibility mode and validate contract parity with representative 4nec2 kernel-call scenarios |
+| CP-012 | 4nec2 external kernel binary workflow | **LOW (deferred)** | Users can keep mature 4nec2 UX while swapping in a faster kernel only if invocation compatibility is preserved | Defer to Phase 4-5: complete filename-steered drop-in mode, Windows replacement workflow compatibility checks, and representative 4nec2 kernel-call contract validation |
 
 ## Commercial benchmark acquisition policy
 


### PR DESCRIPTION
## Summary
- add explicit benchmark-mode coverage to the roadmap for all target classes (CPU single-threaded, CPU multithreaded, GPU offload)
- enable a second external impedance CI-gated case on dipole-ground-51seg
- update corpus and progress docs to reflect the new gate seed and benchmark-mode requirement

## Validation
- cargo fmt --all --check
- cargo test -p nec-cli --test corpus_validation -- --nocapture