### PR TITLE
test(parser): lock PT/NT raw field preservation

### DIFF
--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -727,7 +727,9 @@ EN
         assert!(result.warnings.is_empty());
         assert!(matches!(
             result.deck.cards.first(),
-            Some(Card::Pt(pt)) if !pt.raw_fields.is_empty()
+            Some(Card::Pt(pt))
+                if pt.raw_fields
+                    == vec!["0", "1", "26", "0", "50.0", "0.1", "1.0"]
         ));
     }
 
@@ -738,7 +740,9 @@ EN
         assert!(result.warnings.is_empty());
         assert!(matches!(
             result.deck.cards.first(),
-            Some(Card::Nt(nt)) if !nt.raw_fields.is_empty()
+            Some(Card::Nt(nt))
+                if nt.raw_fields
+                    == vec!["1", "1", "26", "1", "1", "26", "50.0", "0.0"]
         ));
     }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -94,6 +94,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: NT cards are now parsed for staged portability (instead of being treated as unknown cards), and runtime emits an explicit deferred-support warning while NT electrical semantics remain ignored.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_card_emits_deferred_warning_but_run_succeeds` and corpus regression case `dipole-nt-freesp-51seg` to lock NT staged portability behavior in CI.
 	- 2026-04-28 progress: added combined PT+NT warning-contract regression `pt_and_nt_cards_emit_deferred_warnings_and_run_succeeds` and corpus case `dipole-pt-nt-freesp-51seg` to lock multi-card staged portability behavior in CI.
+	- 2026-04-28 progress: strengthened parser-level PT/NT regressions in `crates/nec_parser/src/lib.rs` to assert exact `raw_fields` preservation, locking staged portability token capture semantics in CI.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `tl-two-dipoles-linked` with conservative thresholds (`ExternalR_absolute_ohm=5.0`, `ExternalX_absolute_ohm=20.0`) as external-impedance gate seed-2.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `multi-source` with conservative thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`) as external-impedance gate seed-3.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `yagi-5elm-51seg` with conservative thresholds (`ExternalR_absolute_ohm=30.0`, `ExternalX_absolute_ohm=70.0`) as external-impedance gate seed-5.


### PR DESCRIPTION
## Summary
- strengthen PT parser regression to assert exact raw field token capture
- strengthen NT parser regression to assert exact raw field token capture
- record PAR-003 progress in backlog

## Validation
- cargo fmt
- cargo test -p nec_parser pt_card_is_parsed_without_unknown_warning
- cargo test -p nec_parser nt_card_is_parsed_without_unknown_warning
- cargo test -p nec-cli --test parser_warnings -- --nocapture
- ./scripts/validate-doc-frontmatter.sh