### PR TITLE
solver: add PEC ground-aware RP far-field regression

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -1127,7 +1127,7 @@ fn solve_frequency_point(
 
             // Use standard CPU path once to get normalization, then switch to GPU stub for pattern eval
             // (In production, the GPU would compute this on-device)
-            let _ = compute_radiation_pattern(segs, &i_vec, freq_hz, &[pattern_points[0]]);
+            let _ = compute_radiation_pattern(segs, &i_vec, freq_hz, &[pattern_points[0]], ground);
 
             // For stub, use a simple normalized reference (total current squared)
             let norm_ref = i_vec.iter().map(|i| i.norm_sqr()).sum::<f64>();
@@ -1156,7 +1156,7 @@ fn solve_frequency_point(
                 .collect()
         } else {
             // Standard CPU path
-            let results = compute_radiation_pattern(segs, &i_vec, freq_hz, pattern_points);
+            let results = compute_radiation_pattern(segs, &i_vec, freq_hz, pattern_points, ground);
             results
                 .iter()
                 .map(|r| PatternRow {

--- a/corpus/dipole-ground-rp-51seg.nec
+++ b/corpus/dipole-ground-rp-51seg.nec
@@ -1,0 +1,8 @@
+CE dipole over PEC ground with RP theta sweep (upper hemisphere)
+GW 1 51 0 0 4.718 0 0 15.282 0.001
+GE
+GN 1
+EX 0 1 26 0 1.0 0.0
+FR 0 1 0 0 14.2 0.0
+RP 0 9 1 10.0 0.0 10.0 0.0
+EN

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -713,6 +713,103 @@
       },
       "status": "Regression reference locks RP execution path and radiation-pattern table contract; nec2c external pattern samples captured for parity tracking. ExternalGain gate tightened 0.1→0.08 on 2026-04-29 (actual max |dGain|=0.068)."
     },
+    "dipole-ground-rp-51seg": {
+      "deck_file": "dipole-ground-rp-51seg.nec",
+      "description": "Half-wave dipole over PEC ground, 51 segments, 14.2 MHz, RP theta sweep 10-90 deg",
+      "frequency_mhz": 14.2,
+      "segments": 51,
+      "wires": 1,
+      "sources": 1,
+      "ground": "PEC",
+      "reference_source": "fnec Hallen solver (regression reference; PEC image far-field)",
+      "feedpoint_impedance": {
+        "real_ohm": 81.914743,
+        "imag_ohm": 16.416629
+      },
+      "pattern_samples": [
+        {
+          "theta_deg": 10.0,
+          "phi_deg": 0.0,
+          "gain_db": -8.9913,
+          "gain_v_db": -8.9913,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 20.0,
+          "phi_deg": 0.0,
+          "gain_db": -3.2428,
+          "gain_v_db": -3.2428,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 30.0,
+          "phi_deg": 0.0,
+          "gain_db": -0.5836,
+          "gain_v_db": -0.5836,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 40.0,
+          "phi_deg": 0.0,
+          "gain_db": -0.3009,
+          "gain_v_db": -0.3009,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 50.0,
+          "phi_deg": 0.0,
+          "gain_db": -4.1173,
+          "gain_v_db": -4.1173,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 60.0,
+          "phi_deg": 0.0,
+          "gain_db": -15.3003,
+          "gain_v_db": -15.3003,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 70.0,
+          "phi_deg": 0.0,
+          "gain_db": 2.0188,
+          "gain_v_db": 2.0188,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 80.0,
+          "phi_deg": 0.0,
+          "gain_db": 7.0069,
+          "gain_v_db": 7.0069,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        },
+        {
+          "theta_deg": 90.0,
+          "phi_deg": 0.0,
+          "gain_db": 8.422,
+          "gain_v_db": 8.422,
+          "gain_h_db": -999.99,
+          "axial_ratio": 0.0
+        }
+      ],
+      "tolerance_gates": {
+        "R_percent_rel": 0.1,
+        "X_percent_rel": 0.1,
+        "R_absolute_ohm": 0.05,
+        "X_absolute_ohm": 0.05,
+        "Gain_absolute_dB": 0.05,
+        "AxialRatio_absolute": 0.0001
+      },
+      "status": "Regression reference for PEC ground far-field (image method); captures null at theta≈60° from destructive interference and max gain at horizon. Locked 2026-04-29."
+    },
     "dipole-xaxis-rp-grid-51seg": {
       "deck_file": "dipole-xaxis-rp-grid-51seg.nec",
       "description": "Half-wave dipole rotated onto the x-axis, free space, 51 segments, 14.2 MHz, RP theta/phi grid",

--- a/crates/nec_solver/src/farfield.rs
+++ b/crates/nec_solver/src/farfield.rs
@@ -21,6 +21,7 @@
 use num_complex::Complex64;
 use std::f64::consts::PI;
 
+use crate::geometry::GroundModel;
 use crate::geometry::Segment;
 
 const SPEED_OF_LIGHT: f64 = 299_792_458.0; // m/s
@@ -56,6 +57,27 @@ pub struct FarFieldResult {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/// Convert (θ, φ) in degrees to the three spherical-coordinate unit vectors.
+fn pec_image_farfield(seg: &Segment) -> Segment {
+    // For far-field PEC image at z = 0 (Balanis Table 4-1):
+    //   position: (x, y, −z)
+    //   direction: (−dx, −dy, +dz)
+    // Horizontal components negate (opposite image) and vertical keeps sign
+    // (same-direction image). This ensures constructive interference for vertical
+    // sources and the standard pattern reinforcement above the ground plane.
+    Segment {
+        tag: seg.tag,
+        tag_index: seg.tag_index,
+        global_index: seg.global_index,
+        start: [seg.start[0], seg.start[1], -seg.start[2]],
+        end: [seg.end[0], seg.end[1], -seg.end[2]],
+        midpoint: [seg.midpoint[0], seg.midpoint[1], -seg.midpoint[2]],
+        direction: [-seg.direction[0], -seg.direction[1], seg.direction[2]],
+        length: seg.length,
+        radius: seg.radius,
+    }
+}
 
 /// Convert (θ, φ) in degrees to the three spherical-coordinate unit vectors.
 fn unit_vectors(theta_deg: f64, phi_deg: f64) -> ([f64; 3], [f64; 3], [f64; 3]) {
@@ -109,25 +131,27 @@ fn far_field_components(
 // ---------------------------------------------------------------------------
 
 /// Compute the total radiated power proportionality constant by integrating
-/// `(|F_θ|² + |F_φ|²) sin θ` over the sphere using a trapezoidal rule on a
-/// 1° × 1° grid.
+/// `(|F_θ|² + |F_φ|²) sin θ` over the sphere (or upper hemisphere for PEC).
+///
+/// For free space: integrates θ ∈ [0°, 180°] (full sphere).
+/// For PEC ground: integrates θ ∈ [0°, 90°] (upper hemisphere only, since
+/// no radiation exists below the ground plane).
 ///
 /// Returns the normalisation denominator `∫ U dΩ` (in sr × [|F|²] units).
-fn integrate_over_sphere(segs: &[Segment], i_vec: &[Complex64], k: f64) -> f64 {
-    // 1° resolution: θ ∈ [0°, 180°], φ ∈ [0°, 360°)
-    let n_theta = 181usize;
+fn integrate_power(segs: &[Segment], i_vec: &[Complex64], k: f64, pec_ground: bool) -> f64 {
+    let (n_theta, theta_max_deg): (usize, f64) = if pec_ground { (91, 90.0) } else { (181, 180.0) };
     let n_phi = 360usize;
-    let d_theta = PI / (n_theta as f64 - 1.0);
+    let d_theta = theta_max_deg.to_radians() / (n_theta as f64 - 1.0);
     let d_phi = 2.0 * PI / n_phi as f64;
 
     let mut total = 0.0_f64;
 
     for it in 0..n_theta {
-        let theta_deg = it as f64;
+        let theta_deg = it as f64 * theta_max_deg / (n_theta as f64 - 1.0);
         let th = theta_deg.to_radians();
         let sin_theta = th.sin();
         if sin_theta == 0.0 {
-            // θ = 0° or θ = 180°: singular edge, pattern vanishes for dipole.
+            // θ = 0° or θ = 90°/180°: singular edge, pattern vanishes for dipole.
             continue;
         }
         // θ weight (trapezoidal: half weight for endpoints)
@@ -139,13 +163,56 @@ fn integrate_over_sphere(segs: &[Segment], i_vec: &[Complex64], k: f64) -> f64 {
 
         for ip in 0..n_phi {
             let phi_deg = ip as f64;
-            let (f_t, f_p) = far_field_components(segs, i_vec, k, theta_deg, phi_deg);
+            let (f_t, f_p) = if pec_ground {
+                far_field_components_with_image(segs, i_vec, k, theta_deg, phi_deg)
+            } else {
+                far_field_components(segs, i_vec, k, theta_deg, phi_deg)
+            };
             let u = f_t.norm_sqr() + f_p.norm_sqr();
             total += u * sin_theta * w_theta * d_phi;
         }
     }
 
     total
+}
+
+/// Compute the complex far-field θ and φ components with PEC ground image.
+///
+/// Adds the image contribution for each segment using the far-field PEC
+/// image convention (position reflected about z=0, direction with x/y
+/// components negated and z kept — see `pec_image_farfield`).
+fn far_field_components_with_image(
+    segs: &[Segment],
+    i_vec: &[Complex64],
+    k: f64,
+    theta_deg: f64,
+    phi_deg: f64,
+) -> (Complex64, Complex64) {
+    let (r_hat, theta_hat, phi_hat) = unit_vectors(theta_deg, phi_deg);
+
+    let mut f_theta = Complex64::new(0.0, 0.0);
+    let mut f_phi = Complex64::new(0.0, 0.0);
+
+    for (n, seg) in segs.iter().enumerate() {
+        let i_n = i_vec[n];
+
+        // Direct contribution.
+        let phase_arg = k * dot3(seg.midpoint, r_hat);
+        let phase = Complex64::new(phase_arg.cos(), phase_arg.sin());
+        let weighted = i_n * (seg.length * phase);
+        f_theta += weighted * dot3(seg.direction, theta_hat);
+        f_phi += weighted * dot3(seg.direction, phi_hat);
+
+        // PEC image contribution.
+        let img = pec_image_farfield(seg);
+        let img_phase_arg = k * dot3(img.midpoint, r_hat);
+        let img_phase = Complex64::new(img_phase_arg.cos(), img_phase_arg.sin());
+        let img_weighted = i_n * (img.length * img_phase);
+        f_theta += img_weighted * dot3(img.direction, theta_hat);
+        f_phi += img_weighted * dot3(img.direction, phi_hat);
+    }
+
+    (f_theta, f_phi)
 }
 
 // ---------------------------------------------------------------------------
@@ -161,21 +228,41 @@ fn integrate_over_sphere(segs: &[Segment], i_vec: &[Complex64], k: f64) -> f64 {
 /// * `i_vec`    — solved current vector (one entry per segment).
 /// * `freq_hz`  — operating frequency in Hz.
 /// * `points`   — observation directions (θ, φ in degrees).
+/// * `ground`   — ground model; `PerfectConductor` adds PEC image contribution
+///               and restricts the pattern to the upper hemisphere (θ ≤ 90°).
 pub fn compute_radiation_pattern(
     segs: &[Segment],
     i_vec: &[Complex64],
     freq_hz: f64,
     points: &[FarFieldPoint],
+    ground: &GroundModel,
 ) -> Vec<FarFieldResult> {
     let lambda = SPEED_OF_LIGHT / freq_hz;
     let k = 2.0 * PI / lambda;
 
-    let total_radiated = integrate_over_sphere(segs, i_vec, k);
+    let pec = matches!(ground, GroundModel::PerfectConductor);
+    let total_radiated = integrate_power(segs, i_vec, k, pec);
 
     points
         .iter()
         .map(|pt| {
-            let (f_t, f_p) = far_field_components(segs, i_vec, k, pt.theta_deg, pt.phi_deg);
+            // Below-ground points are null for a PEC plane.
+            if pec && pt.theta_deg > 90.0 {
+                return FarFieldResult {
+                    theta_deg: pt.theta_deg,
+                    phi_deg: pt.phi_deg,
+                    gain_total_dbi: -999.99,
+                    gain_theta_dbi: -999.99,
+                    gain_phi_dbi: -999.99,
+                    axial_ratio: 0.0,
+                };
+            }
+
+            let (f_t, f_p) = if pec {
+                far_field_components_with_image(segs, i_vec, k, pt.theta_deg, pt.phi_deg)
+            } else {
+                far_field_components(segs, i_vec, k, pt.theta_deg, pt.phi_deg)
+            };
             let u_total = f_t.norm_sqr() + f_p.norm_sqr();
             let u_theta = f_t.norm_sqr();
             let u_phi = f_p.norm_sqr();
@@ -298,7 +385,8 @@ mod tests {
                 phi_deg: 0.0,
             },
         ];
-        let results = compute_radiation_pattern(&segs, &i_vec, freq_hz, &pts);
+        let results =
+            compute_radiation_pattern(&segs, &i_vec, freq_hz, &pts, &GroundModel::FreeSpace);
 
         // θ = 90° → maximum, should be close to Hertzian-dipole directivity ≈ 1.76 dBi.
         assert!(
@@ -321,7 +409,8 @@ mod tests {
             theta_deg: 90.0,
             phi_deg: 0.0,
         }];
-        let results = compute_radiation_pattern(&segs, &i_vec, 14.2e6, &pts);
+        let results =
+            compute_radiation_pattern(&segs, &i_vec, 14.2e6, &pts, &GroundModel::FreeSpace);
 
         // z-axis dipole at equator: all energy in E_θ, zero in E_φ.
         assert!(
@@ -352,5 +441,93 @@ mod tests {
         assert!((pts[1].phi_deg - 20.0).abs() < 1e-10);
         assert!((pts[2].theta_deg - 10.0).abs() < 1e-10);
         assert!((pts[2].phi_deg - 60.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn pec_ground_image_direction_vertical() {
+        let seg = Segment {
+            tag: 1,
+            tag_index: 1,
+            global_index: 0,
+            start: [0.0, 0.0, 1.0],
+            end: [0.0, 0.0, 3.0],
+            midpoint: [0.0, 0.0, 2.0],
+            direction: [0.0, 0.0, 1.0],
+            length: 2.0,
+            radius: 1e-4,
+        };
+        let img = pec_image_farfield(&seg);
+        // Position reflected about z = 0.
+        assert!((img.midpoint[2] + 2.0).abs() < 1e-12);
+        // Vertical component: same sign (+z → +z).
+        assert!((img.direction[2] - 1.0).abs() < 1e-12);
+        // Horizontal components: negated (0 → 0 here, trivially).
+        assert!(img.direction[0].abs() < 1e-12);
+    }
+
+    #[test]
+    fn pec_ground_image_direction_horizontal() {
+        let seg = Segment {
+            tag: 1,
+            tag_index: 1,
+            global_index: 0,
+            start: [-1.0, 0.0, 2.0],
+            end: [1.0, 0.0, 2.0],
+            midpoint: [0.0, 0.0, 2.0],
+            direction: [1.0, 0.0, 0.0],
+            length: 2.0,
+            radius: 1e-4,
+        };
+        let img = pec_image_farfield(&seg);
+        // Position reflected: z negated.
+        assert!((img.midpoint[2] + 2.0).abs() < 1e-12);
+        // Horizontal: x negated (−1), z unchanged (0).
+        assert!((img.direction[0] + 1.0).abs() < 1e-12);
+        assert!(img.direction[2].abs() < 1e-12);
+    }
+
+    #[test]
+    fn pec_ground_vertical_dipole_at_origin_doubles_field() {
+        // A z-directed Hertzian dipole at the origin above a PEC plane.
+        // The image is also at the origin (z=0) with the same direction (+z).
+        // At the equator (θ = 90°): field doubles compared to free space.
+        // Total radiated power integrates over upper hemisphere only, so
+        // the normalisation factor changes too; directivity is 2× the free-space
+        // value (≈ +3 dB), giving ≈ 4.77 dBi for a Hertzian dipole at z = 0.
+        let (segs, i_vec) = hertzian_segment(0.01);
+        let freq_hz = 14.2e6;
+        let pts = vec![FarFieldPoint {
+            theta_deg: 90.0,
+            phi_deg: 0.0,
+        }];
+        let free = compute_radiation_pattern(&segs, &i_vec, freq_hz, &pts, &GroundModel::FreeSpace);
+        let pec =
+            compute_radiation_pattern(&segs, &i_vec, freq_hz, &pts, &GroundModel::PerfectConductor);
+
+        // PEC directivity at equator should be ≈ free-space + 3 dB.
+        // Hertzian dipole free-space max ≈ 1.76 dBi; with PEC ≈ 4.77 dBi.
+        let delta_db = pec[0].gain_total_dbi - free[0].gain_total_dbi;
+        assert!(
+            (delta_db - 3.0).abs() < 0.1,
+            "expected PEC boost ≈ +3 dB at equator, got {:.3} dB",
+            delta_db
+        );
+    }
+
+    #[test]
+    fn pec_ground_below_horizon_returns_null() {
+        // Points below the ground plane (θ > 90°) must return −999.99 dB for PEC.
+        let (segs, i_vec) = hertzian_segment(0.01);
+        let pts = vec![FarFieldPoint {
+            theta_deg: 120.0,
+            phi_deg: 0.0,
+        }];
+        let results =
+            compute_radiation_pattern(&segs, &i_vec, 14.2e6, &pts, &GroundModel::PerfectConductor);
+        assert!(
+            (results[0].gain_total_dbi + 999.99).abs() < 1e-6,
+            "below-ground point should be -999.99 dB, got {}",
+            results[0].gain_total_dbi
+        );
     }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -49,6 +49,7 @@ last_updated: 2026-04-29
 	- 2026-04-27 progress: native CLI startup now auto-selects execution mode when `--exec` is omitted by running a quick startup probe and choosing the most suitable available mode (`cpu`/`hybrid`/`gpu`) for current frequency sweep shape and dispatch availability.
 	- 2026-04-29 progress: tightened external impedance gates for 5 corpus cases (`dipole-ground-51seg` R 10→8, `yagi-5elm-51seg` R/X 30/70→25/55, `tl-two-dipoles-linked` R/X 5/20→4/16, `frequency-sweep-dipole` R/X 15/50→14/47, `multi-source` R/X 15/50→12/40) based on actual fnec-vs-nec2c deltas plus 10–15% headroom.
 	- 2026-04-29 progress: tightened external RP gain gates for `dipole-freesp-rp-51seg` (0.1→0.08 dB, actual max |dGain|=0.068) and `dipole-xaxis-rp-grid-51seg` (0.1→0.04 dB, actual max |dGain|=0.034), matching the actual-delta-plus-headroom pattern used for impedance gates.
+	- 2026-04-29 progress: implemented PEC ground-aware RP far-field in `nec_solver::farfield` (image contribution + upper-hemisphere normalization + below-horizon null contract), wired CLI RP path through `ground` model, and added corpus regression fixture `corpus/dipole-ground-rp-51seg.nec` with reference pattern samples.
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary
- implement PEC ground-aware far-field in nec_solver::farfield via image contributions and upper-hemisphere normalization
- update CLI RP computation calls to pass the active ground model through compute_radiation_pattern
- add corpus fixture corpus/dipole-ground-rp-51seg.nec and reference entry with feedpoint + RP sample locks
- record roadmap progress in docs/backlog.md

## Validation
- cargo fmt
- cargo check
- cargo test
- cargo test -p nec-cli --test corpus_validation
- ./scripts/validate-doc-frontmatter.sh
