### PR TITLE
test(corpus): lock exact warning counts for PAR-003 cases

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -68,6 +68,19 @@ fn corpus_validation_cases_with_references() {
             .and_then(Value::as_array)
             .map(|arr| arr.iter().filter_map(Value::as_str).collect())
             .unwrap_or_default();
+        let expected_warning_counts: Vec<(&str, usize)> = case_obj
+            .get("expected_warning_counts")
+            .and_then(Value::as_object)
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(warning, count)| {
+                        count
+                            .as_u64()
+                            .map(|count| (warning.as_str(), count as usize))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         let cli_args: Vec<&str> = case_obj
             .get("cli_args")
             .and_then(Value::as_array)
@@ -224,6 +237,14 @@ fn corpus_validation_cases_with_references() {
                 case_name,
                 forbidden_warning,
                 stderr
+            );
+        }
+        for (warning, expected_count) in &expected_warning_counts {
+            let actual_count = stderr.matches(warning).count();
+            assert_eq!(
+                actual_count, *expected_count,
+                "Case '{}' expected warning '{}' to appear {} time(s), got {} occurrence(s) in stderr:\n{}",
+                case_name, warning, expected_count, actual_count, stderr
             );
         }
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -204,6 +204,10 @@
         "PT card support is currently deferred",
         "NT card support is currently deferred"
       ],
+      "expected_warning_counts": {
+        "PT card support is currently deferred": 1,
+        "NT card support is currently deferred": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -229,6 +233,10 @@
         "NT card support is currently deferred",
         "PT card support is currently deferred"
       ],
+      "expected_warning_counts": {
+        "NT card support is currently deferred": 1,
+        "PT card support is currently deferred": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -254,6 +262,10 @@
         "PT card support is currently deferred",
         "NT card support is currently deferred"
       ],
+      "expected_warning_counts": {
+        "PT card support is currently deferred": 1,
+        "NT card support is currently deferred": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -279,6 +291,10 @@
         "NT card support is currently deferred",
         "PT card support is currently deferred"
       ],
+      "expected_warning_counts": {
+        "NT card support is currently deferred": 1,
+        "PT card support is currently deferred": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -353,6 +369,9 @@
       "expected_warning_substrings": [
         "EX type 3 with non-default I4 is currently treated like EX type 0"
       ],
+      "expected_warning_counts": {
+        "EX type 3 with non-default I4 is currently treated like EX type 0": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -381,6 +400,9 @@
       "expected_warning_substrings": [
         "--ex3-i4-mode=divide-by-i4 enables experimental EX type 3 normalization semantics"
       ],
+      "expected_warning_counts": {
+        "--ex3-i4-mode=divide-by-i4 enables experimental EX type 3 normalization semantics": 1
+      },
       "forbidden_warning_substrings": [
         "EX type 3 with non-default I4 is currently treated like EX type 0"
       ],
@@ -412,6 +434,9 @@
       "expected_warning_substrings": [
         "--ex3-i4-mode=divide-by-i4 enables experimental EX type 3 normalization semantics"
       ],
+      "expected_warning_counts": {
+        "--ex3-i4-mode=divide-by-i4 enables experimental EX type 3 normalization semantics": 1
+      },
       "forbidden_warning_substrings": [
         "EX type 3 with non-default I4 is currently treated like EX type 0"
       ],
@@ -439,6 +464,9 @@
       "expected_warning_substrings": [
         "EX type 3 with non-default I4 is currently treated like EX type 0"
       ],
+      "expected_warning_counts": {
+        "EX type 3 with non-default I4 is currently treated like EX type 0": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -108,6 +108,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-divide-by-i4-freesp-51seg` (deck `dipole-ex3-i4-two-freesp-51seg.nec`) to lock EX3 `I4=2` divide-by-i4 warning semantics in corpus CI.
 	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-freesp-51seg` (legacy mode) to lock EX3 `I4=2` non-default warning semantics on the default runtime path.
 	- 2026-04-28 progress: corpus validation now supports `forbidden_warning_substrings`, and EX3 divide-by-i4 corpus cases now assert the legacy non-default-I4 warning is absent when divide-by-i4 mode is selected.
+	- 2026-04-28 progress: corpus validation now supports `expected_warning_counts`; repeated/interleaved PT/NT and EX3 legacy/divide-by-i4 corpus cases now assert exact warning occurrence counts for stronger warning-contract parity.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- add expected_warning_counts support to corpus validation
- lock exact warning counts for repeated/interleaved PT/NT and EX3 legacy/divide-by-i4 corpus cases
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- ./scripts/validate-doc-frontmatter.sh