### PR TITLE
test(cli): format corpus validation panic output

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -191,11 +191,7 @@ fn corpus_validation_cases_with_references() {
         }
 
         if !output.status.success() {
-            panic!(
-                "fnec failed for case '{}': {}",
-                case_name,
-                stderr
-            );
+            panic!("fnec failed for case '{}': {}", case_name, stderr);
         }
 
         for expected_warning in &expected_warning_substrings {


### PR DESCRIPTION
## Summary
- commit the pending corpus_validation.rs formatting update
- preserve behavior (no logic changes)

## Validation
- cargo test -p nec-cli --test corpus_validation -- --nocapture