### PR TITLE
corpus: tighten external impedance gates (actual delta + 10-15% headroom)

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -917,10 +917,10 @@
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
-        "ExternalR_absolute_ohm": 10.0,
+        "ExternalR_absolute_ohm": 8.0,
         "ExternalX_absolute_ohm": 30.0
       },
-      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy, and now CI-gated with absolute external R/X thresholds."
+      "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy, and now CI-gated with absolute external R/X thresholds. ExternalR gate tightened 10→8 on 2026-04-29 (actual |dR|=7.12)."
     },
     "dipole-gn2-deferred": {
       "deck_file": "dipole-gn2-deferred.nec",
@@ -999,10 +999,10 @@
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
-        "ExternalR_absolute_ohm": 30.0,
-        "ExternalX_absolute_ohm": 70.0
+        "ExternalR_absolute_ohm": 25.0,
+        "ExternalX_absolute_ohm": 55.0
       },
-      "status": "Regression reference captured from corrected fnec multi-wire Hallen implementation; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy and now CI-gated with conservative absolute external R/X thresholds for incremental parity tightening."
+      "status": "Regression reference captured from corrected fnec multi-wire Hallen implementation; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy and now CI-gated with absolute external R/X thresholds. Gates tightened 30/70→25/55 on 2026-04-29 (actual |dR|=22.45, |dX|=51.52)."
     },
     "dipole-ld-loaded-51seg": {
       "deck_file": "dipole-ld-loaded-51seg.nec",
@@ -1097,10 +1097,10 @@
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
-        "ExternalR_absolute_ohm": 5.0,
-        "ExternalX_absolute_ohm": 20.0
+        "ExternalR_absolute_ohm": 4.0,
+        "ExternalX_absolute_ohm": 16.0
       },
-      "status": "Regression lock for TL execution subset (type 0, NSEG=1; explicit or segment=0-mapped endpoints). External candidate now also CI-gated with conservative absolute R/X thresholds for incremental parity tightening."
+      "status": "Regression lock for TL execution subset (type 0, NSEG=1; explicit or segment=0-mapped endpoints). External candidate now CI-gated with absolute R/X thresholds. Gates tightened 5/20→4/16 on 2026-04-29 (actual |dR|=3.65, |dX|=14.49)."
     },
     "tl-two-dipoles-linked-seg0": {
       "deck_file": "tl-two-dipoles-linked-seg0.nec",
@@ -1221,10 +1221,10 @@
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
-        "ExternalR_absolute_ohm": 15.0,
-        "ExternalX_absolute_ohm": 50.0
+        "ExternalR_absolute_ohm": 14.0,
+        "ExternalX_absolute_ohm": 47.0
       },
-      "status": "fnec now solves all FR points and CI-gates the full sweep using Hallen regression values. External NEC2DXS500+XQ candidates are now also gated with absolute external R/X thresholds for parity tightening."
+      "status": "fnec now solves all FR points and CI-gates the full sweep using Hallen regression values. External NEC2DXS500+XQ candidates are now gated with absolute external R/X thresholds. Gates tightened 15/50→14/47 on 2026-04-29 (actual max |dR|=12.34, max |dX|=45.92)."
     },
     "multi-source": {
       "deck_file": "multi-source.nec",
@@ -1249,10 +1249,10 @@
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
-        "ExternalR_absolute_ohm": 15.0,
-        "ExternalX_absolute_ohm": 50.0
+        "ExternalR_absolute_ohm": 12.0,
+        "ExternalX_absolute_ohm": 40.0
       },
-      "status": "Regression reference captured from fnec for both feedpoints; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy and now CI-gated with conservative absolute external R/X thresholds for incremental parity tightening."
+      "status": "Regression reference captured from fnec for both feedpoints; external candidate captured via nec2c 1.3.1 with XQ-appended deck copy and now CI-gated with absolute external R/X thresholds. Gates tightened 15/50→12/40 on 2026-04-29 (actual |dR|=10.85, |dX|=36.97)."
     },
     "multi-source-gr-180": {
       "deck_file": "multi-source-gr-180.nec",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -131,6 +131,7 @@ last_updated: 2026-04-28
 	- 2026-04-28 progress: enabled external impedance candidate gates for `tl-two-dipoles-linked` with conservative thresholds (`ExternalR_absolute_ohm=5.0`, `ExternalX_absolute_ohm=20.0`) as external-impedance gate seed-2.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `multi-source` with conservative thresholds (`ExternalR_absolute_ohm=15.0`, `ExternalX_absolute_ohm=50.0`) as external-impedance gate seed-3.
 	- 2026-04-28 progress: enabled external impedance candidate gates for `yagi-5elm-51seg` with conservative thresholds (`ExternalR_absolute_ohm=30.0`, `ExternalX_absolute_ohm=70.0`) as external-impedance gate seed-5.
+	- 2026-04-29 progress: tightened external impedance gates across 5 corpus cases based on actual solver-vs-nec2c deltas (10-15% headroom): `dipole-ground-51seg` R 10→8; `yagi-5elm-51seg` R/X 30/70→25/55; `tl-two-dipoles-linked` R/X 5/20→4/16; `frequency-sweep-dipole` R/X 15/50→14/47; `multi-source` R/X 15/50→12/40. `dipole-ld-loaded-51seg` unchanged (large known gap).
 	- 2026-04-27 progress: added corpus validation case `tl-two-dipoles-linked` (`corpus/tl-two-dipoles-linked.nec`) to lock TL subset behavior in CI, with a first `nec2c` external impedance candidate captured for parity tracking.
 
 - [ ] **PAR-004 / xnec2c-style workbench parity / Owner: GUI+CLI / Target: Phase 3 / Issue: #17**


### PR DESCRIPTION
Tighten External\* tolerance gates on 5 corpus cases to reflect actual solver-vs-nec2c deltas with ~10-15% headroom, replacing the original conservative seed values.

| Case | R before | R after | X before | X after | actual max \|dR\| | actual max \|dX\| |
|---|---|---|---|---|---|---|
| dipole-ground-51seg | 10 | 8 | 30 | 30 | 7.12 | 27.53 |
| yagi-5elm-51seg | 30 | 25 | 70 | 55 | 22.45 | 51.52 |
| tl-two-dipoles-linked | 5 | 4 | 20 | 16 | 3.65 | 14.49 |
| frequency-sweep-dipole | 15 | 14 | 50 | 47 | 12.34 | 45.92 |
| multi-source | 15 | 12 | 50 | 40 | 10.85 | 36.97 |

dipole-ld-loaded-51seg not touched (large known gap, ~6293/1382 Ω discrepancy).