### PR TITLE
test(cli): lock deduplicated PT/NT warning behavior

### DIFF
--- a/apps/nec-cli/tests/parser_warnings.rs
+++ b/apps/nec-cli/tests/parser_warnings.rs
@@ -374,6 +374,60 @@ fn pt_and_nt_cards_emit_deferred_warnings_and_run_succeeds() {
 }
 
 #[test]
+fn repeated_pt_and_nt_cards_emit_deduplicated_warnings_per_family() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-pt-nt-repeated-{now}.nec"));
+
+    let deck = "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nPT 0 1 26 0 50.0 0.1 1.0\nPT 0 1 26 0 75.0 0.2 1.0\nNT 1 1 26 1 1 26 50.0 0.0\nNT 1 1 26 1 1 26 75.0 0.0\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck)
+        .expect("failed to write temporary deck with repeated PT and NT cards");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("cpu")
+        .env("FNEC_ACCEL_STUB_GPU", "0")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for repeated PT+NT warning test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let pt_warning_count = stderr
+        .matches("PT card support is currently deferred")
+        .count();
+    let nt_warning_count = stderr
+        .matches("NT card support is currently deferred")
+        .count();
+
+    assert_eq!(
+        pt_warning_count, 1,
+        "expected PT deferred warning to be deduplicated per card family, got stderr:\n{stderr}"
+    );
+    assert_eq!(
+        nt_warning_count, 1,
+        "expected NT deferred warning to be deduplicated per card family, got stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown card 'PT'") && !stderr.contains("unknown card 'NT'"),
+        "PT/NT should be parsed explicitly, not treated as unknown cards:\n{stderr}"
+    );
+}
+
+#[test]
 fn ex_type3_runs_without_unsupported_error() {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -95,6 +95,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_card_emits_deferred_warning_but_run_succeeds` and corpus regression case `dipole-nt-freesp-51seg` to lock NT staged portability behavior in CI.
 	- 2026-04-28 progress: added combined PT+NT warning-contract regression `pt_and_nt_cards_emit_deferred_warnings_and_run_succeeds` and corpus case `dipole-pt-nt-freesp-51seg` to lock multi-card staged portability behavior in CI.
 	- 2026-04-28 progress: strengthened parser-level PT/NT regressions in `crates/nec_parser/src/lib.rs` to assert exact `raw_fields` preservation, locking staged portability token capture semantics in CI.
+	- 2026-04-28 progress: added CLI warning-contract regression `repeated_pt_and_nt_cards_emit_deduplicated_warnings_per_family` to lock current deduplicated warning behavior for repeated PT/NT cards.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `tl-two-dipoles-linked` with conservative thresholds (`ExternalR_absolute_ohm=5.0`, `ExternalX_absolute_ohm=20.0`) as external-impedance gate seed-2.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `multi-source` with conservative thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`) as external-impedance gate seed-3.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `yagi-5elm-51seg` with conservative thresholds (`ExternalR_absolute_ohm=30.0`, `ExternalX_absolute_ohm=70.0`) as external-impedance gate seed-5.


### PR DESCRIPTION
## Summary
- add CLI warning-contract regression for repeated PT/NT cards
- lock current behavior: deferred PT/NT warnings are deduplicated per card family
- record PAR-003 progress in backlog

## Validation
- cargo fmt
- cargo test -p nec-cli --test parser_warnings repeated_pt_and_nt_cards_emit_deduplicated_warnings_per_family -- --nocapture
- cargo test -p nec-cli --test parser_warnings -- --nocapture
- ./scripts/validate-doc-frontmatter.sh