### PR TITLE
cli: lock bench-json stream separation contract

### DIFF
--- a/apps/nec-cli/tests/scriptability_contract.rs
+++ b/apps/nec-cli/tests/scriptability_contract.rs
@@ -89,3 +89,45 @@ fn warnings_stay_on_stderr_not_stdout() {
         "stdout report missing expected header, got:\n{stdout}"
     );
 }
+
+#[test]
+fn benchmark_json_stays_on_stderr_not_stdout() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck =
+        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGE\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    let deck_path = write_temp_deck("scriptable-bench-stream", deck);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--bench-format")
+        .arg("json")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for bench stream test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("bench_json:{"),
+        "expected benchmark json record in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("bench_json:{"),
+        "stdout must stay report-only for parsers, got:\n{stdout}"
+    );
+    assert!(
+        stdout.starts_with("FNEC FEEDPOINT REPORT\nFORMAT_VERSION 1\n"),
+        "stdout should begin with stable report header, got:\n{stdout}"
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -53,6 +53,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: activated GN type 0 simple finite-ground model in Hallen matrix assembly using a complex Fresnel-style reflection factor from EPSE/SIG, replaced the prior deferred GN0 warning path, and added corpus regression fixture `corpus/dipole-gn0-fresnel-51seg.nec`.
 	- 2026-04-29 progress: added CLI scriptability regression tests (`apps/nec-cli/tests/scriptability_contract.rs`) to lock stable machine-parseable report headers on stdout and enforce warning/output stream separation (warnings on stderr, report-only stdout).
 	- 2026-04-29 progress: added CLI core-flags contract tests (`apps/nec-cli/tests/core_flags_contract.rs`) covering parse-error contracts (missing/invalid values, unknown options, missing deck path) and a full core-flag success invocation path.
+	- 2026-04-29 progress: extended scriptability contracts to bench mode by locking that `bench_json:` records remain on stderr while stdout keeps the stable report stream for machine parsers.
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary
- extend scriptability contracts to benchmark mode output
- add regression: bench_json records must remain on stderr
- lock stdout parseability by asserting report header remains first and benchmark records are absent from stdout
- update backlog progress notes

## Validation
- cargo test -p nec-cli --test scriptability_contract
- cargo fmt
- cargo check
- ./scripts/validate-doc-frontmatter.sh