### PR TITLE
docs: close Phase 1 CLI scriptability checklist item

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -58,6 +58,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: completed Phase 1 core-flag CLI contract coverage by locking the remaining parser branches in `apps/nec-cli/tests/core_flags_contract.rs` (invalid `--solver`, missing/invalid `--pulse-rhs`, missing/invalid `--bench-format`, missing/invalid `--ex3-i4-mode`, and unexpected extra argument handling).
 	- 2026-04-29 progress: extended CLI report output for multi-frequency FR runs with a machine-parseable `SWEEP_POINTS` summary section (`N_POINTS`, `FREQ_MHZ TAG SEG Z_RE Z_IM`) and locked the format via `apps/nec-cli/tests/report_contract.rs`.
 	- 2026-04-29 progress: added corpus case `dipole-loaded-noncollinear-hallen` (with `--allow-noncollinear-hallen`) to lock the experimental non-collinear Hallen path on the top-hat loaded deck, and added checklist test `phase1_loaded_corpus_gap_cases_are_present_and_contracted` to keep both loaded-case contracts (`dipole-loaded` blocked path + experimental opt-in path) present in CI.
+	- 2026-04-29 progress: closed the Phase 1 CLI scriptability/batch-friendliness checklist item using the expanded contract suite (`apps/nec-cli/tests/scriptability_contract.rs` and `apps/nec-cli/tests/core_flags_contract.rs`) that locks stable stdout report headers, stderr-only warnings/bench records (`bench_json:`/`bench_csv:`), deterministic parse-error exit codes, and no-arg/missing-deck stream behavior.
 
 ## Parity-driven backlog items
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,7 @@ fnec-rust is not aiming for "good enough for a Rust rewrite". The target is to b
 - [x] CLI-first execution flow complete with all core flags (solver mode, solver options).
 - [x] Produce 4nec2/EZNEC-grade text outputs for impedance, sweep points, gain, pattern, and current tables so the CLI is immediately usable as a daily comparison tool.
 - [ ] Close the remaining Phase 1 corpus gaps (loaded element reference parity and broader non-collinear support) so the parity claim is not limited to only the easy cases. Current blocker: Hallen correctly rejects the `dipole-loaded` top-hat geometry as non-collinear, while pulse/continuity/sinusoidal all collapse to the same inaccurate pulse result (`-13.778 + j374.425 Ω` vs external candidate `13.463 - j896.032 Ω` at 7.1 MHz).
-- [ ] Ensure the CLI remains at least as scriptable and batch-friendly as open NEC2 tools like yeti01/nec2, including predictable stdin/stdout behavior and stable machine-parseable reporting conventions.
+- [x] Ensure the CLI remains at least as scriptable and batch-friendly as open NEC2 tools like yeti01/nec2, including predictable stdin/stdout behavior and stable machine-parseable reporting conventions.
 
 **Blocker dependencies**: BLK-002 (NEC-4 feature boundary).
 


### PR DESCRIPTION
## Summary

- mark the Phase 1 roadmap item for CLI scriptability/batch-friendliness as complete
- add backlog evidence linking the checklist closeout to existing contract suites:
  - `apps/nec-cli/tests/scriptability_contract.rs`
  - `apps/nec-cli/tests/core_flags_contract.rs`

## Validation

- cargo test -p nec-cli --test scriptability_contract --test core_flags_contract
- cargo fmt
- cargo check
- ./scripts/validate-doc-frontmatter.sh
