### PR TITLE
test(parser): lock interleaved PT/NT card sequence

### DIFF
--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -839,4 +839,38 @@ EN
             ]
         );
     }
+
+    #[test]
+    fn interleaved_pt_nt_cards_preserve_card_sequence() {
+        let input = "PT 0 1 26 0 50.0 0.1 1.0\nNT 1 1 26 1 1 26 50.0 0.0\nPT 0 1 26 0 75.0 0.2 1.0\nNT 1 1 26 1 1 26 75.0 0.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+
+        let sequence: Vec<(&str, Vec<&str>)> = result
+            .deck
+            .cards
+            .iter()
+            .filter_map(|card| match card {
+                Card::Pt(pt) => Some((
+                    "PT",
+                    pt.raw_fields.iter().map(String::as_str).collect::<Vec<_>>(),
+                )),
+                Card::Nt(nt) => Some((
+                    "NT",
+                    nt.raw_fields.iter().map(String::as_str).collect::<Vec<_>>(),
+                )),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            sequence,
+            vec![
+                ("PT", vec!["0", "1", "26", "0", "50.0", "0.1", "1.0"]),
+                ("NT", vec!["1", "1", "26", "1", "1", "26", "50.0", "0.0"]),
+                ("PT", vec!["0", "1", "26", "0", "75.0", "0.2", "1.0"]),
+                ("NT", vec!["1", "1", "26", "1", "1", "26", "75.0", "0.0"]),
+            ]
+        );
+    }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -101,6 +101,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: updated `docs/corpus-validation-strategy.md` to document EZNEC-via-Wine as a fallback capture path in external-reference workflow guidance.
 	- 2026-04-28 progress: added parser regression `repeated_pt_and_nt_cards_preserve_order_and_raw_fields` in `crates/nec_parser/src/lib.rs` to lock repeated PT/NT token preservation order.
 	- 2026-04-28 progress: added parser regression `repeated_nt_and_pt_cards_preserve_order_and_raw_fields` in `crates/nec_parser/src/lib.rs` to lock repeated NT/PT token preservation order.
+	- 2026-04-28 progress: added parser regression `interleaved_pt_nt_cards_preserve_card_sequence` in `crates/nec_parser/src/lib.rs` to lock interleaved PT/NT sequence preservation with exact raw fields.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- add parser regression for interleaved PT/NT card sequencing
- assert exact variant sequence and raw fields across interleaved cards
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec_parser interleaved_pt_nt_cards_preserve_card_sequence
- ./scripts/validate-doc-frontmatter.sh