### PR TITLE
corpus: lock loaded non-collinear Hallen path

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -939,6 +939,81 @@ fn par002_ground_checklist_cases_are_present_and_contracted() {
     }
 }
 
+#[test]
+fn phase1_loaded_corpus_gap_cases_are_present_and_contracted() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let corpus_root = workspace_root.join("corpus");
+    let reference_path = corpus_root.join("reference-results.json");
+
+    let json_text = std::fs::read_to_string(&reference_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", reference_path.display()));
+    let root: Value = serde_json::from_str(&json_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {}: {e}", reference_path.display()));
+
+    let cases = root
+        .get("cases")
+        .and_then(Value::as_object)
+        .expect("reference-results.json missing 'cases' object");
+
+    let blocked_case = cases
+        .get("dipole-loaded")
+        .and_then(Value::as_object)
+        .expect("Phase 1 loaded-gap case 'dipole-loaded' missing");
+    assert!(
+        blocked_case
+            .get("expected_hallen_error_contains")
+            .and_then(Value::as_str)
+            .is_some(),
+        "Phase 1 loaded-gap case 'dipole-loaded' must keep expected Hallen failure contract"
+    );
+
+    let experimental_case = cases
+        .get("dipole-loaded-noncollinear-hallen")
+        .and_then(Value::as_object)
+        .expect("Phase 1 loaded-gap case 'dipole-loaded-noncollinear-hallen' missing");
+
+    let deck_file = experimental_case
+        .get("deck_file")
+        .and_then(Value::as_str)
+        .expect("'dipole-loaded-noncollinear-hallen' missing 'deck_file'");
+    let deck_path = corpus_root.join(deck_file);
+    assert!(
+        deck_path.exists(),
+        "Phase 1 loaded-gap deck missing for case 'dipole-loaded-noncollinear-hallen': {}",
+        deck_path.display()
+    );
+
+    let cli_args = experimental_case
+        .get("cli_args")
+        .and_then(Value::as_array)
+        .expect("'dipole-loaded-noncollinear-hallen' missing 'cli_args'");
+    assert!(
+        cli_args
+            .iter()
+            .any(|v| v.as_str() == Some("--allow-noncollinear-hallen")),
+        "'dipole-loaded-noncollinear-hallen' must include --allow-noncollinear-hallen in cli_args"
+    );
+
+    let warning_contract = experimental_case
+        .get("expected_warning_substrings")
+        .and_then(Value::as_array)
+        .expect("'dipole-loaded-noncollinear-hallen' missing expected warning contract");
+    assert!(
+        !warning_contract.is_empty(),
+        "'dipole-loaded-noncollinear-hallen' expected warning contract must not be empty"
+    );
+
+    let feed = experimental_case
+        .get("feedpoint_impedance")
+        .and_then(Value::as_object)
+        .expect("'dipole-loaded-noncollinear-hallen' missing 'feedpoint_impedance'");
+    assert!(
+        feed.get("real_ohm").and_then(Value::as_f64).is_some()
+            && feed.get("imag_ohm").and_then(Value::as_f64).is_some(),
+        "'dipole-loaded-noncollinear-hallen' must have numeric real_ohm and imag_ohm"
+    );
+}
+
 fn collect_expected_sources(
     case_obj: &Map<String, Value>,
     feed: &Map<String, Value>,

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -1316,6 +1316,38 @@
       },
       "status": "Hallen path now rejects this case as unsupported because the loaded loop is non-collinear with the driven wire axis. External candidate captured via NEC2DXS500+XQ; full non-collinear solver support is still pending."
     },
+    "dipole-loaded-noncollinear-hallen": {
+      "deck_file": "dipole-loaded.nec",
+      "description": "14.2 MHz dipole driven at 7.1 MHz with top-hat loading loop, using --allow-noncollinear-hallen",
+      "cli_args": [
+        "--allow-noncollinear-hallen"
+      ],
+      "frequency_mhz": 7.1,
+      "segments": null,
+      "wires": 5,
+      "sources": 1,
+      "ground": "none",
+      "reference_source": "fnec Hallen solver (experimental non-collinear projection path regression lock)",
+      "expected_warning_substrings": [
+        "--allow-noncollinear-hallen enables an EXPERIMENTAL Hallen RHS projection on non-collinear geometries"
+      ],
+      "feedpoint_impedance": {
+        "real_ohm": 12.386579,
+        "imag_ohm": -918.149412
+      },
+      "external_reference_candidate": {
+        "source": "NEC2DXS500 via Wine (temporary XQ-inserted deck)",
+        "real_ohm": 13.4632,
+        "imag_ohm": -896.032
+      },
+      "tolerance_gates": {
+        "R_percent_rel": 0.1,
+        "X_percent_rel": 0.1,
+        "R_absolute_ohm": 0.05,
+        "X_absolute_ohm": 0.05
+      },
+      "status": "Regression lock for the experimental non-collinear Hallen path on the loaded top-hat case while full non-collinear basis support remains pending."
+    },
     "frequency-sweep-dipole": {
       "deck_file": "frequency-sweep-dipole.nec",
       "description": "Half-wave dipole, frequency sweep: 10, 12, 14, 16, 18 MHz (FR step 2.0 MHz from 10.0)",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,6 +57,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: hardened scriptability contracts with three additional locks: bench CSV records remain on stderr (`bench_csv:` prefix absent from stdout), nonexistent deck exits with code 1 and "cannot read" on stderr (no report on stdout), and no-arg invocation exits with code 2 and usage on stderr (no report on stdout).
 	- 2026-04-29 progress: completed Phase 1 core-flag CLI contract coverage by locking the remaining parser branches in `apps/nec-cli/tests/core_flags_contract.rs` (invalid `--solver`, missing/invalid `--pulse-rhs`, missing/invalid `--bench-format`, missing/invalid `--ex3-i4-mode`, and unexpected extra argument handling).
 	- 2026-04-29 progress: extended CLI report output for multi-frequency FR runs with a machine-parseable `SWEEP_POINTS` summary section (`N_POINTS`, `FREQ_MHZ TAG SEG Z_RE Z_IM`) and locked the format via `apps/nec-cli/tests/report_contract.rs`.
+	- 2026-04-29 progress: added corpus case `dipole-loaded-noncollinear-hallen` (with `--allow-noncollinear-hallen`) to lock the experimental non-collinear Hallen path on the top-hat loaded deck, and added checklist test `phase1_loaded_corpus_gap_cases_are_present_and_contracted` to keep both loaded-case contracts (`dipole-loaded` blocked path + experimental opt-in path) present in CI.
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary

- add corpus reference case `dipole-loaded-noncollinear-hallen` using `--allow-noncollinear-hallen` to lock the experimental non-collinear Hallen path on the top-hat loaded deck
- lock warning contract for that path and capture current feedpoint impedance regression values
- add checklist test `phase1_loaded_corpus_gap_cases_are_present_and_contracted` to keep both loaded-case contracts present in CI:
  - default Hallen rejection contract (`dipole-loaded`)
  - experimental opt-in non-collinear contract (`dipole-loaded-noncollinear-hallen`)
- update backlog progress entry for this Phase 1 corpus-gap increment

## Validation

- cargo test -p nec-cli --test corpus_validation
- cargo fmt
- cargo check
- ./scripts/validate-doc-frontmatter.sh
