### PR TITLE
test(parser): lock repeated PT/NT token ordering

### DIFF
--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -745,4 +745,51 @@ EN
                     == vec!["1", "1", "26", "1", "1", "26", "50.0", "0.0"]
         ));
     }
+
+    #[test]
+    fn repeated_pt_and_nt_cards_preserve_order_and_raw_fields() {
+        let input = "PT 0 1 26 0 50.0 0.1 1.0\nPT 0 1 26 0 75.0 0.2 1.0\nNT 1 1 26 1 1 26 50.0 0.0\nNT 1 1 26 1 1 26 75.0 0.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+
+        let pt_cards: Vec<_> = result
+            .deck
+            .cards
+            .iter()
+            .filter_map(|card| {
+                if let Card::Pt(pt) = card {
+                    Some(pt.raw_fields.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let nt_cards: Vec<_> = result
+            .deck
+            .cards
+            .iter()
+            .filter_map(|card| {
+                if let Card::Nt(nt) = card {
+                    Some(nt.raw_fields.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            pt_cards,
+            vec![
+                vec!["0", "1", "26", "0", "50.0", "0.1", "1.0"],
+                vec!["0", "1", "26", "0", "75.0", "0.2", "1.0"],
+            ]
+        );
+        assert_eq!(
+            nt_cards,
+            vec![
+                vec!["1", "1", "26", "1", "1", "26", "50.0", "0.0"],
+                vec!["1", "1", "26", "1", "1", "26", "75.0", "0.0"],
+            ]
+        );
+    }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -99,6 +99,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: added corpus regression case `dipole-pt-nt-repeated-freesp-51seg` to lock repeated PT/NT deck portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: external validation path expanded: EZNEC via Wine is now available for future external impedance candidate capture alongside nec2c seeds.
 	- 2026-04-28 progress: updated `docs/corpus-validation-strategy.md` to document EZNEC-via-Wine as a fallback capture path in external-reference workflow guidance.
+	- 2026-04-28 progress: added parser regression `repeated_pt_and_nt_cards_preserve_order_and_raw_fields` in `crates/nec_parser/src/lib.rs` to lock repeated PT/NT token preservation order.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `tl-two-dipoles-linked` with conservative thresholds (`ExternalR_absolute_ohm=5.0`, `ExternalX_absolute_ohm=20.0`) as external-impedance gate seed-2.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `multi-source` with conservative thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`) as external-impedance gate seed-3.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `yagi-5elm-51seg` with conservative thresholds (`ExternalR_absolute_ohm=30.0`, `ExternalX_absolute_ohm=70.0`) as external-impedance gate seed-5.


### PR DESCRIPTION
## Summary
- add parser regression for repeated PT/NT cards to assert stable order and raw token preservation
- keep existing PT/NT single-card parser locks intact
- record PAR-003 progress in backlog

## Validation
- cargo fmt
- cargo test -p nec_parser repeated_pt_and_nt_cards_preserve_order_and_raw_fields
- cargo test -p nec_parser pt_card_is_parsed_without_unknown_warning
- cargo test -p nec_parser nt_card_is_parsed_without_unknown_warning
- ./scripts/validate-doc-frontmatter.sh