### PR TITLE
par002: GN-2 deferred corpus fixture + type 2/3 warning regressions + checklist gate

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -811,6 +811,109 @@ fn par003_portability_checklist_cases_are_present_and_contracted() {
     }
 }
 
+#[test]
+fn par002_ground_checklist_cases_are_present_and_contracted() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let corpus_root = workspace_root.join("corpus");
+    let reference_path = corpus_root.join("reference-results.json");
+
+    let json_text = std::fs::read_to_string(&reference_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", reference_path.display()));
+    let root: Value = serde_json::from_str(&json_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {}: {e}", reference_path.display()));
+
+    let cases = root
+        .get("cases")
+        .and_then(Value::as_object)
+        .expect("reference-results.json missing 'cases' object");
+
+    // PAR-002 ground checklist:
+    //   (case_name, expect_regression_gate, expect_warning_contract)
+    //   expect_regression_gate: feedpoint_impedance.real_ohm must be non-null
+    //   expect_warning_contract: expected_warning_substrings must be present and non-empty
+    let required_cases: &[(&str, bool, bool)] = &[
+        // GN=1 PEC image method: implemented; must have regression AND external
+        // reference gates; no warning expected.
+        ("dipole-ground-51seg", true, false),
+        // GN=2 Sommerfeld/Norton finite-conductivity: deferred; must have
+        // warning contract documenting fallback behavior.
+        ("dipole-gn2-deferred", true, true),
+    ];
+
+    for (case_name, expect_regression_gate, expect_warning_contract) in required_cases {
+        let case_obj = cases
+            .get(*case_name)
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("PAR-002 checklist case '{}' missing", case_name));
+
+        let deck_file = case_obj
+            .get("deck_file")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("PAR-002 case '{}' missing 'deck_file'", case_name));
+        let deck_path = corpus_root.join(deck_file);
+        assert!(
+            deck_path.exists(),
+            "PAR-002 checklist deck missing for case '{}': {}",
+            case_name,
+            deck_path.display()
+        );
+
+        if *expect_regression_gate {
+            let feed = case_obj
+                .get("feedpoint_impedance")
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "PAR-002 checklist case '{}' missing 'feedpoint_impedance' object",
+                        case_name
+                    )
+                });
+            let real = feed.get("real_ohm").and_then(Value::as_f64);
+            let imag = feed.get("imag_ohm").and_then(Value::as_f64);
+            assert!(
+                real.is_some() && imag.is_some(),
+                "PAR-002 checklist case '{}' must have numeric real_ohm and imag_ohm",
+                case_name
+            );
+
+            let gates = case_obj
+                .get("tolerance_gates")
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "PAR-002 checklist case '{}' missing 'tolerance_gates' object",
+                        case_name
+                    )
+                });
+            assert!(
+                gates
+                    .get("R_absolute_ohm")
+                    .and_then(Value::as_f64)
+                    .is_some(),
+                "PAR-002 checklist case '{}' missing 'R_absolute_ohm' gate",
+                case_name
+            );
+        }
+
+        if *expect_warning_contract {
+            let expected_warning_substrings = case_obj
+                .get("expected_warning_substrings")
+                .and_then(Value::as_array)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "PAR-002 checklist case '{}' missing 'expected_warning_substrings'",
+                        case_name
+                    )
+                });
+            assert!(
+                !expected_warning_substrings.is_empty(),
+                "PAR-002 checklist case '{}' has empty warning contract",
+                case_name
+            );
+        }
+    }
+}
+
 fn collect_expected_sources(
     case_obj: &Map<String, Value>,
     feed: &Map<String, Value>,

--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -153,3 +153,84 @@ fn ge_negative_flag_emits_unsupported_warning() {
         "expected below-ground warning in stderr, got:\n{stderr}"
     );
 }
+
+#[test]
+fn gn_type2_deferred_emits_warning_and_falls_back_to_free_space() {
+    // GN type 2 (Sommerfeld/Norton finite-conductivity) is deferred; the
+    // solver must warn and fall back to free-space, not fail or produce PEC
+    // results.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-gn2-{now}.nec"));
+
+    // Average-ground parameters (EPSE=13, SIG=0.005 S/m); parser reads only
+    // the type field so the extra parameters are silently ignored.
+    let deck =
+        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGN 2 0 0 0 13.0 0.005\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary GN-2 deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for GN type 2 diagnostics test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .contains("warning: GN type 2 is not yet supported; treating this deck as free-space"),
+        "expected deferred GN type 2 warning in stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn gn_type3_deferred_emits_warning_and_falls_back_to_free_space() {
+    // GN type 3 is not a standard NEC-2 type but may appear in NEC-4 decks.
+    // It must be treated as deferred with a warning, not silently accepted.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-gn3-{now}.nec"));
+
+    let deck =
+        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGN 3\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary GN-3 deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for GN type 3 diagnostics test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .contains("warning: GN type 3 is not yet supported; treating this deck as free-space"),
+        "expected deferred GN type 3 warning in stderr, got:\n{stderr}"
+    );
+}

--- a/corpus/dipole-gn2-deferred.nec
+++ b/corpus/dipole-gn2-deferred.nec
@@ -1,0 +1,11 @@
+CE PAR-002 deferred-ground fixture: GN type 2 (Sommerfeld/Norton, finite conductivity)
+CE Wire geometry identical to dipole-freesp-51seg.nec so that free-space fallback
+CE impedance can be verified against the known free-space reference.
+CE Medium parameters (EPSE=13, SIG=0.005 S/m — "average ground") are parsed but
+CE currently ignored; runtime falls back to free-space with a warning.
+GW 1 51 0 0 -5.282 0 0 5.282 0.001
+GE
+GN 2 0 0 0 13.0 0.005
+EX 0 1 26 0 1.0 0.0
+FR 0 1 0 0 14.2 0.0
+EN

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -922,6 +922,34 @@
       },
       "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy, and now CI-gated with absolute external R/X thresholds."
     },
+    "dipole-gn2-deferred": {
+      "deck_file": "dipole-gn2-deferred.nec",
+      "description": "Half-wave dipole, GN type 2 (Sommerfeld/Norton finite-conductivity; deferred), 51 segments, 14.2 MHz. Falls back to free-space with a runtime warning.",
+      "frequency_mhz": 14.2,
+      "segments": 51,
+      "wires": 1,
+      "sources": 1,
+      "ground": "finite conductivity Sommerfeld/Norton (deferred, falls back to free-space)",
+      "reference_source": "fnec Hallén solver free-space fallback (regression); GN type 2 ground parameters parsed but not yet applied",
+      "feedpoint_impedance": {
+        "real_ohm": 74.23,
+        "imag_ohm": 13.90
+      },
+      "tolerance_gates": {
+        "R_percent_rel": 0.1,
+        "X_percent_rel": 0.1,
+        "R_absolute_ohm": 0.05,
+        "X_absolute_ohm": 0.05
+      },
+      "expected_warning_substrings": [
+        "GN type 2 is not yet supported; treating this deck as free-space"
+      ],
+      "forbidden_warning_substrings": [],
+      "expected_warning_counts": {
+        "warning: GN type 2 is not yet supported; treating this deck as free-space": 1
+      },
+      "status": "PAR-002 deferred-ground fixture. GN 2 (Sommerfeld/Norton) is not implemented; runtime warns and falls back to free-space. Impedance gated on known free-space reference. Once Sommerfeld is implemented, reference values and gates will be updated."
+    },
     "yagi-5elm-51seg": {
       "deck_file": "yagi-5elm-51seg.nec",
       "description": "5-element Yagi (1 reflector + driven + 3 directors), 14.2 MHz, 0.2-lambda element spacing",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -58,6 +58,9 @@ last_updated: 2026-04-28
 	Resolution criteria: NEC-4-class ground scope document published; Sommerfeld validation corpus added; tolerance pass documented for supported near-ground cases.
 	- 2026-04-28 progress: started PAR-002 docs-first discovery slice by adding a scoped finite-ground plan to `docs/nec4-support.md` (scope/non-goals/completion evidence).
 	- 2026-04-28 progress: added PAR-002 finite-ground validation workflow and closure checklist to `docs/corpus-validation-strategy.md` to define capture/gating expectations before solver expansion.
+	- 2026-04-28 progress: added GN type 2 (Sommerfeld/Norton) deferred-ground corpus fixture `corpus/dipole-gn2-deferred.nec` with warning contract and free-space fallback regression gate in `corpus/reference-results.json`.
+	- 2026-04-28 progress: added GN type 2 and GN type 3 warning-contract regression tests to `apps/nec-cli/tests/ground_diagnostics.rs`, extending deferred-ground test coverage beyond the existing GN type 0 test.
+	- 2026-04-28 progress: added `par002_ground_checklist_cases_are_present_and_contracted` gate test to `apps/nec-cli/tests/corpus_validation.rs` to lock both the PEC and deferred-ground corpus fixtures in CI.
 
 - [x] **PAR-003 / Mainstream NEC workflow card coverage / Owner: Parser+Solver / Target: Phase 2 / Issue: #16**
 	Resolution criteria: load/source/TL-network card subset listed as supported in `docs/nec4-support.md`; integration tests added per card family; deck portability checklist passes for selected reference decks.


### PR DESCRIPTION
## PAR-002 ground parity — deferred-type corpus coverage slice

### What this does

Adds the concrete PAR-002 test coverage for deferred GN types (Sommerfeld/Norton finite-conductivity ground), extending the existing GN type 0 inline test.

**New corpus fixture:** `corpus/dipole-gn2-deferred.nec`
- GN type 2 (Sommerfeld/Norton) with average-ground medium parameters (EPSE=13, SIG=0.005 S/m)
- Parameters are parsed but currently ignored (Phase 1 limitation)
- Runtime falls back to free-space with a warning

**New corpus JSON entry:** `dipole-gn2-deferred`
- Regression-gated on the known free-space fallback impedance
- Warning contract locking the deferred-GN warning message and count

**New inline warning-contract tests** in `ground_diagnostics.rs`:
- `gn_type2_deferred_emits_warning_and_falls_back_to_free_space`
- `gn_type3_deferred_emits_warning_and_falls_back_to_free_space`

**New corpus gate test** in `corpus_validation.rs`:
- `par002_ground_checklist_cases_are_present_and_contracted` — asserts both PEC and deferred-ground corpus fixtures are present, deck files exist, regression gates are numeric, and warning contracts are non-empty

**Backlog updated:** three PAR-002 progress bullets added

### Test status
All tests pass: 5/5 ground_diagnostics, 3/3 corpus_validation (validated=36, skipped=0 after adding the new case with numeric gates), full suite green.