### PR TITLE
docs(contract): default autonomous continuation on feature branches

### DIFF
--- a/docs/autopilot-operating-contract.md
+++ b/docs/autopilot-operating-contract.md
@@ -27,6 +27,7 @@ Define near-continuous execution rules for autonomous development with minimal i
   - fix/topic
   - docs/topic
 - Lifecycle rule: create a new topic branch immediately after each merge
+- Continuation default: while on a feature branch, continue autonomous implementation, validation, PR, and merge-eligible iteration without waiting for additional prompts unless a hard stop condition is hit
 
 ## Allowed Autonomous Actions
 


### PR DESCRIPTION
## Summary
- update autopilot operating contract with explicit continuation default on feature branches
- document that autonomous implementation/validation/PR iteration should continue until hard-stop conditions

## Validation
- ./scripts/validate-doc-frontmatter.sh