### PR TITLE
cli: add core-flags parsing contract tests

### DIFF
--- a/apps/nec-cli/tests/core_flags_contract.rs
+++ b/apps/nec-cli/tests/core_flags_contract.rs
@@ -1,0 +1,110 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn fixture_deck(name: &str) -> PathBuf {
+    workspace_root().join("corpus").join(name)
+}
+
+fn run_fnec(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec: {e}"))
+}
+
+#[test]
+fn missing_solver_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&["--solver"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>]"),
+        "missing usage contract in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("missing value after --solver"),
+        "missing parse error detail in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn invalid_exec_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&[
+        "--exec",
+        "bogus",
+        fixture_deck("dipole-freesp-51seg.nec").to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --exec value 'bogus'"),
+        "missing invalid-value detail in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: cpu|hybrid|gpu"),
+        "missing expected-value hint in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn unknown_option_reports_contract_error() {
+    let output = run_fnec(&["--definitely-not-a-flag"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown option: --definitely-not-a-flag"),
+        "missing unknown-option error in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn missing_deck_path_reports_contract_error() {
+    let output = run_fnec(&["--solver", "hallen", "--pulse-rhs", "nec2"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("missing deck path"),
+        "missing deck-path parse error in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn all_core_flags_combination_runs_successfully() {
+    let deck = fixture_deck("dipole-freesp-51seg.nec");
+    let output = run_fnec(&[
+        "--solver",
+        "hallen",
+        "--pulse-rhs",
+        "raw",
+        "--exec",
+        "cpu",
+        "--allow-noncollinear-hallen",
+        "--bench-format",
+        "json",
+        "--ex3-i4-mode",
+        "legacy",
+        "--gpu-fr",
+        deck.to_str().unwrap(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "fnec failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FNEC FEEDPOINT REPORT"),
+        "expected report header in stdout, got:\n{stdout}"
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -52,6 +52,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: implemented PEC ground-aware RP far-field in `nec_solver::farfield` (image contribution + upper-hemisphere normalization + below-horizon null contract), wired CLI RP path through `ground` model, and added corpus regression fixture `corpus/dipole-ground-rp-51seg.nec` with reference pattern samples.
 	- 2026-04-29 progress: activated GN type 0 simple finite-ground model in Hallen matrix assembly using a complex Fresnel-style reflection factor from EPSE/SIG, replaced the prior deferred GN0 warning path, and added corpus regression fixture `corpus/dipole-gn0-fresnel-51seg.nec`.
 	- 2026-04-29 progress: added CLI scriptability regression tests (`apps/nec-cli/tests/scriptability_contract.rs`) to lock stable machine-parseable report headers on stdout and enforce warning/output stream separation (warnings on stderr, report-only stdout).
+	- 2026-04-29 progress: added CLI core-flags contract tests (`apps/nec-cli/tests/core_flags_contract.rs`) covering parse-error contracts (missing/invalid values, unknown options, missing deck path) and a full core-flag success invocation path.
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary
- add core flag parsing contract coverage in apps/nec-cli/tests/core_flags_contract.rs
- lock parse error contracts for missing values, invalid values, unknown options, and missing deck path
- add a full core-flags success invocation regression
- record progress in docs/backlog.md

## Validation
- cargo fmt
- cargo check
- cargo test -p nec-cli --test core_flags_contract
- ./scripts/validate-doc-frontmatter.sh