### PR TITLE
test(corpus): normalize GE cards in corpus decks

### DIFF
--- a/corpus/dipole-ld-series-rc-51seg.nec
+++ b/corpus/dipole-ld-series-rc-51seg.nec
@@ -1,6 +1,7 @@
 CM Half-wave dipole with LD type 3 series RC load on the feed segment.
 CE
 GW 1 51 0 0 -5.282 0 0 5.282 0.001
+GE
 LD 3 1 26 26 10.0 0.0 1e-12
 EX 0 1 26 0 1.0 0.0
 FR 0 1 0 0 14.2 0.0

--- a/corpus/dipole-ld-series-rl-51seg.nec
+++ b/corpus/dipole-ld-series-rl-51seg.nec
@@ -1,6 +1,7 @@
 CM Half-wave dipole with LD type 2 series RL load on the feed segment.
 CE
 GW 1 51 0 0 -5.282 0 0 5.282 0.001
+GE
 LD 2 1 26 26 10.0 1e-6 0.0
 EX 0 1 26 0 1.0 0.0
 FR 0 1 0 0 14.2 0.0

--- a/corpus/tl-two-dipoles-linked-seg0.nec
+++ b/corpus/tl-two-dipoles-linked-seg0.nec
@@ -2,6 +2,7 @@ CM Two parallel dipoles linked by a lossless TL card using segment=0 endpoints.
 CM segment=0 is mapped to the tag center segment by fnec runtime.
 GW 1 51 0.0 0 -5.282 0.0 0 5.282 0.001
 GW 2 51 1.0 0 -5.282 1.0 0 5.282 0.001
+GE
 TL 1 0 2 0 1 0 50.0 0.1 1.0
 EX 0 1 26 0 1.0 0.0
 FR 0 1 0 0 14.2 0.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,7 @@ All notable documentation process changes are recorded here.
 
 ### Changed
 
+- Added missing `GE` cards to three corpus decks (`dipole-ld-series-rc-51seg`, `dipole-ld-series-rl-51seg`, `tl-two-dipoles-linked-seg0`) so `corpus_deck_sanity` passes consistently in local hooks and CI.
 - Native CLI startup now auto-selects execution mode when `--exec` is omitted by running a quick execution probe (CPU threads, frequency-point count, and accelerator dispatch availability) and choosing among `cpu`/`hybrid`/`gpu` heuristically for the current workload shape.
 - Consolidated benchmark documentation into a single canonical file (`docs/benchmarks.md`) and removed the duplicate `docs/benchmark.md` shim.
 - Benchmark docs now explicitly map reported numbers to four execution modes: CPU single-thread, CPU multithread, GPU, and hybrid (CPU multithread + GPU), with a dedicated local four-mode coverage result block.


### PR DESCRIPTION
## Summary
- add missing GE cards to corpus decks required by corpus sanity contract
  - corpus/dipole-ld-series-rc-51seg.nec
  - corpus/dipole-ld-series-rl-51seg.nec
  - corpus/tl-two-dipoles-linked-seg0.nec
- add changelog note for the corpus GE normalization fix

## Validation
- cargo test -p nec-cli --test corpus_deck_sanity
- cargo test -p nec-cli --test corpus_validation
- ./scripts/validate-doc-frontmatter.sh

## Scope notes
- intentionally excluded unrelated local modification in apps/nec-cli/tests/corpus_validation.rs
- left local tmp/ untracked
