### PR TITLE
test(corpus): expand exact warning-count locks

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -59,6 +59,9 @@
       "expected_warning_substrings": [
         "EX type 1 is currently treated like EX type 0"
       ],
+      "expected_warning_counts": {
+        "EX type 1 is currently treated like EX type 0": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -83,6 +86,9 @@
       "expected_warning_substrings": [
         "EX type 2 is currently treated like EX type 0"
       ],
+      "expected_warning_counts": {
+        "EX type 2 is currently treated like EX type 0": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -107,6 +113,9 @@
       "expected_warning_substrings": [
         "EX type 4 is currently treated like EX type 0"
       ],
+      "expected_warning_counts": {
+        "EX type 4 is currently treated like EX type 0": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -131,6 +140,9 @@
       "expected_warning_substrings": [
         "EX type 5 is currently treated like EX type 0"
       ],
+      "expected_warning_counts": {
+        "EX type 5 is currently treated like EX type 0": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -155,6 +167,9 @@
       "expected_warning_substrings": [
         "PT card support is currently deferred"
       ],
+      "expected_warning_counts": {
+        "PT card support is currently deferred": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -179,6 +194,9 @@
       "expected_warning_substrings": [
         "NT card support is currently deferred"
       ],
+      "expected_warning_counts": {
+        "NT card support is currently deferred": 1
+      },
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -109,6 +109,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: added corpus case `dipole-ex3-i4-two-freesp-51seg` (legacy mode) to lock EX3 `I4=2` non-default warning semantics on the default runtime path.
 	- 2026-04-28 progress: corpus validation now supports `forbidden_warning_substrings`, and EX3 divide-by-i4 corpus cases now assert the legacy non-default-I4 warning is absent when divide-by-i4 mode is selected.
 	- 2026-04-28 progress: corpus validation now supports `expected_warning_counts`; repeated/interleaved PT/NT and EX3 legacy/divide-by-i4 corpus cases now assert exact warning occurrence counts for stronger warning-contract parity.
+	- 2026-04-28 progress: expanded `expected_warning_counts` corpus locks to single-card EX1/EX2/EX4/EX5 and PT/NT portability cases, enforcing one-warning-per-case contracts across those PAR-003 fixtures.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- expand expected_warning_counts coverage to single-card EX1/EX2/EX4/EX5 and PT/NT corpus cases
- keep warning-contract assertions consistent across PAR-003 staged portability fixtures
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- ./scripts/validate-doc-frontmatter.sh