### PR TITLE
test(parser): lock PT/NT parse regressions

### DIFF
--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -719,4 +719,26 @@ EN
         assert_eq!(gr.count, 3);
         assert!((gr.angle_deg - 120.0).abs() < 1e-10);
     }
+
+    #[test]
+    fn pt_card_is_parsed_without_unknown_warning() {
+        let input = "PT 0 1 26 0 50.0 0.1 1.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+        assert!(matches!(
+            result.deck.cards.first(),
+            Some(Card::Pt(pt)) if !pt.raw_fields.is_empty()
+        ));
+    }
+
+    #[test]
+    fn nt_card_is_parsed_without_unknown_warning() {
+        let input = "NT 1 1 26 1 1 26 50.0 0.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+        assert!(matches!(
+            result.deck.cards.first(),
+            Some(Card::Nt(nt)) if !nt.raw_fields.is_empty()
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- add parser regression tests to lock staged portability parsing for PT/NT cards
- assert PT/NT are parsed as card variants and do not regress to unknown-card warnings

## Validation
- cargo test -p nec_parser -- --nocapture
- pre-commit hook suite passed during commit

## Scope notes
- intentionally excluded unrelated local modification in apps/nec-cli/tests/corpus_validation.rs
- left local tmp/ untracked
