### PR TITLE
par002: fix GN -1 null-ground → FreeSpace (silent), add corpus fixture and gate tests

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -828,19 +828,24 @@ fn par002_ground_checklist_cases_are_present_and_contracted() {
         .expect("reference-results.json missing 'cases' object");
 
     // PAR-002 ground checklist:
-    //   (case_name, expect_regression_gate, expect_warning_contract)
+    //   (case_name, expect_regression_gate, expect_warning_contract, expect_forbidden_contract)
     //   expect_regression_gate: feedpoint_impedance.real_ohm must be non-null
     //   expect_warning_contract: expected_warning_substrings must be present and non-empty
-    let required_cases: &[(&str, bool, bool)] = &[
-        // GN=1 PEC image method: implemented; must have regression AND external
-        // reference gates; no warning expected.
-        ("dipole-ground-51seg", true, false),
+    //   expect_forbidden_contract: forbidden_warning_substrings must be present and non-empty
+    let required_cases: &[(&str, bool, bool, bool)] = &[
+        // GN=1 PEC image method: implemented; must have regression gate; no warning expected.
+        ("dipole-ground-51seg", true, false, false),
         // GN=2 Sommerfeld/Norton finite-conductivity: deferred; must have
         // warning contract documenting fallback behavior.
-        ("dipole-gn2-deferred", true, true),
+        ("dipole-gn2-deferred", true, true, false),
+        // GN=-1 null ground: maps to free-space silently; must have a
+        // forbidden-warning contract ensuring no deferred-ground warning fires.
+        ("dipole-gn-1-null", true, false, true),
     ];
 
-    for (case_name, expect_regression_gate, expect_warning_contract) in required_cases {
+    for (case_name, expect_regression_gate, expect_warning_contract, expect_forbidden_contract) in
+        required_cases
+    {
         let case_obj = cases
             .get(*case_name)
             .and_then(Value::as_object)
@@ -908,6 +913,23 @@ fn par002_ground_checklist_cases_are_present_and_contracted() {
             assert!(
                 !expected_warning_substrings.is_empty(),
                 "PAR-002 checklist case '{}' has empty warning contract",
+                case_name
+            );
+        }
+
+        if *expect_forbidden_contract {
+            let forbidden_warning_substrings = case_obj
+                .get("forbidden_warning_substrings")
+                .and_then(Value::as_array)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "PAR-002 checklist case '{}' missing 'forbidden_warning_substrings'",
+                        case_name
+                    )
+                });
+            assert!(
+                !forbidden_warning_substrings.is_empty(),
+                "PAR-002 checklist case '{}' has empty forbidden-warning contract",
                 case_name
             );
         }

--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -272,3 +272,61 @@ fn gn_type2_warning_includes_parsed_medium_params() {
         "expected medium params in deferred warning, got:\n{stderr}"
     );
 }
+
+#[test]
+fn gn_negative1_null_ground_is_silent_free_space() {
+    // GN -1 cancels a previous GN statement (NEC spec §3.3); when it is the
+    // only GN card the solver must treat it as free-space WITHOUT emitting the
+    // deferred-ground warning.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-gn-neg1-{now}.nec"));
+
+    let deck =
+        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGN -1\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary GN -1 deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for GN -1 test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("warning: GN type -1 is not yet supported"),
+        "GN -1 should NOT emit a deferred-ground warning, got:\n{stderr}"
+    );
+
+    // GN -1 should produce free-space results matching the free-space dipole.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let z_re = stdout
+        .lines()
+        .find_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 8 && parts[0] == "1" && parts[1] == "26" {
+                parts[6].parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .expect("no feedpoint row in output");
+
+    assert!(
+        (z_re - 74.23).abs() < 0.1,
+        "Z_RE mismatch for GN -1 deck: got {z_re}, expected ~74.23 (free-space)"
+    );
+}

--- a/corpus/dipole-gn-1-null.nec
+++ b/corpus/dipole-gn-1-null.nec
@@ -1,0 +1,8 @@
+CE Half-wave dipole with GN -1 (null ground — cancel previous GN)
+CE GN -1 is treated as free-space per NEC spec §3.3.
+GW 1 51 0 0 -5.282 0 0 5.282 0.001
+GE
+GN -1
+EX 0 1 26 0 1.0 0.0
+FR 0 1 0 0 14.2 0.0
+EN

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -950,6 +950,32 @@
       },
       "status": "PAR-002 deferred-ground fixture. GN 2 (Sommerfeld/Norton) is not implemented; runtime warns and falls back to free-space. Impedance gated on known free-space reference. Once Sommerfeld is implemented, reference values and gates will be updated."
     },
+    "dipole-gn-1-null": {
+      "deck_file": "dipole-gn-1-null.nec",
+      "description": "Half-wave dipole, GN -1 (null ground — cancels previous GN per NEC spec §3.3), 51 segments, 14.2 MHz. Must produce free-space results with NO deferred-ground warning.",
+      "frequency_mhz": 14.2,
+      "segments": 51,
+      "wires": 1,
+      "sources": 1,
+      "ground": "none (GN -1 null ground → free-space)",
+      "reference_source": "fnec Hallén solver free-space (regression; GN -1 treated as free-space per NEC spec)",
+      "feedpoint_impedance": {
+        "real_ohm": 74.23,
+        "imag_ohm": 13.90
+      },
+      "tolerance_gates": {
+        "R_percent_rel": 0.1,
+        "X_percent_rel": 0.1,
+        "R_absolute_ohm": 0.05,
+        "X_absolute_ohm": 0.05
+      },
+      "expected_warning_substrings": [],
+      "forbidden_warning_substrings": [
+        "GN type -1 is not yet supported"
+      ],
+      "expected_warning_counts": {},
+      "status": "PAR-002 GN -1 null-ground correctness fixture. GN -1 must map to FreeSpace silently; no deferred-ground warning should be emitted."
+    },
     "yagi-5elm-51seg": {
       "deck_file": "yagi-5elm-51seg.nec",
       "description": "5-element Yagi (1 reflector + driven + 3 directors), 14.2 MHz, 0.2-lambda element spacing",

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -47,6 +47,7 @@ pub enum GroundModel {
 ///
 /// Resolution order:
 /// 1. If a `GN` card is present it takes priority.
+///    - `GN -1` → [`GroundModel::FreeSpace`] (null ground; equivalent to no GN card).
 ///    - `GN 1`  → [`GroundModel::PerfectConductor`].
 ///    - Other GN types → [`GroundModel::Deferred`].
 /// 2. If no `GN` card is present but a `GE` card has `ground_reflection_flag > 0`
@@ -58,6 +59,9 @@ pub fn ground_model_from_deck(deck: &NecDeck) -> GroundModel {
     for card in &deck.cards {
         if let Card::Gn(gn) = card {
             return match gn.ground_type {
+                // -1 = null ground: NEC spec says this is equivalent to no
+                // GN card — treat as free-space without emitting a warning.
+                -1 => GroundModel::FreeSpace,
                 1 => GroundModel::PerfectConductor,
                 other => GroundModel::Deferred {
                     gn_type: other,
@@ -542,6 +546,19 @@ mod tests {
                 sigma: None,
             }
         );
+    }
+
+    #[test]
+    fn ground_model_gn_negative1_returns_free_space() {
+        // GN -1 is the NEC "null ground" card — it cancels a previous GN
+        // statement and should produce FreeSpace with no warning.
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gn(GnCard {
+            ground_type: -1,
+            eps_r: None,
+            sigma: None,
+        }));
+        assert_eq!(ground_model_from_deck(&deck), GroundModel::FreeSpace);
     }
 
     #[test]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -65,6 +65,7 @@ last_updated: 2026-04-28
 	- 2026-04-28 progress: updated `nec_solver::geometry::GroundModel::Deferred` to carry `eps_r` and `sigma` from the parsed GN card; updated `ground_model_from_deck()` to pass them through.
 	- 2026-04-28 progress: updated CLI `warn_deferred_ground_model()` to append parsed medium parameters to the deferred-ground warning (e.g. `[parsed: EPSE=13, SIG=0.005 S/m]`) when present.
 	- 2026-04-28 progress: added parser tests `gn_card_with_medium_params_parses_eps_r_and_sigma` and `gn_card_without_medium_params_uses_none`; added geometry test `ground_model_carries_medium_params_from_gn_card`; added CLI integration test `gn_type2_warning_includes_parsed_medium_params`.
+	- 2026-04-28 progress: fixed GN -1 (null ground) to map to `GroundModel::FreeSpace` without emitting a deferred-ground warning; added geometry unit test `ground_model_gn_negative1_returns_free_space`, CLI integration test `gn_negative1_null_ground_is_silent_free_space`, corpus fixture `corpus/dipole-gn-1-null.nec`, and `corpus/reference-results.json` entry with forbidden-warning contract; extended PAR-002 checklist gate to include the GN -1 case with `expect_forbidden_contract`.
 
 - [x] **PAR-003 / Mainstream NEC workflow card coverage / Owner: Parser+Solver / Target: Phase 2 / Issue: #16**
 	Resolution criteria: load/source/TL-network card subset listed as supported in `docs/nec4-support.md`; integration tests added per card family; deck portability checklist passes for selected reference decks.


### PR DESCRIPTION
## Summary

Fixes GN -1 (null-ground card) to map to `GroundModel::FreeSpace` without emitting a deferred-ground warning. Previously GN -1 fell through to `Deferred { gn_type: -1 }` which triggered a spurious warning.

Per NEC spec §3.3, GN -1 cancels a previous GN statement and is equivalent to no GN card (i.e. free-space).

## Changes

- **`crates/nec_solver/src/geometry.rs`**: Added `-1 => GroundModel::FreeSpace` match arm in `ground_model_from_deck()` before the existing arms; updated doc comment. Added unit test `ground_model_gn_negative1_returns_free_space`.
- **`apps/nec-cli/tests/ground_diagnostics.rs`**: Added CLI integration test `gn_negative1_null_ground_is_silent_free_space` — verifies no warning emitted and free-space impedance is produced.
- **`corpus/dipole-gn-1-null.nec`**: New corpus fixture — half-wave dipole with GN -1 null ground.
- **`corpus/reference-results.json`**: New entry `dipole-gn-1-null` with free-space impedance gate and `forbidden_warning_substrings` contract.
- **`apps/nec-cli/tests/corpus_validation.rs`**: Extended PAR-002 checklist gate to a 4-tuple including `expect_forbidden_contract`; added GN -1 case with forbidden-warning contract validation.
- **`docs/backlog.md`**: Progress bullet for this slice.