### PR TITLE
docs(validation): add EZNEC via Wine fallback path

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -98,6 +98,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_pt_and_nt_cards_emit_deduplicated_warnings_per_family` to lock current deduplicated warning behavior for repeated PT/NT cards.
 	- 2026-04-28 progress: added corpus regression case `dipole-pt-nt-repeated-freesp-51seg` to lock repeated PT/NT deck portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: external validation path expanded: EZNEC via Wine is now available for future external impedance candidate capture alongside nec2c seeds.
+	- 2026-04-28 progress: updated `docs/corpus-validation-strategy.md` to document EZNEC-via-Wine as a fallback capture path in external-reference workflow guidance.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `tl-two-dipoles-linked` with conservative thresholds (`ExternalR_absolute_ohm=5.0`, `ExternalX_absolute_ohm=20.0`) as external-impedance gate seed-2.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `multi-source` with conservative thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`) as external-impedance gate seed-3.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `yagi-5elm-51seg` with conservative thresholds (`ExternalR_absolute_ohm=30.0`, `ExternalX_absolute_ohm=70.0`) as external-impedance gate seed-5.

--- a/docs/corpus-validation-strategy.md
+++ b/docs/corpus-validation-strategy.md
@@ -109,15 +109,15 @@ For each corpus case:
    ```bash
   xnec2c --batch -j0 -i corpus/dipole-freesp-51seg.nec --write-csv .tmp-work/dipole-freesp.csv
    ```
-  If xnec2c hangs in headless Linux (known with some 4.4.x builds), run 4nec2 under Wine/VM and export equivalent impedance/report data.
+  If xnec2c hangs in headless Linux (known with some 4.4.x builds), run 4nec2 or EZNEC under Wine/VM and export equivalent impedance/report data.
 3. Extract key results (impedance, gain, pattern samples, currents)
 4. Record in `corpus/reference-results.json` (manual edit or helper script):
    ```bash
    scripts/import-reference-impedance.py \
      --case dipole-ground-51seg \
      --real 63.12 --imag -18.45 \
-     --source "4nec2 (Wine 9.x)" \
-     --status "Reference captured via 4nec2/Wine"
+    --source "4nec2 or EZNEC (Wine 9.x)" \
+    --status "Reference captured via Windows NEC engine under Wine"
    ```
 
    For full runs, use batch import:
@@ -212,9 +212,9 @@ The following external tools are required for the reference-capture and validati
 |:-----|:--------:|:--------|
 | `gh` (GitHub CLI) | Yes | PR/issue automation, milestone/label management, and workflow integration from terminal runs |
 | `jq` | Yes | JSON inspection and extraction in terminal workflows (corpus status, reference field queries) |
-| `wine` | Conditional | Run Windows NEC engines (4nec2/NEC2 binaries) when native xnec2c batch execution is unstable |
+| `wine` | Conditional | Run Windows NEC engines (4nec2/EZNEC/NEC2 binaries) when native xnec2c batch execution is unstable |
 | `xnec2c` | Preferred | Primary external NEC2 reference engine for golden-reference capture |
-| 4nec2 + NEC2 executable (`nec2dxs500.exe`/equivalent) | Fallback | External reference capture path when xnec2c is unavailable or unstable on host |
+| 4nec2 or EZNEC + NEC2 executable (`nec2dxs500.exe`/equivalent) | Fallback | External reference capture path when xnec2c is unavailable or unstable on host |
 | `pdftotext` | Conditional | Extract text from NEC-5 Validation Manual for planning and traceability work |
 
 Notes:
@@ -228,7 +228,7 @@ To add a new corpus case:
 1. Write the NEC deck: `corpus/my-case.nec`
 2. Update `corpus/README.md` with case description
 3. Add stub to `corpus/reference-results.json` with `null` values and status "Deck created; reference TBD"
-4. Run reference capture (manual): `xnec2c --batch -j0 -i corpus/my-case.nec --write-csv ...` (or 4nec2 export when xnec2c is unstable)
+4. Run reference capture (manual): `xnec2c --batch -j0 -i corpus/my-case.nec --write-csv ...` (or 4nec2/EZNEC export when xnec2c is unstable)
 5. Update `corpus/reference-results.json` with real values
 6. Ensure the new case is represented in `corpus/reference-results.json` (the harness is table-driven and reads from the JSON table)
 7. Update status in `corpus/README.md`: "Reference captured"


### PR DESCRIPTION
## Summary
- document EZNEC via Wine as an external-reference fallback capture path
- update corpus validation workflow wording and host-tool table
- log PAR-003 progress update in backlog

## Validation
- ./scripts/validate-doc-frontmatter.sh