### PR TITLE
Phase2: add current/phase corpus contracts

### DIFF
--- a/apps/nec-cli/tests/corpus_validation.rs
+++ b/apps/nec-cli/tests/corpus_validation.rs
@@ -1033,6 +1033,67 @@ fn phase1_loaded_corpus_gap_cases_are_present_and_contracted() {
     );
 }
 
+#[test]
+fn phase2_current_phase_corpus_contract_is_present_and_contracted() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let corpus_root = workspace_root.join("corpus");
+    let reference_path = corpus_root.join("reference-results.json");
+
+    let json_text = std::fs::read_to_string(&reference_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", reference_path.display()));
+    let root: Value = serde_json::from_str(&json_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {}: {e}", reference_path.display()));
+
+    let cases = root
+        .get("cases")
+        .and_then(Value::as_object)
+        .expect("reference-results.json missing 'cases' object");
+
+    let case_obj = cases
+        .get("dipole-freesp-51seg")
+        .and_then(Value::as_object)
+        .expect("PH2 current/phase checklist case 'dipole-freesp-51seg' missing");
+
+    let deck_file = case_obj
+        .get("deck_file")
+        .and_then(Value::as_str)
+        .expect("'dipole-freesp-51seg' missing 'deck_file'");
+    let deck_path = corpus_root.join(deck_file);
+    assert!(
+        deck_path.exists(),
+        "PH2 current/phase checklist deck missing: {}",
+        deck_path.display()
+    );
+
+    let gates = case_obj
+        .get("tolerance_gates")
+        .and_then(Value::as_object)
+        .expect("'dipole-freesp-51seg' missing 'tolerance_gates'");
+    assert!(
+        gates
+            .get("Current_amplitude_dB")
+            .and_then(Value::as_f64)
+            .is_some(),
+        "'dipole-freesp-51seg' must define Current_amplitude_dB tolerance gate"
+    );
+    assert!(
+        gates
+            .get("Current_phase_deg")
+            .and_then(Value::as_f64)
+            .is_some(),
+        "'dipole-freesp-51seg' must define Current_phase_deg tolerance gate"
+    );
+
+    let current_samples = case_obj
+        .get("current_samples")
+        .and_then(Value::as_array)
+        .expect("'dipole-freesp-51seg' missing 'current_samples' array");
+    assert!(
+        current_samples.len() >= 3,
+        "'dipole-freesp-51seg' should include at least 3 current sample contracts"
+    );
+}
+
 fn collect_expected_sources(
     case_obj: &Map<String, Value>,
     feed: &Map<String, Value>,
@@ -1290,8 +1351,8 @@ fn parse_current_rows(stdout: &str) -> Vec<(usize, usize, f64, f64)> {
         }
 
         let parts: Vec<&str> = line.split_whitespace().collect();
-        // Format: TAG SEG I_MAG I_PHASE ...
-        if parts.len() < 4 {
+        // Format: TAG SEG I_RE I_IM I_MAG I_PHASE
+        if parts.len() < 6 {
             continue;
         }
 
@@ -1301,10 +1362,10 @@ fn parse_current_rows(stdout: &str) -> Vec<(usize, usize, f64, f64)> {
         let Ok(seg) = parts[1].parse::<usize>() else {
             continue;
         };
-        let Ok(magnitude_db) = parts[2].parse::<f64>() else {
+        let Ok(magnitude_db) = parts[4].parse::<f64>() else {
             continue;
         };
-        let Ok(phase_deg) = parts[3].parse::<f64>() else {
+        let Ok(phase_deg) = parts[5].parse::<f64>() else {
             continue;
         };
 

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -22,8 +22,30 @@
         "R_percent_rel": 0.1,
         "X_percent_rel": 0.1,
         "R_absolute_ohm": 0.05,
-        "X_absolute_ohm": 0.05
+        "X_absolute_ohm": 0.05,
+        "Current_amplitude_dB": 0.0001,
+        "Current_phase_deg": 0.1
       },
+      "current_samples": [
+        {
+          "wire_id": 1,
+          "segment_id": 1,
+          "amplitude_db": 2.167828e-7,
+          "phase_deg": -86.2964
+        },
+        {
+          "wire_id": 1,
+          "segment_id": 26,
+          "amplitude_db": 0.01323928,
+          "phase_deg": -10.6040
+        },
+        {
+          "wire_id": 1,
+          "segment_id": 51,
+          "amplitude_db": 2.167828e-7,
+          "phase_deg": -86.2964
+        }
+      ],
       "status": "Reference captured from Python study; xnec2c validation TBD"
     },
     "dipole-ex3-freesp-51seg": {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -61,6 +61,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: closed the Phase 1 CLI scriptability/batch-friendliness checklist item using the expanded contract suite (`apps/nec-cli/tests/scriptability_contract.rs` and `apps/nec-cli/tests/core_flags_contract.rs`) that locks stable stdout report headers, stderr-only warnings/bench records (`bench_json:`/`bench_csv:`), deterministic parse-error exit codes, and no-arg/missing-deck stream behavior.
 	- 2026-04-29 progress: strengthened loaded-case parity tracking by adding external impedance gates to `dipole-loaded-noncollinear-hallen` (`ExternalR_absolute_ohm=5`, `ExternalX_absolute_ohm=35`) and extending `phase1_loaded_corpus_gap_cases_are_present_and_contracted` to require those external gates.
 	- 2026-04-29 progress: added an EZNEC-informed concrete Phase 2 implementation checklist to `docs/roadmap.md` (`PH2-CHK-001..008`), explicitly mapping roadmap parity IDs (`PRT-*`, `CP-*`) to implementation targets and validation artifacts (test/corpus files).
+	- 2026-04-29 progress: started PH2-CHK-005 corpus truth expansion for current/phase classes by adding deterministic `current_samples` and current/phase tolerance gates to `dipole-freesp-51seg` in `corpus/reference-results.json`, plus checklist gate `phase2_current_phase_corpus_contract_is_present_and_contracted` in `apps/nec-cli/tests/corpus_validation.rs`.
 
 ## Parity-driven backlog items
 


### PR DESCRIPTION
## Summary
- expand PH2-CHK-005 corpus truth with deterministic current/phase sample contracts on `dipole-freesp-51seg`
- add explicit current/phase tolerance gates (`Current_amplitude_dB`, `Current_phase_deg`) in corpus references
- add checklist test `phase2_current_phase_corpus_contract_is_present_and_contracted` to keep the new contract surface present
- fix current-row parsing in corpus validation to consume `I_MAG`/`I_PHASE` columns (matching schema and report contract)

## Files touched
- `corpus/reference-results.json`
- `apps/nec-cli/tests/corpus_validation.rs`
- `docs/backlog.md`

## Validation
- `cargo test -p nec-cli --test corpus_validation`
- `cargo fmt`
- `cargo check`
- `./scripts/validate-doc-frontmatter.sh`
