### PR TITLE
refactor(cli): extract execution profile policy module

### DIFF
--- a/apps/nec-cli/src/exec_profile.rs
+++ b/apps/nec-cli/src/exec_profile.rs
@@ -1,0 +1,111 @@
+use super::ExecutionMode;
+use nec_accel::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CompatibilityProfile {
+    Native,
+    FourNec2DropIn,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct StartupExecutionProbe {
+    pub(super) cpu_threads: usize,
+    pub(super) freq_points: usize,
+    pub(super) gpu_available: bool,
+    pub(super) hybrid_gpu_lane_available: bool,
+}
+
+pub(super) fn detect_compatibility_profile(argv0: &str) -> CompatibilityProfile {
+    let stem = Path::new(argv0)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if stem.contains("nec2dxs") || stem.contains("4nec2") {
+        CompatibilityProfile::FourNec2DropIn
+    } else {
+        CompatibilityProfile::Native
+    }
+}
+
+pub(super) fn steer_execution_mode_by_profile(
+    execution_mode: ExecutionMode,
+    profile: CompatibilityProfile,
+    exec_flag_explicitly_set: bool,
+) -> ExecutionMode {
+    if exec_flag_explicitly_set {
+        return execution_mode;
+    }
+
+    match profile {
+        CompatibilityProfile::Native => execution_mode,
+        // In drop-in mode prefer throughput when caller did not force an exec mode.
+        CompatibilityProfile::FourNec2DropIn => ExecutionMode::Hybrid,
+    }
+}
+
+pub(super) fn warn_compatibility_profile(
+    profile: CompatibilityProfile,
+    requested_execution_mode: ExecutionMode,
+    effective_execution_mode: ExecutionMode,
+    exec_flag_explicitly_set: bool,
+) {
+    if profile != CompatibilityProfile::FourNec2DropIn {
+        return;
+    }
+
+    if exec_flag_explicitly_set {
+        eprintln!(
+            "warning: 4nec2 drop-in compatibility profile detected by binary name; preserving explicit --exec={}",
+            requested_execution_mode.as_diag_str()
+        );
+    } else {
+        eprintln!(
+            "warning: 4nec2 drop-in compatibility profile detected by binary name; default execution path steered to exec={}",
+            effective_execution_mode.as_diag_str()
+        );
+    }
+}
+
+pub(super) fn startup_execution_probe(freq_points: usize) -> StartupExecutionProbe {
+    let cpu_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let gpu_available = matches!(
+        dispatch_frequency_point(AccelRequestKind::GpuOnly, 14.2e6),
+        DispatchDecision::RunOnGpu
+    );
+    let hybrid_gpu_lane_available = matches!(
+        dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, 14.2e6),
+        DispatchDecision::RunOnGpu
+    );
+
+    StartupExecutionProbe {
+        cpu_threads,
+        freq_points,
+        gpu_available,
+        hybrid_gpu_lane_available,
+    }
+}
+
+pub(super) fn auto_select_execution_mode(
+    suggested_default: ExecutionMode,
+    probe: StartupExecutionProbe,
+) -> ExecutionMode {
+    // For single-point solves CPU is typically best today due scheduling overhead.
+    let cpu_multithread_viable = probe.cpu_threads > 1 && probe.freq_points > 1;
+
+    if probe.gpu_available && probe.hybrid_gpu_lane_available && cpu_multithread_viable {
+        return ExecutionMode::Hybrid;
+    }
+    if probe.gpu_available {
+        return ExecutionMode::Gpu;
+    }
+    if cpu_multithread_viable {
+        return ExecutionMode::Hybrid;
+    }
+
+    suggested_default
+}

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -2,8 +2,13 @@
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
 mod cli_args;
+mod exec_profile;
 
 use cli_args::{parse_args, ParsedArgs, USAGE};
+use exec_profile::{
+    auto_select_execution_mode, detect_compatibility_profile, startup_execution_probe,
+    steer_execution_mode_by_profile, warn_compatibility_profile, CompatibilityProfile,
+};
 use nec_accel::{
     dispatch_frequency_point, execute_frequency_point, AccelRequestKind, DispatchDecision,
     ExecutionPath,
@@ -24,7 +29,6 @@ use nec_solver::{
 };
 use num_complex::Complex64;
 use rayon::prelude::*;
-use std::path::Path;
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -51,12 +55,6 @@ enum ExecutionMode {
     Cpu,
     Hybrid,
     Gpu,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CompatibilityProfile {
-    Native,
-    FourNec2DropIn,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,7 +91,7 @@ impl SolverMode {
 }
 
 impl ExecutionMode {
-    fn as_cli_str(self) -> &'static str {
+    pub(crate) fn as_cli_str(self) -> &'static str {
         match self {
             ExecutionMode::Cpu => "cpu",
             ExecutionMode::Hybrid => "hybrid",
@@ -101,7 +99,7 @@ impl ExecutionMode {
         }
     }
 
-    fn as_diag_str(self) -> &'static str {
+    pub(crate) fn as_diag_str(self) -> &'static str {
         match self {
             ExecutionMode::Cpu => "cpu",
             ExecutionMode::Hybrid => "hybrid",
@@ -116,59 +114,6 @@ impl PulseRhsMode {
             PulseRhsMode::Raw => "Raw",
             PulseRhsMode::Nec2 => "Nec2",
         }
-    }
-}
-
-fn detect_compatibility_profile(argv0: &str) -> CompatibilityProfile {
-    let stem = Path::new(argv0)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-
-    if stem.contains("nec2dxs") || stem.contains("4nec2") {
-        CompatibilityProfile::FourNec2DropIn
-    } else {
-        CompatibilityProfile::Native
-    }
-}
-
-fn steer_execution_mode_by_profile(
-    execution_mode: ExecutionMode,
-    profile: CompatibilityProfile,
-    exec_flag_explicitly_set: bool,
-) -> ExecutionMode {
-    if exec_flag_explicitly_set {
-        return execution_mode;
-    }
-
-    match profile {
-        CompatibilityProfile::Native => execution_mode,
-        // In drop-in mode prefer throughput when caller did not force an exec mode.
-        CompatibilityProfile::FourNec2DropIn => ExecutionMode::Hybrid,
-    }
-}
-
-fn warn_compatibility_profile(
-    profile: CompatibilityProfile,
-    requested_execution_mode: ExecutionMode,
-    effective_execution_mode: ExecutionMode,
-    exec_flag_explicitly_set: bool,
-) {
-    if profile != CompatibilityProfile::FourNec2DropIn {
-        return;
-    }
-
-    if exec_flag_explicitly_set {
-        eprintln!(
-            "warning: 4nec2 drop-in compatibility profile detected by binary name; preserving explicit --exec={}",
-            requested_execution_mode.as_diag_str()
-        );
-    } else {
-        eprintln!(
-            "warning: 4nec2 drop-in compatibility profile detected by binary name; default execution path steered to exec={}",
-            effective_execution_mode.as_diag_str()
-        );
     }
 }
 
@@ -1048,55 +993,6 @@ fn build_hybrid_lane_plan(freq_count: usize) -> HybridLanePlan {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-struct StartupExecutionProbe {
-    cpu_threads: usize,
-    freq_points: usize,
-    gpu_available: bool,
-    hybrid_gpu_lane_available: bool,
-}
-
-fn startup_execution_probe(freq_points: usize) -> StartupExecutionProbe {
-    let cpu_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-    let gpu_available = matches!(
-        dispatch_frequency_point(AccelRequestKind::GpuOnly, 14.2e6),
-        DispatchDecision::RunOnGpu
-    );
-    let hybrid_gpu_lane_available = matches!(
-        dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, 14.2e6),
-        DispatchDecision::RunOnGpu
-    );
-
-    StartupExecutionProbe {
-        cpu_threads,
-        freq_points,
-        gpu_available,
-        hybrid_gpu_lane_available,
-    }
-}
-
-fn auto_select_execution_mode(
-    suggested_default: ExecutionMode,
-    probe: StartupExecutionProbe,
-) -> ExecutionMode {
-    // For single-point solves CPU is typically best today due scheduling overhead.
-    let cpu_multithread_viable = probe.cpu_threads > 1 && probe.freq_points > 1;
-
-    if probe.gpu_available && probe.hybrid_gpu_lane_available && cpu_multithread_viable {
-        return ExecutionMode::Hybrid;
-    }
-    if probe.gpu_available {
-        return ExecutionMode::Gpu;
-    }
-    if cpu_multithread_viable {
-        return ExecutionMode::Hybrid;
-    }
-
-    suggested_default
-}
-
 struct FrequencySolveResult {
     report: String,
     diag_line: String,
@@ -1773,9 +1669,10 @@ fn main() -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use super::exec_profile::StartupExecutionProbe;
     use super::{
         auto_select_execution_mode, detect_compatibility_profile, steer_execution_mode_by_profile,
-        CompatibilityProfile, ExecutionMode, StartupExecutionProbe,
+        CompatibilityProfile, ExecutionMode,
     };
 
     #[test]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -79,6 +79,7 @@ last_updated: 2026-04-29
 - [ ] **CLI orchestration extraction / Owner: CLI+Core APIs / Target: Phase 2-3**
 	Resolution criteria: `apps/nec-cli/src/main.rs` is reduced to frontend wiring; argument parsing, solve-session orchestration, and FR sweep coordination are extracted into reusable units that can be tested without spawning the CLI binary.
 	- 2026-04-29 progress: started the extraction by moving CLI option parsing and usage-contract text into `apps/nec-cli/src/cli_args.rs`, leaving `main.rs` with a narrower frontend-wiring role.
+	- 2026-04-29 progress: extracted compatibility-profile detection/steering and startup execution auto-probe policy into `apps/nec-cli/src/exec_profile.rs`, further shrinking policy logic embedded in `main.rs`.
 
 - [ ] **Parser fuzz harness / Owner: Parser / Target: Phase 2**
 	Resolution criteria: a `cargo-fuzz` target exists for `nec_parser`, seed inputs are checked in, and contributor docs describe how to run the fuzz target locally.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ All notable documentation process changes are recorded here.
 
 ### Changed
 
+- Continued CLI decomposition by extracting execution-profile policy logic (4nec2 drop-in detection/steering and startup auto-probe mode selection) from `apps/nec-cli/src/main.rs` into `apps/nec-cli/src/exec_profile.rs`.
 - Started three accepted review follow-ups: parser fuzz scaffolding now exists under `fuzz/`, CLI argument parsing/usage text now lives in `apps/nec-cli/src/cli_args.rs`, and `nec_solver` now carries a first property-based Hallen reciprocity invariant test.
 - Review follow-up triage now assigns owners and concrete closure criteria for the remaining GAP items, adds measurable Phase 3 usability minima, documents experimental residual budgets and the scoped GN0/GN2 finite-ground validity envelope, and starts documenting crate-level public surfaces for `nec_report` and `nec_project`.
 - Report contract coverage now locks combined sweep-plus-operator-table ordering on stdout: multi-frequency runs with `LD` cards must emit one full per-frequency block in `FEEDPOINTS -> SOURCES -> LOADS -> CURRENTS` order before the final `SWEEP_POINTS` summary.


### PR DESCRIPTION
## Summary
- extract compatibility profile detection and steering into apps/nec-cli/src/exec_profile.rs
- extract startup execution auto-probe policy into apps/nec-cli/src/exec_profile.rs
- keep behavior and tests unchanged while reducing policy logic inside main.rs
- record progress in docs/backlog.md and docs/changelog.md

## Validation
- cargo fmt --check
- cargo check -p nec-cli
- cargo test -p nec-cli --test exec_modes -- --nocapture
- cargo test -p nec-cli --bin fnec -- --nocapture
- ./scripts/validate-doc-frontmatter.sh