### PR TITLE
test(corpus): lock EX3 I4=2 legacy warning case

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -421,6 +421,30 @@
       },
       "status": "Regression lock for EX type 3 I4=2 divide-by-i4 corpus-path warning semantics."
     },
+    "dipole-ex3-i4-two-freesp-51seg": {
+      "deck_file": "dipole-ex3-i4-two-freesp-51seg.nec",
+      "description": "Half-wave dipole, free space, 51 segments, 14.2 MHz, EX type 3 source with I4=2 in legacy mode",
+      "frequency_mhz": 14.2,
+      "segments": 51,
+      "wires": 1,
+      "sources": 1,
+      "ground": "none",
+      "reference_source": "fnec Hallen solver (regression reference for EX type 3 I4=2 legacy warning contract)",
+      "expected_warning_substrings": [
+        "EX type 3 with non-default I4 is currently treated like EX type 0"
+      ],
+      "feedpoint_impedance": {
+        "real_ohm": 74.23,
+        "imag_ohm": 13.90
+      },
+      "tolerance_gates": {
+        "R_percent_rel": 0.1,
+        "X_percent_rel": 0.1,
+        "R_absolute_ohm": 0.05,
+        "X_absolute_ohm": 0.05
+      },
+      "status": "Regression lock for EX type 3 I4=2 legacy corpus-path warning semantics."
+    },
     "dipole-freesp-rp-51seg": {
       "deck_file": "dipole-freesp-rp-51seg.nec",
       "description": "Half-wave dipole, free space, 51 segments, 14.2 MHz, RP theta sweep",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -106,6 +106,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: added parser regression `interleaved_nt_pt_cards_preserve_card_sequence`, CLI warning-contract regression `interleaved_nt_and_pt_cards_emit_deduplicated_warnings_per_family`, and corpus case `dipole-nt-pt-interleaved-freesp-51seg` to lock NT-first interleaved PT/NT portability behavior in CI.
 	- 2026-04-28 progress: corpus validation harness now supports per-case `cli_args`, and `dipole-ex3-i4-divide-by-i4-freesp-51seg` was added to lock EX3 `--ex3-i4-mode divide-by-i4` warning semantics in corpus CI.
 	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-divide-by-i4-freesp-51seg` (deck `dipole-ex3-i4-two-freesp-51seg.nec`) to lock EX3 `I4=2` divide-by-i4 warning semantics in corpus CI.
+	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-freesp-51seg` (legacy mode) to lock EX3 `I4=2` non-default warning semantics on the default runtime path.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- add corpus lock for EX type 3 with I4=2 in default legacy mode
- assert legacy EX3 non-default I4 warning in corpus validation path
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- ./scripts/validate-doc-frontmatter.sh