### PR TITLE
test(parser): lock repeated NT/PT token ordering

### DIFF
--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -792,4 +792,51 @@ EN
             ]
         );
     }
+
+    #[test]
+    fn repeated_nt_and_pt_cards_preserve_order_and_raw_fields() {
+        let input = "NT 1 1 26 1 1 26 50.0 0.0\nNT 1 1 26 1 1 26 75.0 0.0\nPT 0 1 26 0 50.0 0.1 1.0\nPT 0 1 26 0 75.0 0.2 1.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+
+        let nt_cards: Vec<_> = result
+            .deck
+            .cards
+            .iter()
+            .filter_map(|card| {
+                if let Card::Nt(nt) = card {
+                    Some(nt.raw_fields.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let pt_cards: Vec<_> = result
+            .deck
+            .cards
+            .iter()
+            .filter_map(|card| {
+                if let Card::Pt(pt) = card {
+                    Some(pt.raw_fields.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            nt_cards,
+            vec![
+                vec!["1", "1", "26", "1", "1", "26", "50.0", "0.0"],
+                vec!["1", "1", "26", "1", "1", "26", "75.0", "0.0"],
+            ]
+        );
+        assert_eq!(
+            pt_cards,
+            vec![
+                vec!["0", "1", "26", "0", "50.0", "0.1", "1.0"],
+                vec!["0", "1", "26", "0", "75.0", "0.2", "1.0"],
+            ]
+        );
+    }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -100,6 +100,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: external validation path expanded: EZNEC via Wine is now available for future external impedance candidate capture alongside nec2c seeds.
 	- 2026-04-28 progress: updated `docs/corpus-validation-strategy.md` to document EZNEC-via-Wine as a fallback capture path in external-reference workflow guidance.
 	- 2026-04-28 progress: added parser regression `repeated_pt_and_nt_cards_preserve_order_and_raw_fields` in `crates/nec_parser/src/lib.rs` to lock repeated PT/NT token preservation order.
+	- 2026-04-28 progress: added parser regression `repeated_nt_and_pt_cards_preserve_order_and_raw_fields` in `crates/nec_parser/src/lib.rs` to lock repeated NT/PT token preservation order.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- add parser regression for repeated NT then PT cards
- lock raw-field token preservation order for reversed repeated card order
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec_parser repeated_nt_and_pt_cards_preserve_order_and_raw_fields
- cargo test -p nec_parser repeated_pt_and_nt_cards_preserve_order_and_raw_fields
- ./scripts/validate-doc-frontmatter.sh