### PR TITLE
test(corpus): assert forbidden warnings for EX3 mode

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -63,6 +63,11 @@ fn corpus_validation_cases_with_references() {
             .and_then(Value::as_array)
             .map(|arr| arr.iter().filter_map(Value::as_str).collect())
             .unwrap_or_default();
+        let forbidden_warning_substrings: Vec<&str> = case_obj
+            .get("forbidden_warning_substrings")
+            .and_then(Value::as_array)
+            .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
         let cli_args: Vec<&str> = case_obj
             .get("cli_args")
             .and_then(Value::as_array)
@@ -209,6 +214,15 @@ fn corpus_validation_cases_with_references() {
                 "Case '{}' expected warning containing '{}', got stderr:\n{}",
                 case_name,
                 expected_warning,
+                stderr
+            );
+        }
+        for forbidden_warning in &forbidden_warning_substrings {
+            assert!(
+                !stderr.contains(forbidden_warning),
+                "Case '{}' should not emit warning containing '{}', got stderr:\n{}",
+                case_name,
+                forbidden_warning,
                 stderr
             );
         }

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -381,6 +381,9 @@
       "expected_warning_substrings": [
         "--ex3-i4-mode=divide-by-i4 enables experimental EX type 3 normalization semantics"
       ],
+      "forbidden_warning_substrings": [
+        "EX type 3 with non-default I4 is currently treated like EX type 0"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -408,6 +411,9 @@
       "reference_source": "fnec Hallen solver (regression reference for EX type 3 I4=2 divide-by-i4 mode warning contract)",
       "expected_warning_substrings": [
         "--ex3-i4-mode=divide-by-i4 enables experimental EX type 3 normalization semantics"
+      ],
+      "forbidden_warning_substrings": [
+        "EX type 3 with non-default I4 is currently treated like EX type 0"
       ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -107,6 +107,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: corpus validation harness now supports per-case `cli_args`, and `dipole-ex3-i4-divide-by-i4-freesp-51seg` was added to lock EX3 `--ex3-i4-mode divide-by-i4` warning semantics in corpus CI.
 	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-divide-by-i4-freesp-51seg` (deck `dipole-ex3-i4-two-freesp-51seg.nec`) to lock EX3 `I4=2` divide-by-i4 warning semantics in corpus CI.
 	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-freesp-51seg` (legacy mode) to lock EX3 `I4=2` non-default warning semantics on the default runtime path.
+	- 2026-04-28 progress: corpus validation now supports `forbidden_warning_substrings`, and EX3 divide-by-i4 corpus cases now assert the legacy non-default-I4 warning is absent when divide-by-i4 mode is selected.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- add forbidden_warning_substrings support to corpus validation
- assert divide-by-i4 EX3 corpus cases do not emit legacy non-default-I4 warning
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- ./scripts/validate-doc-frontmatter.sh