### PR TITLE
par002: parse GN medium parameters (eps_r/sigma) and surface in deferred warning

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -645,10 +645,23 @@ fn find_or_insert_node(
 }
 
 fn warn_deferred_ground_model(ground: &GroundModel) {
-    let GroundModel::Deferred { gn_type } = ground else {
+    let GroundModel::Deferred {
+        gn_type,
+        eps_r,
+        sigma,
+    } = ground
+    else {
         return;
     };
-    eprintln!("warning: GN type {gn_type} is not yet supported; treating this deck as free-space");
+    let params = match (eps_r, sigma) {
+        (Some(e), Some(s)) => format!(" [parsed: EPSE={e}, SIG={s} S/m]"),
+        (Some(e), None) => format!(" [parsed: EPSE={e}]"),
+        (None, Some(s)) => format!(" [parsed: SIG={s} S/m]"),
+        (None, None) => String::new(),
+    };
+    eprintln!(
+        "warning: GN type {gn_type} is not yet supported; treating this deck as free-space{params}"
+    );
 }
 
 fn warn_ge_ground_reflection_flag(deck: &nec_model::deck::NecDeck) {

--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -166,8 +166,8 @@ fn gn_type2_deferred_emits_warning_and_falls_back_to_free_space() {
         .as_nanos();
     let deck_path = std::env::temp_dir().join(format!("fnec-gn2-{now}.nec"));
 
-    // Average-ground parameters (EPSE=13, SIG=0.005 S/m); parser reads only
-    // the type field so the extra parameters are silently ignored.
+    // Average-ground parameters (EPSE=13, SIG=0.005 S/m); the parser now reads
+    // and stores these fields, and the CLI warning appends them.
     let deck =
         "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGN 2 0 0 0 13.0 0.005\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
     fs::write(&deck_path, deck).expect("failed to write temporary GN-2 deck");
@@ -232,5 +232,43 @@ fn gn_type3_deferred_emits_warning_and_falls_back_to_free_space() {
         stderr
             .contains("warning: GN type 3 is not yet supported; treating this deck as free-space"),
         "expected deferred GN type 3 warning in stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn gn_type2_warning_includes_parsed_medium_params() {
+    // When a GN card includes medium parameters (EPSE, SIG), the deferred
+    // warning must append them so the user sees what was parsed.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-gn2-params-{now}.nec"));
+
+    let deck =
+        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGN 2 0 0 0 13.0 0.005\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary GN-2 params deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for GN medium params test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[parsed: EPSE=13, SIG=0.005 S/m]"),
+        "expected medium params in deferred warning, got:\n{stderr}"
     );
 }

--- a/crates/nec_model/src/card.rs
+++ b/crates/nec_model/src/card.rs
@@ -106,8 +106,6 @@ pub struct RpCard {
 /// GN — Ground definition card.
 ///
 /// Specifies the electrical ground model below the antenna geometry.
-/// Only the first integer field (ground type) is stored in Phase 1.
-/// Future phases can extend this struct with conductivity and permittivity.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GnCard {
     /// Ground type:
@@ -116,6 +114,16 @@ pub struct GnCard {
     ///    1 = perfect electric conductor (image method)
     ///    2 = finite conductivity Sommerfeld/Norton (deferred Phase 2)
     pub ground_type: i32,
+    /// Relative dielectric constant (EPSE field), if specified on the card.
+    ///
+    /// Present when the GN card includes medium parameters (typically GN type
+    /// 0 or 2). `None` for bare cards such as `GN 1` or `GN 0`.
+    pub eps_r: Option<f64>,
+    /// Conductivity in S/m (SIG field), if specified on the card.
+    ///
+    /// Present alongside `eps_r` when the GN card specifies a finite-ground
+    /// medium. `None` for bare cards.
+    pub sigma: Option<f64>,
 }
 
 /// EN — End-of-data card.  Signals the end of a NEC deck.

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -204,8 +204,24 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
             "GN" => {
                 let fields = parse_fields(rest);
                 require_fields(lineno, "GN", &fields, 1)?;
+                // GN I1 NRADL I3 I4 EPSE SIG
+                // Fields 0-3 are integer fields (I1, NRADL, I3, I4).
+                // Fields 4 and 5 (EPSE, SIG) are optional medium parameters
+                // used with GN types 0 and 2.
+                let eps_r = if fields.len() > 4 {
+                    Some(parse_f64(lineno, "GN", 5, &fields[4])?)
+                } else {
+                    None
+                };
+                let sigma = if fields.len() > 5 {
+                    Some(parse_f64(lineno, "GN", 6, &fields[5])?)
+                } else {
+                    None
+                };
                 deck.cards.push(Card::Gn(GnCard {
                     ground_type: parse_i32(lineno, "GN", 1, &fields[0])?,
+                    eps_r,
+                    sigma,
                 }));
             }
             "LD" => {
@@ -593,7 +609,48 @@ EN
             }
         });
         assert!(gn_card.is_some(), "GN card not found in deck");
-        assert_eq!(gn_card.unwrap().ground_type, 1);
+        let gn = gn_card.unwrap();
+        assert_eq!(gn.ground_type, 1);
+        assert_eq!(gn.eps_r, None, "bare GN 1 should have no eps_r");
+        assert_eq!(gn.sigma, None, "bare GN 1 should have no sigma");
+    }
+
+    #[test]
+    fn gn_card_with_medium_params_parses_eps_r_and_sigma() {
+        // GN 2 0 0 0 13.0 0.005 — average-ground parameters (EPSE=13, SIG=0.005 S/m)
+        let input =
+            "GW 1 3 0 0 1 0 0 4 0.001\nGN 2 0 0 0 13.0 0.005\nEX 0 1 2 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+        let gn_card = result.deck.cards.iter().find_map(|c| {
+            if let Card::Gn(g) = c {
+                Some(g.clone())
+            } else {
+                None
+            }
+        });
+        let gn = gn_card.expect("GN card not found");
+        assert_eq!(gn.ground_type, 2);
+        assert_eq!(gn.eps_r, Some(13.0));
+        assert_eq!(gn.sigma, Some(0.005));
+    }
+
+    #[test]
+    fn gn_card_without_medium_params_uses_none() {
+        // Bare GN 0 with no medium parameters — eps_r and sigma must be None
+        let input = "GW 1 3 0 0 1 0 0 4 0.001\nGN 0\nEX 0 1 2 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        let gn_card = result.deck.cards.iter().find_map(|c| {
+            if let Card::Gn(g) = c {
+                Some(g.clone())
+            } else {
+                None
+            }
+        });
+        let gn = gn_card.expect("GN card not found");
+        assert_eq!(gn.ground_type, 0);
+        assert_eq!(gn.eps_r, None);
+        assert_eq!(gn.sigma, None);
     }
 
     #[test]

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -16,7 +16,7 @@
 //! - `tag_index`     — 1-based segment index within the tag
 //! - `global_index`  — 0-based index in the flat segment list
 
-use nec_model::card::{Card, GeCard, GmCard, GnCard, GrCard, GwCard};
+use nec_model::card::{Card, GeCard, GmCard, GrCard, GwCard};
 use nec_model::deck::NecDeck;
 
 /// Ground model extracted from a GN card (or absence thereof).
@@ -34,7 +34,13 @@ pub enum GroundModel {
     ///
     /// The current Phase-1 behavior is to fall back to free-space while
     /// emitting a runtime warning in the CLI.
-    Deferred { gn_type: i32 },
+    Deferred {
+        gn_type: i32,
+        /// Relative dielectric constant (EPSE) from the GN card, if present.
+        eps_r: Option<f64>,
+        /// Conductivity in S/m (SIG) from the GN card, if present.
+        sigma: Option<f64>,
+    },
 }
 
 /// Extract the ground model from a parsed deck.
@@ -50,10 +56,14 @@ pub enum GroundModel {
 pub fn ground_model_from_deck(deck: &NecDeck) -> GroundModel {
     // GN card takes priority.
     for card in &deck.cards {
-        if let Card::Gn(GnCard { ground_type }) = card {
-            return match ground_type {
+        if let Card::Gn(gn) = card {
+            return match gn.ground_type {
                 1 => GroundModel::PerfectConductor,
-                other => GroundModel::Deferred { gn_type: *other },
+                other => GroundModel::Deferred {
+                    gn_type: other,
+                    eps_r: gn.eps_r,
+                    sigma: gn.sigma,
+                },
             };
         }
     }
@@ -490,27 +500,65 @@ mod tests {
     #[test]
     fn ground_model_detects_perfect_conductor_gn1() {
         let mut deck = NecDeck::new();
-        deck.cards.push(Card::Gn(GnCard { ground_type: 1 }));
+        deck.cards.push(Card::Gn(GnCard {
+            ground_type: 1,
+            eps_r: None,
+            sigma: None,
+        }));
         assert_eq!(ground_model_from_deck(&deck), GroundModel::PerfectConductor);
     }
 
     #[test]
     fn ground_model_marks_gn0_as_deferred() {
         let mut deck = NecDeck::new();
-        deck.cards.push(Card::Gn(GnCard { ground_type: 0 }));
+        deck.cards.push(Card::Gn(GnCard {
+            ground_type: 0,
+            eps_r: None,
+            sigma: None,
+        }));
         assert_eq!(
             ground_model_from_deck(&deck),
-            GroundModel::Deferred { gn_type: 0 }
+            GroundModel::Deferred {
+                gn_type: 0,
+                eps_r: None,
+                sigma: None,
+            }
         );
     }
 
     #[test]
     fn ground_model_marks_gn2_as_deferred() {
         let mut deck = NecDeck::new();
-        deck.cards.push(Card::Gn(GnCard { ground_type: 2 }));
+        deck.cards.push(Card::Gn(GnCard {
+            ground_type: 2,
+            eps_r: None,
+            sigma: None,
+        }));
         assert_eq!(
             ground_model_from_deck(&deck),
-            GroundModel::Deferred { gn_type: 2 }
+            GroundModel::Deferred {
+                gn_type: 2,
+                eps_r: None,
+                sigma: None,
+            }
+        );
+    }
+
+    #[test]
+    fn ground_model_carries_medium_params_from_gn_card() {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gn(GnCard {
+            ground_type: 2,
+            eps_r: Some(13.0),
+            sigma: Some(0.005),
+        }));
+        assert_eq!(
+            ground_model_from_deck(&deck),
+            GroundModel::Deferred {
+                gn_type: 2,
+                eps_r: Some(13.0),
+                sigma: Some(0.005),
+            }
         );
     }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -61,6 +61,10 @@ last_updated: 2026-04-28
 	- 2026-04-28 progress: added GN type 2 (Sommerfeld/Norton) deferred-ground corpus fixture `corpus/dipole-gn2-deferred.nec` with warning contract and free-space fallback regression gate in `corpus/reference-results.json`.
 	- 2026-04-28 progress: added GN type 2 and GN type 3 warning-contract regression tests to `apps/nec-cli/tests/ground_diagnostics.rs`, extending deferred-ground test coverage beyond the existing GN type 0 test.
 	- 2026-04-28 progress: added `par002_ground_checklist_cases_are_present_and_contracted` gate test to `apps/nec-cli/tests/corpus_validation.rs` to lock both the PEC and deferred-ground corpus fixtures in CI.
+	- 2026-04-28 progress: extended `nec_model::card::GnCard` with `eps_r: Option<f64>` and `sigma: Option<f64>` fields; updated parser to read EPSE/SIG medium-parameter fields from GN cards (e.g. `GN 2 0 0 0 13.0 0.005`).
+	- 2026-04-28 progress: updated `nec_solver::geometry::GroundModel::Deferred` to carry `eps_r` and `sigma` from the parsed GN card; updated `ground_model_from_deck()` to pass them through.
+	- 2026-04-28 progress: updated CLI `warn_deferred_ground_model()` to append parsed medium parameters to the deferred-ground warning (e.g. `[parsed: EPSE=13, SIG=0.005 S/m]`) when present.
+	- 2026-04-28 progress: added parser tests `gn_card_with_medium_params_parses_eps_r_and_sigma` and `gn_card_without_medium_params_uses_none`; added geometry test `ground_model_carries_medium_params_from_gn_card`; added CLI integration test `gn_type2_warning_includes_parsed_medium_params`.
 
 - [x] **PAR-003 / Mainstream NEC workflow card coverage / Owner: Parser+Solver / Target: Phase 2 / Issue: #16**
 	Resolution criteria: load/source/TL-network card subset listed as supported in `docs/nec4-support.md`; integration tests added per card family; deck portability checklist passes for selected reference decks.


### PR DESCRIPTION
## PAR-002 ground parity — GN medium parameter parsing

### What this does

Extends the NEC ground-card parsing pipeline to capture and preserve EPSE/SIG medium parameters from GN cards, and surfaces them in the runtime deferred-ground warning.

**`nec_model::card::GnCard`**: two new fields added
- `eps_r: Option<f64>` — relative dielectric constant (EPSE)
- `sigma: Option<f64>` — conductivity in S/m (SIG)
- Bare cards (`GN 1`, `GN 0`) keep both as `None`; cards with medium parameters (e.g. `GN 2 0 0 0 13.0 0.005`) store them

**`nec_parser`**: GN parsing updated to read EPSE (field 5) and SIG (field 6) when present

**`nec_solver::geometry::GroundModel::Deferred`**: `eps_r` and `sigma` fields added; `ground_model_from_deck()` passes them through from the parsed card

**CLI `warn_deferred_ground_model()`**: when medium parameters are present, the warning now appends:
```
warning: GN type 2 is not yet supported; treating this deck as free-space [parsed: EPSE=13, SIG=0.005 S/m]
```
The base message is unchanged so all existing `contains()`-based warning contracts continue to pass.

**New tests:**
- Parser: `gn_card_with_medium_params_parses_eps_r_and_sigma`, `gn_card_without_medium_params_uses_none`
- Geometry: `ground_model_carries_medium_params_from_gn_card`
- CLI integration: `gn_type2_warning_includes_parsed_medium_params`

### Why this matters

This is the data-pipeline foundation for future Sommerfeld/finite-conductivity ground implementation. The medium parameters are now stored through the full model→solver path, ready for use when reflection coefficients are computed.

### Test status
All 6/6 ground_diagnostics, 3/3 corpus_validation, and full suite green.