### PR TITLE
test: seed-5 yagi external impedance gate

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -446,9 +446,11 @@
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
-        "X_absolute_ohm": 0.05
+        "X_absolute_ohm": 0.05,
+        "ExternalR_absolute_ohm": 30.0,
+        "ExternalX_absolute_ohm": 70.0
       },
-      "status": "Regression reference captured from corrected fnec multi-wire Hallen implementation; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy"
+      "status": "Regression reference captured from corrected fnec multi-wire Hallen implementation; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy and now CI-gated with conservative absolute external R/X thresholds for incremental parity tightening."
     },
     "dipole-ld-loaded-51seg": {
       "deck_file": "dipole-ld-loaded-51seg.nec",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -79,6 +79,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: wired runtime CLI flag `--ex3-i4-mode <legacy|divide-by-i4>` through solver and Hallen RHS paths; default remains legacy while `divide-by-i4` enables experimental EX3 I4-divisor semantics with explicit warning-contract coverage.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `tl-two-dipoles-linked` with conservative thresholds (`ExternalR_absolute_ohm=5.0`, `ExternalX_absolute_ohm=20.0`) as external-impedance gate seed-2.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `multi-source` with conservative thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`) as external-impedance gate seed-3.
+	- 2026-04-28 progress: enabled external impedance candidate gates for `yagi-5elm-51seg` with conservative thresholds (`ExternalR_absolute_ohm=30.0`, `ExternalX_absolute_ohm=70.0`) as external-impedance gate seed-5.
 	- 2026-04-27 progress: added corpus validation case `tl-two-dipoles-linked` (`corpus/tl-two-dipoles-linked.nec`) to lock TL subset behavior in CI, with a first `nec2c` external impedance candidate captured for parity tracking.
 
 - [ ] **PAR-004 / xnec2c-style workbench parity / Owner: GUI+CLI / Target: Phase 3 / Issue: #17**


### PR DESCRIPTION
## Summary
- enable external impedance candidate gates for yagi-5elm-51seg
- add conservative thresholds: ExternalR_absolute_ohm=30.0, ExternalX_absolute_ohm=70.0
- update backlog with external-impedance gate seed-5 progress

## Validation
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- ./scripts/validate-doc-frontmatter.sh

## Scope notes
- intentionally excluded unrelated local formatting-only change in apps/nec-cli/tests/corpus_validation.rs
- left local tmp/ untracked
