### PR TITLE
cli: add tiny source-segment geometry guard

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -664,6 +664,39 @@ fn segment_intersection_error(segs: &[nec_solver::Segment]) -> Option<String> {
     None
 }
 
+fn source_risk_geometry_error(cards: &[Card], segs: &[nec_solver::Segment]) -> Option<String> {
+    const MIN_SOURCE_LENGTH_TO_RADIUS_RATIO: f64 = 2.0;
+
+    for card in cards {
+        if let Card::Ex(ex) = card {
+            let Some(seg) = segs
+                .iter()
+                .find(|s| s.tag == ex.tag && s.tag_index == ex.segment)
+            else {
+                continue;
+            };
+
+            if seg.radius <= 0.0 {
+                continue;
+            }
+
+            let length_to_radius = seg.length / seg.radius;
+            if length_to_radius < MIN_SOURCE_LENGTH_TO_RADIUS_RATIO {
+                return Some(format!(
+                    "unsupported source-risk geometry: EX on tiny segment tag {} seg {} (length={:.6e} m, radius={:.6e} m, L/r={:.3}). Increase segment length or reduce wire radius; tiny-loop/source-risk classes are deferred",
+                    ex.tag,
+                    ex.segment,
+                    seg.length,
+                    seg.radius,
+                    length_to_radius,
+                ));
+            }
+        }
+    }
+
+    None
+}
+
 fn buried_wire_geometry_error(
     segs: &[nec_solver::Segment],
     ground: &GroundModel,
@@ -1664,6 +1697,10 @@ fn main() -> ExitCode {
         }
     };
     if let Some(err) = segment_intersection_error(&segs) {
+        eprintln!("error: {err}");
+        return ExitCode::FAILURE;
+    }
+    if let Some(err) = source_risk_geometry_error(&deck.cards, &segs) {
         eprintln!("error: {err}");
         return ExitCode::FAILURE;
     }

--- a/apps/nec-cli/tests/geometry_diagnostics.rs
+++ b/apps/nec-cli/tests/geometry_diagnostics.rs
@@ -73,3 +73,39 @@ fn endpoint_wire_junction_is_not_rejected_as_intersection() {
         "did not expect intersection geometry error for endpoint join, got:\n{stderr}"
     );
 }
+
+#[test]
+fn tiny_source_segment_fails_fast_with_actionable_error() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-geometry-tiny-source-{now}.nec"));
+
+    // Very short source segment (length/radius < 2) is currently deferred and
+    // should fail early with an actionable source-risk geometry diagnostic.
+    let deck =
+        "GW 1 1 0.0 0.0 0.0 0.000001 0.0 0.0 0.001\nEX 0 1 1 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary tiny-source deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for tiny-source test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        !output.status.success(),
+        "tiny-source deck should fail, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error: unsupported source-risk geometry: EX on tiny segment"),
+        "expected source-risk geometry error in stderr, got:\n{stderr}"
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -68,6 +68,7 @@ last_updated: 2026-04-29
 	- 2026-04-29 progress: advanced PH2-CHK-008 scriptability preservation by extending `apps/nec-cli/tests/scriptability_contract.rs` to lock `FEEDPOINTS -> SOURCES -> CURRENTS` stdout ordering and to assert `LOADS` table rendering remains stdout-only while parser warnings stay stderr-only.
 	- 2026-04-29 progress: tightened Phase 1 loaded-gap guardrails in `apps/nec-cli/tests/loaded_case_tracking.rs` with an explicit default-Hallen contract test on `dipole-loaded` that locks fail-fast non-collinear diagnostics, exit code 1, and no report emission on stdout.
 	- 2026-04-29 progress: started PH2-CHK-006 geometry diagnostics slice by adding an early-fail CLI guard for unsupported intersecting wire segments (non-endpoint crossings) before solve, with deterministic integration contracts in `apps/nec-cli/tests/geometry_diagnostics.rs` covering both failing crossing-wire geometry and allowed endpoint junctions.
+	- 2026-04-29 progress: extended PH2-CHK-006 geometry guardrails with a tiny source-segment early-fail contract (`EX` on `L/r < 2`), adding deterministic CLI diagnostics coverage in `apps/nec-cli/tests/geometry_diagnostics.rs`.
 
 ## Parity-driven backlog items
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ All notable documentation process changes are recorded here.
 
 ### Changed
 
+- Geometry diagnostics now also fail fast for source-risk tiny segments: `EX` requests on `L/r < 2` emit an actionable deferred-class error before solve.
 - GN type 0 is now active as a simple finite-ground model in Hallen impedance assembly (complex Fresnel-style image scaling from EPSE/SIG) instead of the prior deferred free-space fallback warning path.
 - Phase 2 current/phase corpus coverage now includes both `dipole-freesp-51seg` and `dipole-ground-51seg`, so CI locks representative free-space and PEC-ground current magnitude/phase samples instead of only the base dipole case.
 - EX type 1 now has a first real implementation slice for `--solver pulse`: the pulse solver enforces the requested driven-segment current and reports the resulting source voltage/impedance. Hallen and other non-pulse paths still keep the staged portability fallback warning.


### PR DESCRIPTION
## Summary
- extend PH2-CHK-006 geometry diagnostics with a second early-fail class for source-risk tiny segments
- add a fail-fast CLI guard for `EX` sources placed on tiny segments (`L/r < 2`) with actionable error text
- add deterministic integration coverage for the new contract and document progress in backlog/changelog

## Validation
- cargo test -p nec-cli --test geometry_diagnostics
- cargo fmt
- cargo check
- ./scripts/validate-doc-frontmatter.sh
