### PR TITLE
test(corpus): expand forbidden warning locks

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -62,6 +62,9 @@
       "expected_warning_counts": {
         "EX type 1 is currently treated like EX type 0": 1
       },
+      "forbidden_warning_substrings": [
+        "not yet supported"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -89,6 +92,9 @@
       "expected_warning_counts": {
         "EX type 2 is currently treated like EX type 0": 1
       },
+      "forbidden_warning_substrings": [
+        "not yet supported"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -116,6 +122,9 @@
       "expected_warning_counts": {
         "EX type 4 is currently treated like EX type 0": 1
       },
+      "forbidden_warning_substrings": [
+        "not yet supported"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -143,6 +152,9 @@
       "expected_warning_counts": {
         "EX type 5 is currently treated like EX type 0": 1
       },
+      "forbidden_warning_substrings": [
+        "not yet supported"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -170,6 +182,9 @@
       "expected_warning_counts": {
         "PT card support is currently deferred": 1
       },
+      "forbidden_warning_substrings": [
+        "unknown card 'PT'"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -197,6 +212,9 @@
       "expected_warning_counts": {
         "NT card support is currently deferred": 1
       },
+      "forbidden_warning_substrings": [
+        "unknown card 'NT'"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -226,6 +244,10 @@
         "PT card support is currently deferred": 1,
         "NT card support is currently deferred": 1
       },
+      "forbidden_warning_substrings": [
+        "unknown card 'PT'",
+        "unknown card 'NT'"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -255,6 +277,10 @@
         "NT card support is currently deferred": 1,
         "PT card support is currently deferred": 1
       },
+      "forbidden_warning_substrings": [
+        "unknown card 'PT'",
+        "unknown card 'NT'"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -284,6 +310,10 @@
         "PT card support is currently deferred": 1,
         "NT card support is currently deferred": 1
       },
+      "forbidden_warning_substrings": [
+        "unknown card 'PT'",
+        "unknown card 'NT'"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90
@@ -313,6 +343,10 @@
         "NT card support is currently deferred": 1,
         "PT card support is currently deferred": 1
       },
+      "forbidden_warning_substrings": [
+        "unknown card 'PT'",
+        "unknown card 'NT'"
+      ],
       "feedpoint_impedance": {
         "real_ohm": 74.23,
         "imag_ohm": 13.90

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -110,6 +110,7 @@ last_updated: 2026-04-24
 	- 2026-04-28 progress: corpus validation now supports `forbidden_warning_substrings`, and EX3 divide-by-i4 corpus cases now assert the legacy non-default-I4 warning is absent when divide-by-i4 mode is selected.
 	- 2026-04-28 progress: corpus validation now supports `expected_warning_counts`; repeated/interleaved PT/NT and EX3 legacy/divide-by-i4 corpus cases now assert exact warning occurrence counts for stronger warning-contract parity.
 	- 2026-04-28 progress: expanded `expected_warning_counts` corpus locks to single-card EX1/EX2/EX4/EX5 and PT/NT portability cases, enforcing one-warning-per-case contracts across those PAR-003 fixtures.
+	- 2026-04-28 progress: expanded `forbidden_warning_substrings` corpus locks across EX1/EX2/EX4/EX5 and PT/NT (single/combo/repeated/interleaved) cases to assert no fallback unsupported/unknown-card warnings leak into staged-portability runs.
 	- 2026-04-28 progress: added CLI warning-contract regression `nt_then_pt_cards_emit_deferred_warnings_and_run_succeeds` to lock PT/NT deferred-warning behavior independent of card order.
 	- 2026-04-28 progress: added corpus regression case `dipole-nt-pt-freesp-51seg` to lock NT-then-PT card-order portability and warning contract in corpus validation CI.
 	- 2026-04-28 progress: added CLI warning-contract regression `repeated_nt_and_pt_cards_emit_deduplicated_warnings_per_family` and corpus case `dipole-nt-pt-repeated-freesp-51seg` to lock deduplicated deferred warnings for repeated reversed-order NT/PT cards.


### PR DESCRIPTION
## Summary
- expand forbidden warning assertions across EX1/EX2/EX4/EX5 and PT/NT staged portability corpus cases
- enforce no unsupported/unknown-card warning regressions for those PAR-003 fixtures
- update PAR-003 backlog progress

## Validation
- cargo fmt
- cargo test -p nec-cli --test corpus_validation -- --nocapture
- ./scripts/validate-doc-frontmatter.sh