### PR TITLE
solver: activate GN0 simple finite-ground model

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -835,6 +835,9 @@ fn par002_ground_checklist_cases_are_present_and_contracted() {
     let required_cases: &[(&str, bool, bool, bool)] = &[
         // GN=1 PEC image method: implemented; must have regression gate; no warning expected.
         ("dipole-ground-51seg", true, false, false),
+        // GN=0 finite-ground reflection coefficient method: implemented and
+        // regression-gated; old deferred warning must be forbidden.
+        ("dipole-gn0-fresnel-51seg", true, false, true),
         // GN=2 Sommerfeld/Norton finite-conductivity: deferred; must have
         // warning contract documenting fallback behavior.
         ("dipole-gn2-deferred", true, true, false),

--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
-fn gn_deferred_type_emits_warning_and_falls_back_to_free_space() {
+fn gn0_is_active_without_deferred_warning() {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -34,9 +34,27 @@ fn gn_deferred_type_emits_warning_and_falls_back_to_free_space() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr
-            .contains("warning: GN type 0 is not yet supported; treating this deck as free-space"),
-        "expected deferred GN warning in stderr, got:\n{stderr}"
+        !stderr.contains("warning: GN type 0 is not yet supported"),
+        "GN0 should no longer use deferred-ground warning, got:\n{stderr}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let z_re = stdout
+        .lines()
+        .find_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 8 && parts[0] == "1" && parts[1] == "26" {
+                parts[6].parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .expect("no feedpoint row in output");
+
+    // GN0 finite ground should not collapse to free-space (~74.23 Ohm real).
+    assert!(
+        (z_re - 74.23).abs() > 0.5,
+        "GN0 should alter impedance vs free-space, got Z_RE={z_re}"
     );
 }
 

--- a/corpus/dipole-gn0-fresnel-51seg.nec
+++ b/corpus/dipole-gn0-fresnel-51seg.nec
@@ -1,0 +1,7 @@
+CE Half-wave dipole over finite ground (GN type 0 simple Fresnel model)
+GW 1 51 0 0 4.718 0 0 15.282 0.001
+GE
+GN 0 0 0 0 13.0 0.005
+EX 0 1 26 0 1.0 0.0
+FR 0 1 0 0 14.2 0.0
+EN

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -1020,6 +1020,32 @@
       },
       "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy, and now CI-gated with absolute external R/X thresholds. ExternalR gate tightened 10→8 on 2026-04-29 (actual |dR|=7.12)."
     },
+    "dipole-gn0-fresnel-51seg": {
+      "deck_file": "dipole-gn0-fresnel-51seg.nec",
+      "description": "Half-wave dipole, 10 m AGL, GN type 0 finite ground (simple Fresnel model), 51 segments, 14.2 MHz",
+      "frequency_mhz": 14.2,
+      "segments": 51,
+      "wires": 1,
+      "sources": 1,
+      "ground": "finite ground GN0 (simple Fresnel approximation)",
+      "reference_source": "fnec Hallen solver with GN=0 simple finite-ground model (regression)",
+      "feedpoint_impedance": {
+        "real_ohm": 78.170459,
+        "imag_ohm": 14.95465
+      },
+      "tolerance_gates": {
+        "R_percent_rel": 0.1,
+        "X_percent_rel": 0.1,
+        "R_absolute_ohm": 0.05,
+        "X_absolute_ohm": 0.05
+      },
+      "expected_warning_substrings": [],
+      "forbidden_warning_substrings": [
+        "GN type 0 is not yet supported; treating this deck as free-space"
+      ],
+      "expected_warning_counts": {},
+      "status": "GN=0 simple finite-ground model active. Regression-gated in CI and explicitly forbids the former deferred-ground warning contract."
+    },
     "dipole-gn2-deferred": {
       "deck_file": "dipole-gn2-deferred.nec",
       "description": "Half-wave dipole, GN type 2 (Sommerfeld/Norton finite-conductivity; deferred), 51 segments, 14.2 MHz. Falls back to free-space with a runtime warning.",

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -30,6 +30,16 @@ pub enum GroundModel {
     /// Implemented via the image method: for each real segment a mirror image
     /// at z → −z is added to the Green's function kernel.
     PerfectConductor,
+    /// Simple finite-ground model (GN type 0) using medium parameters.
+    ///
+    /// This Phase-1 model is a pragmatic Fresnel-coefficient approximation
+    /// used to enable baseline non-PEC ground behavior in impedance solves.
+    SimpleFiniteGround {
+        /// Relative dielectric constant (EPSE).
+        eps_r: f64,
+        /// Conductivity in S/m (SIG).
+        sigma: f64,
+    },
     /// GN card was present, but the requested ground type is not implemented.
     ///
     /// The current Phase-1 behavior is to fall back to free-space while
@@ -49,6 +59,8 @@ pub enum GroundModel {
 /// 1. If a `GN` card is present it takes priority.
 ///    - `GN -1` → [`GroundModel::FreeSpace`] (null ground; equivalent to no GN card).
 ///    - `GN 1`  → [`GroundModel::PerfectConductor`].
+///    - `GN 0`  → [`GroundModel::SimpleFiniteGround`] using parsed EPSE/SIG
+///      (or conservative defaults when omitted).
 ///    - Other GN types → [`GroundModel::Deferred`].
 /// 2. If no `GN` card is present but a `GE` card has `ground_reflection_flag > 0`
 ///    (the standard NEC flag for "enable image-method PEC ground at z = 0"),
@@ -63,6 +75,13 @@ pub fn ground_model_from_deck(deck: &NecDeck) -> GroundModel {
                 // GN card — treat as free-space without emitting a warning.
                 -1 => GroundModel::FreeSpace,
                 1 => GroundModel::PerfectConductor,
+                0 => GroundModel::SimpleFiniteGround {
+                    // Keep GN0 usable even when medium params are omitted.
+                    // Values are the same "average ground" defaults commonly
+                    // used in NEC workflows.
+                    eps_r: gn.eps_r.unwrap_or(13.0),
+                    sigma: gn.sigma.unwrap_or(0.005),
+                },
                 other => GroundModel::Deferred {
                     gn_type: other,
                     eps_r: gn.eps_r,
@@ -513,7 +532,7 @@ mod tests {
     }
 
     #[test]
-    fn ground_model_marks_gn0_as_deferred() {
+    fn ground_model_maps_gn0_to_simple_finite_ground() {
         let mut deck = NecDeck::new();
         deck.cards.push(Card::Gn(GnCard {
             ground_type: 0,
@@ -522,10 +541,26 @@ mod tests {
         }));
         assert_eq!(
             ground_model_from_deck(&deck),
-            GroundModel::Deferred {
-                gn_type: 0,
-                eps_r: None,
-                sigma: None,
+            GroundModel::SimpleFiniteGround {
+                eps_r: 13.0,
+                sigma: 0.005,
+            }
+        );
+    }
+
+    #[test]
+    fn ground_model_gn0_uses_explicit_medium_params() {
+        let mut deck = NecDeck::new();
+        deck.cards.push(Card::Gn(GnCard {
+            ground_type: 0,
+            eps_r: Some(5.0),
+            sigma: Some(0.001),
+        }));
+        assert_eq!(
+            ground_model_from_deck(&deck),
+            GroundModel::SimpleFiniteGround {
+                eps_r: 5.0,
+                sigma: 0.001,
             }
         );
     }

--- a/crates/nec_solver/src/matrix.rs
+++ b/crates/nec_solver/src/matrix.rs
@@ -30,6 +30,7 @@ use crate::geometry::{GroundModel, Segment};
 
 const C0: f64 = 299_792_458.0; // m/s
 const MU0: f64 = 4.0 * std::f64::consts::PI * 1e-7; // H/m
+const EPS0: f64 = 8.854_187_817e-12; // F/m
 
 // ---------------------------------------------------------------------------
 // 4-point Gauss-Legendre quadrature nodes and weights on [-1, 1]
@@ -147,16 +148,15 @@ pub fn assemble_z_matrix(segs: &[Segment], freq_hz: f64) -> ZMatrix {
 /// Assemble the N×N Hallén A-matrix for `segs` at frequency `freq_hz`,
 /// optionally including a ground-plane image contribution.
 ///
-/// For [`GroundModel::PerfectConductor`] each element A[i,j] gets an
-/// additional term from the mirror image of segment j across z = 0:
+/// For reflective ground models each element A[i,j] gets an additional term
+/// from the mirror image of segment j across z = 0:
 ///
 /// ```text
-/// A[i,j] = A_free[i,j] + A_free(segs[i], image(segs[j]))
+/// A[i,j] = A_free[i,j] + Γ · A_free(segs[i], image(segs[j]))
 /// ```
 ///
-/// where `image(seg)` has its z-coordinates negated and its z-direction
-/// component sign-flipped, which produces the correct ±1 reflection
-/// coefficient for horizontal (cos = +1) and vertical (cos = −1) currents.
+/// where `Γ = 1` for PEC and `Γ` is a simple complex Fresnel-style
+/// reflection factor for [`GroundModel::SimpleFiniteGround`].
 pub fn assemble_z_matrix_with_ground(
     segs: &[Segment],
     freq_hz: f64,
@@ -177,6 +177,11 @@ pub fn assemble_z_matrix_with_ground(
                     // Image is always at a different location than the
                     // observation segment, so never treat as self-element.
                     elem(&segs[i], &img, k, false)
+                }
+                GroundModel::SimpleFiniteGround { eps_r, sigma } => {
+                    let img = image_segment(&segs[j]);
+                    let gamma = fresnel_reflection_scalar(freq_hz, *eps_r, *sigma);
+                    gamma * elem(&segs[i], &img, k, false)
                 }
             };
             z.set(i, j, direct + image_contrib);
@@ -235,6 +240,19 @@ fn image_segment(seg: &Segment) -> Segment {
         length: seg.length,
         radius: seg.radius,
     }
+}
+
+/// Simple scalar reflection coefficient used by GN type 0 ground.
+///
+/// Uses a complex relative permittivity model:
+/// εr_complex = εr - j σ/(ω ε0)
+/// and a normal-incidence Fresnel factor:
+/// Γ = (sqrt(εr_complex) - 1) / (sqrt(εr_complex) + 1)
+fn fresnel_reflection_scalar(freq_hz: f64, eps_r: f64, sigma: f64) -> Complex64 {
+    let omega = 2.0 * std::f64::consts::PI * freq_hz;
+    let eps_c = Complex64::new(eps_r.max(1.0e-6), -sigma.max(0.0) / (omega * EPS0));
+    let sqrt_eps_c = eps_c.sqrt();
+    (sqrt_eps_c - Complex64::new(1.0, 0.0)) / (sqrt_eps_c + Complex64::new(1.0, 0.0))
 }
 
 /// Compute the (obs, src) Hallén A-matrix element:
@@ -523,6 +541,26 @@ mod tests {
         assert!(
             delta.norm() > 1e-8,
             "PEC image term should modify A11, delta={delta}"
+        );
+    }
+
+    #[test]
+    fn gn0_ground_changes_hallen_matrix_element() {
+        let s = make_seg(1, 1, 0, [0.0, 0.0, 1.0], DIR_Z, SEG_LEN, RADIUS);
+        let z_free = assemble_z_matrix_with_ground(&[s.clone()], FREQ, &GroundModel::FreeSpace);
+        let z_gn0 = assemble_z_matrix_with_ground(
+            &[s],
+            FREQ,
+            &GroundModel::SimpleFiniteGround {
+                eps_r: 13.0,
+                sigma: 0.005,
+            },
+        );
+
+        let delta = z_gn0.get(0, 0) - z_free.get(0, 0);
+        assert!(
+            delta.norm() > 1e-8,
+            "GN0 finite-ground image term should modify A11, delta={delta}"
         );
     }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -50,6 +50,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: tightened external impedance gates for 5 corpus cases (`dipole-ground-51seg` R 10→8, `yagi-5elm-51seg` R/X 30/70→25/55, `tl-two-dipoles-linked` R/X 5/20→4/16, `frequency-sweep-dipole` R/X 15/50→14/47, `multi-source` R/X 15/50→12/40) based on actual fnec-vs-nec2c deltas plus 10–15% headroom.
 	- 2026-04-29 progress: tightened external RP gain gates for `dipole-freesp-rp-51seg` (0.1→0.08 dB, actual max |dGain|=0.068) and `dipole-xaxis-rp-grid-51seg` (0.1→0.04 dB, actual max |dGain|=0.034), matching the actual-delta-plus-headroom pattern used for impedance gates.
 	- 2026-04-29 progress: implemented PEC ground-aware RP far-field in `nec_solver::farfield` (image contribution + upper-hemisphere normalization + below-horizon null contract), wired CLI RP path through `ground` model, and added corpus regression fixture `corpus/dipole-ground-rp-51seg.nec` with reference pattern samples.
+	- 2026-04-29 progress: activated GN type 0 simple finite-ground model in Hallen matrix assembly using a complex Fresnel-style reflection factor from EPSE/SIG, replaced the prior deferred GN0 warning path, and added corpus regression fixture `corpus/dipole-gn0-fresnel-51seg.nec`.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ All notable documentation process changes are recorded here.
 
 ### Changed
 
+- GN type 0 is now active as a simple finite-ground model in Hallen impedance assembly (complex Fresnel-style image scaling from EPSE/SIG) instead of the prior deferred free-space fallback warning path.
 - EX type 1 is now accepted as a staged portability fallback: the CLI warns that current-source semantics are still pending, and current runtime behavior treats EX type 1 like EX type 0 until a dedicated implementation lands.
 - EX type 2 is now accepted as a staged portability fallback: the CLI warns that incident-plane-wave semantics are still pending, and current runtime behavior treats EX type 2 like EX type 0 until a dedicated implementation lands.
 - EX type 4 is now accepted as a staged portability fallback: the CLI warns that segment-current semantics are still pending, and current runtime behavior treats EX type 4 like EX type 0 until a dedicated implementation lands.


### PR DESCRIPTION
## Summary
- activate GN type 0 as an implemented simple finite-ground model instead of deferred free-space fallback
- add GroundModel::SimpleFiniteGround and map GN0 cards to it (using EPSE/SIG or conservative defaults)
- apply a complex Fresnel-style scalar reflection factor to Hallen image contributions in matrix assembly
- replace GN0 deferred-warning diagnostics contract with active-behavior tests
- add corpus fixture corpus/dipole-gn0-fresnel-51seg.nec and lock new GN0 feedpoint reference values
- extend PAR-002 ground checklist coverage to require the GN0 regression case and forbid old deferred warning text

## Contract-impacting changes (approved)
- numerical outputs for GN0 decks now change from free-space fallback behavior
- warning contract for GN0 decks changed: old deferred warning is now forbidden

## Validation
- cargo fmt
- cargo check
- cargo test
- ./scripts/validate-doc-frontmatter.sh
