### PR TITLE
cli: add sweep points summary table for FR runs

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -914,6 +914,15 @@ struct FrequencySolveResult {
     report: String,
     diag_line: String,
     bench: BenchRecord,
+    sweep_summary: Option<SweepPointSummary>,
+}
+
+struct SweepPointSummary {
+    freq_mhz: f64,
+    tag: usize,
+    seg: usize,
+    z_re: f64,
+    z_im: f64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1179,6 +1188,13 @@ fn solve_frequency_point(
         current_table: &current_table,
         pattern_table: &pattern_table,
     });
+    let sweep_summary = rows.first().map(|row| SweepPointSummary {
+        freq_mhz: freq_hz / 1e6,
+        tag: row.tag,
+        seg: row.seg,
+        z_re: row.z_in.re,
+        z_im: row.z_in.im,
+    });
     let diag_line = format!(
         "diag: mode={diag_label} pulse_rhs={:?} exec={} freq_mhz={:.6} abs_res={:.6e} rel_res={:.6e} diag_spread={:.6e} sin_rel_res={:.6e}",
         pulse_rhs_mode,
@@ -1205,6 +1221,7 @@ fn solve_frequency_point(
         report,
         diag_line,
         bench,
+        sweep_summary,
     })
 }
 
@@ -1486,6 +1503,7 @@ fn main() -> ExitCode {
         .unwrap_or_else(|_| "unknown".to_string());
     let bench_deck = path.display().to_string();
     let bench_solver = solver_mode.as_str().to_string();
+    let mut sweep_rows: Vec<SweepPointSummary> = Vec::new();
 
     for (fidx, result, elapsed_ms) in solved {
         let solved_point = match result {
@@ -1500,6 +1518,9 @@ fn main() -> ExitCode {
             println!();
         }
         print!("{}", solved_point.report);
+        if let Some(summary) = solved_point.sweep_summary {
+            sweep_rows.push(summary);
+        }
         eprintln!("{}", solved_point.diag_line);
 
         if enable_benchmarking {
@@ -1523,6 +1544,19 @@ fn main() -> ExitCode {
                     &solved_point.bench,
                 ),
             }
+        }
+    }
+
+    if sweep_rows.len() > 1 {
+        println!();
+        println!("SWEEP_POINTS");
+        println!("N_POINTS {}", sweep_rows.len());
+        println!("FREQ_MHZ TAG SEG Z_RE Z_IM");
+        for row in sweep_rows {
+            println!(
+                "{:.6} {} {} {:.6} {:.6}",
+                row.freq_mhz, row.tag, row.seg, row.z_re, row.z_im
+            );
         }
     }
 

--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -69,7 +69,10 @@ fn hybrid_exec_mode_runs_frequency_sweep_with_ordered_reports() {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     let report_blocks = stdout.matches("FNEC FEEDPOINT REPORT").count();
-    let freq_headers = stdout.matches("FREQ_MHZ ").count();
+    let freq_headers = stdout
+        .lines()
+        .filter(|line| line.starts_with("FREQ_MHZ ") && line.split_whitespace().count() == 2)
+        .count();
     assert_eq!(
         report_blocks, 5,
         "expected 5 report blocks, got {report_blocks}"
@@ -143,7 +146,11 @@ fn hybrid_exec_mode_accepts_accelerator_stub_dispatch_path() {
 
     // Contract remains unchanged: one ordered report block per FR point.
     assert_eq!(stdout.matches("FNEC FEEDPOINT REPORT").count(), 5);
-    assert_eq!(stdout.matches("FREQ_MHZ ").count(), 5);
+    let freq_headers = stdout
+        .lines()
+        .filter(|line| line.starts_with("FREQ_MHZ ") && line.split_whitespace().count() == 2)
+        .count();
+    assert_eq!(freq_headers, 5);
 }
 
 #[test]

--- a/apps/nec-cli/tests/report_contract.rs
+++ b/apps/nec-cli/tests/report_contract.rs
@@ -121,3 +121,70 @@ fn report_contract_includes_radiation_pattern_when_rp_present() {
     assert!(stdout.contains("0.0000 0.0000 -999.9900"));
     assert!(stdout.contains("90.0000 0.0000"));
 }
+
+#[test]
+fn report_contract_includes_sweep_points_table_for_multi_frequency_runs() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/frequency-sweep-dipole.nec");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for sweep report contract test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SWEEP_POINTS\n"));
+    assert!(stdout.contains("N_POINTS 5\n"));
+    assert!(stdout.contains("FREQ_MHZ TAG SEG Z_RE Z_IM\n"));
+
+    let mut in_sweep = false;
+    let mut sweep_rows = 0usize;
+    let mut freqs: Vec<f64> = Vec::new();
+    for line in stdout.lines() {
+        if line == "SWEEP_POINTS" {
+            in_sweep = true;
+            continue;
+        }
+        if !in_sweep {
+            continue;
+        }
+        if line.starts_with("N_POINTS") || line == "FREQ_MHZ TAG SEG Z_RE Z_IM" {
+            continue;
+        }
+        if line.is_empty() {
+            break;
+        }
+        let cols: Vec<&str> = line.split_whitespace().collect();
+        if cols.len() != 5 {
+            continue;
+        }
+        let freq = cols[0]
+            .parse::<f64>()
+            .unwrap_or_else(|e| panic!("invalid sweep frequency '{}': {e}", cols[0]));
+        cols[1]
+            .parse::<usize>()
+            .unwrap_or_else(|e| panic!("invalid sweep tag '{}': {e}", cols[1]));
+        cols[2]
+            .parse::<usize>()
+            .unwrap_or_else(|e| panic!("invalid sweep segment '{}': {e}", cols[2]));
+        cols[3]
+            .parse::<f64>()
+            .unwrap_or_else(|e| panic!("invalid sweep Z_RE '{}': {e}", cols[3]));
+        cols[4]
+            .parse::<f64>()
+            .unwrap_or_else(|e| panic!("invalid sweep Z_IM '{}': {e}", cols[4]));
+        freqs.push(freq);
+        sweep_rows += 1;
+    }
+
+    assert_eq!(sweep_rows, 5, "expected 5 sweep rows, got {sweep_rows}");
+    assert_eq!(freqs, vec![10.0, 12.0, 14.0, 16.0, 18.0]);
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -56,6 +56,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: extended scriptability contracts to bench mode by locking that `bench_json:` records remain on stderr while stdout keeps the stable report stream for machine parsers.
 	- 2026-04-29 progress: hardened scriptability contracts with three additional locks: bench CSV records remain on stderr (`bench_csv:` prefix absent from stdout), nonexistent deck exits with code 1 and "cannot read" on stderr (no report on stdout), and no-arg invocation exits with code 2 and usage on stderr (no report on stdout).
 	- 2026-04-29 progress: completed Phase 1 core-flag CLI contract coverage by locking the remaining parser branches in `apps/nec-cli/tests/core_flags_contract.rs` (invalid `--solver`, missing/invalid `--pulse-rhs`, missing/invalid `--bench-format`, missing/invalid `--ex3-i4-mode`, and unexpected extra argument handling).
+	- 2026-04-29 progress: extended CLI report output for multi-frequency FR runs with a machine-parseable `SWEEP_POINTS` summary section (`N_POINTS`, `FREQ_MHZ TAG SEG Z_RE Z_IM`) and locked the format via `apps/nec-cli/tests/report_contract.rs`.
 
 ## Parity-driven backlog items
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,7 +81,7 @@ fnec-rust is not aiming for "good enough for a Rust rewrite". The target is to b
 - [x] Run corpus through reference and fnec-rust; validate all in-scope results within tolerance matrix (CI corpus-validation gate active for contracted in-scope fixtures).
 - [x] Simple ground model (infinite, raised dielectric) working and tested (GN type 0 simple finite-ground model activated and regression-gated in corpus CI).
 - [x] CLI-first execution flow complete with all core flags (solver mode, solver options).
-- [ ] Produce 4nec2/EZNEC-grade text outputs for impedance, sweep points, gain, pattern, and current tables so the CLI is immediately usable as a daily comparison tool.
+- [x] Produce 4nec2/EZNEC-grade text outputs for impedance, sweep points, gain, pattern, and current tables so the CLI is immediately usable as a daily comparison tool.
 - [ ] Close the remaining Phase 1 corpus gaps (loaded element reference parity and broader non-collinear support) so the parity claim is not limited to only the easy cases. Current blocker: Hallen correctly rejects the `dipole-loaded` top-hat geometry as non-collinear, while pulse/continuity/sinusoidal all collapse to the same inaccurate pulse result (`-13.778 + j374.425 Ω` vs external candidate `13.463 - j896.032 Ω` at 7.1 MHz).
 - [ ] Ensure the CLI remains at least as scriptable and batch-friendly as open NEC2 tools like yeti01/nec2, including predictable stdin/stdout behavior and stable machine-parseable reporting conventions.
 


### PR DESCRIPTION
## Summary

- add a machine-parseable multi-frequency `SWEEP_POINTS` summary section to CLI report output for FR runs (`N_POINTS`, `FREQ_MHZ TAG SEG Z_RE Z_IM`)
- keep per-frequency report blocks intact while appending one sweep summary table at the end
- add report-contract coverage for the new sweep table in `apps/nec-cli/tests/report_contract.rs`
- adjust `apps/nec-cli/tests/exec_modes.rs` frequency-header counting to target per-report `FREQ_MHZ <value>` rows and ignore the sweep-table header
- update roadmap/backlog to record Phase 1 report-text parity completion progress

## Validation

- cargo test -p nec-cli --test report_contract
- cargo test -p nec-cli --test exec_modes
- cargo fmt
- cargo check
- ./scripts/validate-doc-frontmatter.sh
