### PR TITLE
corpus: tighten external RP gain gates based on actual fnec-vs-nec2c deltas

### DIFF
--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -708,10 +708,10 @@
         "X_absolute_ohm": 0.05,
         "Gain_absolute_dB": 0.05,
         "AxialRatio_absolute": 0.0001,
-        "ExternalGain_absolute_dB": 0.1,
+        "ExternalGain_absolute_dB": 0.08,
         "ExternalAxialRatio_absolute": 0.0001
       },
-      "status": "Regression reference locks RP execution path and radiation-pattern table contract; nec2c external pattern samples captured for parity tracking"
+      "status": "Regression reference locks RP execution path and radiation-pattern table contract; nec2c external pattern samples captured for parity tracking. ExternalGain gate tightened 0.1→0.08 on 2026-04-29 (actual max |dGain|=0.068)."
     },
     "dipole-xaxis-rp-grid-51seg": {
       "deck_file": "dipole-xaxis-rp-grid-51seg.nec",
@@ -868,10 +868,11 @@
         "X_absolute_ohm": 0.05,
         "Gain_absolute_dB": 0.05,
         "AxialRatio_absolute": 0.0001,
-        "ExternalGain_absolute_dB": 0.1,
+        "ExternalGain_absolute_dB": 0.04,
         "ExternalAxialRatio_absolute": 0.0001
       },
-      "status": "Regression reference locks multi-phi RP table support on a non-z-axis dipole; nec2c external pattern samples captured for parity tracking"
+      "status": "Regression reference locks multi-phi RP table support on a non-z-axis dipole; nec2c external pattern samples captured for parity tracking. ExternalGain gate tightened 0.1→0.04 on 2026-04-29 (actual max |dGain|=0.034)."
+
     },
     "dipole-freesp-gm-inplace-shifted": {
       "deck_file": "dipole-freesp-gm-inplace-shifted.nec",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/backlog.md
 status: living
-last_updated: 2026-04-28
+last_updated: 2026-04-29
 ---
 
 # Backlog
@@ -47,6 +47,8 @@ last_updated: 2026-04-28
 	- 2026-04-26 progress: `DispatchDecision::RunOnGpu` is now handled non-fatally in CLI hybrid and gpu execution flows via an accelerator stub branch (`FNEC_ACCEL_STUB_GPU=1`) that preserves report/diag contracts while using CPU emulation.
 	- 2026-04-26 progress: first concrete GPU kernel scaffold landed (`nec_accel::gpu_kernels::HallenFrGpuKernel`) with Hallen far-field radiation pattern computation stubs. Module provides GPU-compatible data layouts and API surface for future CUDA/OpenCL kernel implementations, complete with unit tests (8) and integration test suite (6) validating dipole patterns, multi-segment arrays, azimuth symmetry, and numerical edge cases.
 	- 2026-04-27 progress: native CLI startup now auto-selects execution mode when `--exec` is omitted by running a quick startup probe and choosing the most suitable available mode (`cpu`/`hybrid`/`gpu`) for current frequency sweep shape and dispatch availability.
+	- 2026-04-29 progress: tightened external impedance gates for 5 corpus cases (`dipole-ground-51seg` R 10→8, `yagi-5elm-51seg` R/X 30/70→25/55, `tl-two-dipoles-linked` R/X 5/20→4/16, `frequency-sweep-dipole` R/X 15/50→14/47, `multi-source` R/X 15/50→12/40) based on actual fnec-vs-nec2c deltas plus 10–15% headroom.
+	- 2026-04-29 progress: tightened external RP gain gates for `dipole-freesp-rp-51seg` (0.1→0.08 dB, actual max |dGain|=0.068) and `dipole-xaxis-rp-grid-51seg` (0.1→0.04 dB, actual max |dGain|=0.034), matching the actual-delta-plus-headroom pattern used for impedance gates.
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary

Tighten `ExternalGain_absolute_dB` thresholds for both RP corpus cases using actual measured fnec-vs-nec2c pattern deltas plus 15% headroom — the same methodology used for impedance gate tightening in PR #104.

| Case | Old gate | New gate | Actual max \|dGain\| |
|:-----|:---------|:---------|:---------------------|
| `dipole-freesp-rp-51seg` | 0.1 dB | 0.08 dB | 0.068 dB |
| `dipole-xaxis-rp-grid-51seg` | 0.1 dB | 0.04 dB | 0.034 dB |

Also documents the PR #104 impedance gate tightening and this RP gate tightening in `docs/backlog.md` progress entries.

## Test plan
- `cargo test` passes with the tightened thresholds
- Corpus validation confirms all RP external-gain delta checks are within the new gates