### PR TITLE
cli: complete Phase 1 core-flag contracts

### DIFF
--- a/apps/nec-cli/tests/core_flags_contract.rs
+++ b/apps/nec-cli/tests/core_flags_contract.rs
@@ -34,6 +34,62 @@ fn missing_solver_value_reports_contract_error_and_usage() {
 }
 
 #[test]
+fn invalid_solver_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&[
+        "--solver",
+        "bogus",
+        fixture_deck("dipole-freesp-51seg.nec").to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --solver value 'bogus'"),
+        "missing invalid solver detail in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: hallen|pulse|continuity|sinusoidal"),
+        "missing expected solver values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn missing_pulse_rhs_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&["--pulse-rhs"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("missing value after --pulse-rhs"),
+        "missing pulse-rhs parse error in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: raw|nec2"),
+        "missing expected pulse-rhs values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn invalid_pulse_rhs_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&[
+        "--pulse-rhs",
+        "bogus",
+        fixture_deck("dipole-freesp-51seg.nec").to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --pulse-rhs value 'bogus'"),
+        "missing invalid pulse-rhs detail in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: raw|nec2"),
+        "missing expected pulse-rhs values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn invalid_exec_value_reports_contract_error_and_usage() {
     let output = run_fnec(&[
         "--exec",
@@ -54,6 +110,78 @@ fn invalid_exec_value_reports_contract_error_and_usage() {
 }
 
 #[test]
+fn missing_bench_format_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&["--bench-format"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("missing value after --bench-format"),
+        "missing bench-format parse error in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: human|csv|json"),
+        "missing expected bench-format values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn invalid_bench_format_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&[
+        "--bench-format",
+        "bogus",
+        fixture_deck("dipole-freesp-51seg.nec").to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --bench-format value 'bogus'"),
+        "missing invalid bench-format detail in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: human|csv|json"),
+        "missing expected bench-format values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn missing_ex3_i4_mode_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&["--ex3-i4-mode"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("missing value after --ex3-i4-mode"),
+        "missing ex3-i4-mode parse error in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: legacy|divide-by-i4"),
+        "missing expected ex3-i4-mode values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn invalid_ex3_i4_mode_value_reports_contract_error_and_usage() {
+    let output = run_fnec(&[
+        "--ex3-i4-mode",
+        "bogus",
+        fixture_deck("dipole-freesp-51seg.nec").to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid --ex3-i4-mode value 'bogus'"),
+        "missing invalid ex3-i4-mode detail in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: legacy|divide-by-i4"),
+        "missing expected ex3-i4-mode values in stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn unknown_option_reports_contract_error() {
     let output = run_fnec(&["--definitely-not-a-flag"]);
     assert_eq!(output.status.code(), Some(2));
@@ -62,6 +190,24 @@ fn unknown_option_reports_contract_error() {
     assert!(
         stderr.contains("unknown option: --definitely-not-a-flag"),
         "missing unknown-option error in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn unexpected_extra_argument_reports_contract_error() {
+    let deck = fixture_deck("dipole-freesp-51seg.nec");
+    let output = run_fnec(&[
+        "--solver",
+        "hallen",
+        deck.to_str().unwrap(),
+        deck.to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected extra argument:"),
+        "missing extra-argument parse error in stderr:\n{stderr}"
     );
 }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -55,6 +55,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: added CLI core-flags contract tests (`apps/nec-cli/tests/core_flags_contract.rs`) covering parse-error contracts (missing/invalid values, unknown options, missing deck path) and a full core-flag success invocation path.
 	- 2026-04-29 progress: extended scriptability contracts to bench mode by locking that `bench_json:` records remain on stderr while stdout keeps the stable report stream for machine parsers.
 	- 2026-04-29 progress: hardened scriptability contracts with three additional locks: bench CSV records remain on stderr (`bench_csv:` prefix absent from stdout), nonexistent deck exits with code 1 and "cannot read" on stderr (no report on stdout), and no-arg invocation exits with code 2 and usage on stderr (no report on stdout).
+	- 2026-04-29 progress: completed Phase 1 core-flag CLI contract coverage by locking the remaining parser branches in `apps/nec-cli/tests/core_flags_contract.rs` (invalid `--solver`, missing/invalid `--pulse-rhs`, missing/invalid `--bench-format`, missing/invalid `--ex3-i4-mode`, and unexpected extra argument handling).
 
 ## Parity-driven backlog items
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,7 +80,7 @@ fnec-rust is not aiming for "good enough for a Rust rewrite". The target is to b
 - [x] Assemble golden reference corpus (half-wave dipole free-space/over-ground, Yagi, loaded element, frequency sweep, multi-source, GM/GR equivalence cases).
 - [x] Run corpus through reference and fnec-rust; validate all in-scope results within tolerance matrix (CI corpus-validation gate active for contracted in-scope fixtures).
 - [x] Simple ground model (infinite, raised dielectric) working and tested (GN type 0 simple finite-ground model activated and regression-gated in corpus CI).
-- [ ] CLI-first execution flow complete with all core flags (solver mode, solver options).
+- [x] CLI-first execution flow complete with all core flags (solver mode, solver options).
 - [ ] Produce 4nec2/EZNEC-grade text outputs for impedance, sweep points, gain, pattern, and current tables so the CLI is immediately usable as a daily comparison tool.
 - [ ] Close the remaining Phase 1 corpus gaps (loaded element reference parity and broader non-collinear support) so the parity claim is not limited to only the easy cases. Current blocker: Hallen correctly rejects the `dipole-loaded` top-hat geometry as non-collinear, while pulse/continuity/sinusoidal all collapse to the same inaccurate pulse result (`-13.778 + j374.425 Ω` vs external candidate `13.463 - j896.032 Ω` at 7.1 MHz).
 - [ ] Ensure the CLI remains at least as scriptable and batch-friendly as open NEC2 tools like yeti01/nec2, including predictable stdin/stdout behavior and stable machine-parseable reporting conventions.


### PR DESCRIPTION
## Summary

- extend CLI core-flags contract coverage to lock the remaining value-taking parse branches
- add regression coverage for invalid `--solver`, missing or invalid `--pulse-rhs`, missing or invalid `--bench-format`, missing or invalid `--ex3-i4-mode`, and unexpected extra argument handling
- mark the Phase 1 roadmap item for core CLI flag completeness done and record backlog progress

## Validation

- cargo fmt
- cargo check
- cargo test -p nec-cli --test core_flags_contract
- ./scripts/validate-doc-frontmatter.sh
