### PR TITLE
cli: harden scriptability contracts (csv stream, error exits)

### DIFF
--- a/apps/nec-cli/tests/scriptability_contract.rs
+++ b/apps/nec-cli/tests/scriptability_contract.rs
@@ -131,3 +131,105 @@ fn benchmark_json_stays_on_stderr_not_stdout() {
         "stdout should begin with stable report header, got:\n{stdout}"
     );
 }
+
+#[test]
+fn bench_csv_stays_on_stderr_not_stdout() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck =
+        "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGE\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    let deck_path = write_temp_deck("scriptable-bench-csv", deck);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--bench-format")
+        .arg("csv")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for bench csv stream test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("bench_csv:"),
+        "expected bench csv records in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("bench_csv:"),
+        "stdout must stay report-only for parsers, got:\n{stdout}"
+    );
+    assert!(
+        stdout.starts_with("FNEC FEEDPOINT REPORT\nFORMAT_VERSION 1\n"),
+        "stdout should begin with stable report header, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn nonexistent_deck_exits_with_code_1_and_error_on_stderr() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let bogus_path = std::env::temp_dir().join("fnec-definitely-does-not-exist.nec");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&bogus_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for missing-file test: {e}"));
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1 for missing deck file"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("cannot read"),
+        "expected file-read error in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("FNEC FEEDPOINT REPORT"),
+        "stdout must be empty on file-read error, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn no_arg_invocation_exits_with_code_2_and_usage_on_stderr() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for no-arg test: {e}"));
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2 for no-arg invocation"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("Usage: fnec"),
+        "expected usage text in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("FNEC FEEDPOINT REPORT"),
+        "stdout must have no report output on no-arg invocation, got:\n{stdout}"
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -54,6 +54,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: added CLI scriptability regression tests (`apps/nec-cli/tests/scriptability_contract.rs`) to lock stable machine-parseable report headers on stdout and enforce warning/output stream separation (warnings on stderr, report-only stdout).
 	- 2026-04-29 progress: added CLI core-flags contract tests (`apps/nec-cli/tests/core_flags_contract.rs`) covering parse-error contracts (missing/invalid values, unknown options, missing deck path) and a full core-flag success invocation path.
 	- 2026-04-29 progress: extended scriptability contracts to bench mode by locking that `bench_json:` records remain on stderr while stdout keeps the stable report stream for machine parsers.
+	- 2026-04-29 progress: hardened scriptability contracts with three additional locks: bench CSV records remain on stderr (`bench_csv:` prefix absent from stdout), nonexistent deck exits with code 1 and "cannot read" on stderr (no report on stdout), and no-arg invocation exits with code 2 and usage on stderr (no report on stdout).
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary

- Extend scriptability contract tests with three new locks:
  - `bench_csv_stays_on_stderr_not_stdout`: assert `bench_csv:` prefixed records never appear on stdout
  - `nonexistent_deck_exits_with_code_1_and_error_on_stderr`: assert exit code 1 and "cannot read" on stderr for missing deck, no report on stdout
  - `no_arg_invocation_exits_with_code_2_and_usage_on_stderr`: assert exit code 2 and usage text on stderr for no-arg runs, no report on stdout
- Backlog progress note added

## Validation

- cargo test -p nec-cli --test scriptability_contract (6 passed)
- cargo fmt
- cargo check
- ./scripts/validate-doc-frontmatter.sh
