### PR TITLE
feat(ground): restore GN/GE parsing and active ground contracts

### DIFF
--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -5,9 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn gn0_is_active_without_deferred_warning() {
-    // Phase-1: GN is not parsed; card produces 'unknown card' warning and deck
-    // runs as free-space.  The old "GN type 0 is not yet supported" deferred
-    // warning must NOT appear.
+    // GN0 is active and should not emit deferred/unknown warnings.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -36,18 +34,16 @@ fn gn0_is_active_without_deferred_warning() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // Phase-1 parser does not emit the old deferred-ground warning.
     assert!(
         !stderr.contains("GN type 0 is not yet supported"),
-        "did not expect deferred-ground warning for GN0 in Phase-1, got:\n{stderr}"
+        "GN0 should not emit deferred-ground warning, got:\n{stderr}"
     );
-    // Phase-1 parser emits 'unknown card' for unrecognised cards.
     assert!(
-        stderr.contains("unknown card 'GN'"),
-        "expected unknown-card warning for GN, got:\n{stderr}"
+        !stderr.contains("unknown card 'GN'"),
+        "GN should be parsed and not reported as unknown, got:\n{stderr}"
     );
 
-    // Phase-1: runs as free-space → Z_RE ≈ 74.24 Ω.
+    // GN0 finite ground should alter impedance vs free-space.
     let stdout = String::from_utf8_lossy(&output.stdout);
     let z_re = stdout
         .lines()
@@ -62,15 +58,14 @@ fn gn0_is_active_without_deferred_warning() {
         .expect("no feedpoint row in output");
 
     assert!(
-        (z_re - 74.23).abs() < 0.5,
-        "Phase-1 GN0 deck should run as free-space (~74.23 Ω), got Z_RE={z_re}"
+        (z_re - 74.23).abs() > 0.5,
+        "GN0 should alter impedance vs free-space (~74.23 Ω), got Z_RE={z_re}"
     );
 }
 
 #[test]
 fn ge1_without_gn_infers_pec_ground() {
-    // Phase-1: GE is not parsed; card produces 'unknown card' warning and deck
-    // runs as free-space.  The old GE1 PEC-inference path is deferred.
+    // GE 1 without an explicit GN card should infer PEC image-method ground.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -100,11 +95,10 @@ fn ge1_without_gn_infers_pec_ground() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("unknown card 'GE'"),
-        "expected unknown-card warning for GE, got:\n{stderr}"
+        !stderr.contains("unknown card 'GE'"),
+        "GE should be parsed and not reported as unknown, got:\n{stderr}"
     );
 
-    // Phase-1: runs as free-space → Z_RE ≈ 74.24 Ω (not PEC 81.91 Ω).
     let stdout = String::from_utf8_lossy(&output.stdout);
     let z_re = stdout
         .lines()
@@ -117,17 +111,31 @@ fn ge1_without_gn_infers_pec_ground() {
             }
         })
         .expect("no feedpoint row in output");
+    let z_im = stdout
+        .lines()
+        .find_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 8 && parts[0] == "1" && parts[1] == "26" {
+                parts[7].parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .expect("no feedpoint row in output");
 
     assert!(
-        (z_re - 74.24).abs() < 0.5,
-        "Phase-1 GE1 deck should run as free-space (~74.24 Ω), got Z_RE={z_re}"
+        (z_re - 81.914743).abs() < 0.05,
+        "Z_RE mismatch for GE1 PEC deck: got {z_re}, expected ~81.91"
+    );
+    assert!(
+        (z_im - 16.416629).abs() < 0.05,
+        "Z_IM mismatch for GE1 PEC deck: got {z_im}, expected ~16.42"
     );
 }
 
 #[test]
 fn ge_negative_flag_emits_unsupported_warning() {
-    // Phase-1: GE is not parsed; card produces 'unknown card' warning.
-    // The old "GE I1=-1 requests below-ground wire handling" warning no longer fires.
+    // GE I1=-1 is parsed and should emit the explicit unsupported warning.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -156,22 +164,16 @@ fn ge_negative_flag_emits_unsupported_warning() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // Phase-1: unknown card warning replaces the old specific warning.
     assert!(
-        stderr.contains("unknown card 'GE'"),
-        "expected unknown-card warning for GE, got:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("GE I1=-1 requests below-ground wire handling"),
-        "Phase-1 should not emit the old GE below-ground warning, got:\n{stderr}"
+        stderr.contains("GE I1=-1 requests below-ground wire handling"),
+        "expected GE I1=-1 warning in stderr, got:\n{stderr}"
     );
 }
 
 #[test]
 fn gn_type2_runs_without_deferred_warning_and_changes_impedance() {
-    // Phase-1: GN is not parsed; card produces 'unknown card' warning and deck
-    // runs as free-space.  The old "GN type 2 is not yet supported" deferred
-    // warning must NOT appear.
+    // GN type 2 is mapped to the simple finite-ground path and must not use
+    // the deferred-ground warning.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -205,7 +207,6 @@ fn gn_type2_runs_without_deferred_warning_and_changes_impedance() {
         "Phase-1 should not emit old deferred GN2 warning, got:\n{stderr}"
     );
 
-    // Phase-1: runs as free-space → Z_RE ≈ 74.24 Ω.
     let stdout = String::from_utf8_lossy(&output.stdout);
     let z_re = stdout
         .lines()
@@ -220,16 +221,14 @@ fn gn_type2_runs_without_deferred_warning_and_changes_impedance() {
         .expect("no feedpoint row in output");
 
     assert!(
-        (z_re - 74.24).abs() < 0.5,
-        "Phase-1 GN2 deck should run as free-space (~74.24 Ω), got Z_RE={z_re}"
+        (z_re - 78.170459).abs() < 0.05,
+        "GN2 regression mismatch: got Z_RE={z_re}, expected ~78.17"
     );
 }
 
 #[test]
 fn gn_type3_deferred_emits_warning_and_falls_back_to_free_space() {
-    // Phase-1: GN is not parsed; card produces 'unknown card' warning and deck
-    // runs as free-space.  The old "GN type 3 is not yet supported; treating
-    // this deck as free-space" deferred warning no longer fires.
+    // GN type 3 is deferred and should emit the deferred-ground warning.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -258,15 +257,9 @@ fn gn_type3_deferred_emits_warning_and_falls_back_to_free_space() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // Phase-1: unknown card warning.
     assert!(
-        stderr.contains("unknown card 'GN'"),
-        "expected unknown-card warning for GN, got:\n{stderr}"
-    );
-    // Old deferred-ground warning must not fire.
-    assert!(
-        !stderr.contains("GN type 3 is not yet supported; treating this deck as free-space"),
-        "Phase-1 should not emit old deferred GN3 warning, got:\n{stderr}"
+        stderr.contains("GN type 3 is not yet supported; treating this deck as free-space"),
+        "expected deferred GN3 warning, got:\n{stderr}"
     );
 }
 
@@ -368,10 +361,7 @@ fn gn_negative1_null_ground_is_silent_free_space() {
 
 #[test]
 fn buried_wire_with_active_ground_fails_fast_with_actionable_error() {
-    // Phase-1: GN and GE are not parsed; they produce 'unknown card' warnings.
-    // With no active ground model, the deck runs as free-space and succeeds.
-    // The old "unsupported buried-wire geometry for active ground model" fail-fast
-    // guardrail no longer fires because the ground model is never activated.
+    // Buried wire with active ground must fail fast with actionable diagnostics.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -393,28 +383,22 @@ fn buried_wire_with_active_ground_fails_fast_with_actionable_error() {
 
     let _ = fs::remove_file(&deck_path);
 
-    // Phase-1: runs as free-space, succeeds.
     assert!(
-        output.status.success(),
-        "Phase-1 buried-wire deck should succeed (no active ground), stderr:\n{}",
+        !output.status.success(),
+        "buried-wire deck with active ground should fail, stderr:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("error: unsupported buried-wire geometry for active ground model"),
-        "Phase-1 should not emit buried-wire guardrail error (no active ground), got:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("GN type 2 is not yet supported"),
-        "Phase-1 should not emit deferred GN2 warning, got:\n{stderr}"
+        stderr.contains("error: unsupported buried-wire geometry for active ground model"),
+        "expected buried-wire guardrail error, got:\n{stderr}"
     );
 }
 
 #[test]
 fn near_ground_wire_with_active_ground_runs_without_deferred_warning() {
-    // Phase-1: GN is not parsed; card produces 'unknown card' warning and deck
-    // runs as free-space.  Impedance is the free-space result (~74.24 Ω).
+    // Near-ground wire with GN2 is a supported active-ground path.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -452,7 +436,6 @@ fn near_ground_wire_with_active_ground_runs_without_deferred_warning() {
         "Phase-1 should not emit buried-wire error (no active ground), got:\n{stderr}"
     );
 
-    // Phase-1: runs as free-space → Z_RE ≈ 74.24 Ω.
     let stdout = String::from_utf8_lossy(&output.stdout);
     let z_re = stdout
         .lines()
@@ -467,7 +450,7 @@ fn near_ground_wire_with_active_ground_runs_without_deferred_warning() {
         .expect("no feedpoint row in output");
 
     assert!(
-        (z_re - 74.24).abs() < 0.5,
-        "near-ground GN2 regression mismatch: got Z_RE={z_re}, expected ~74.24 (free-space)"
+        (z_re - 69.436745).abs() < 0.05,
+        "near-ground GN2 regression mismatch: got Z_RE={z_re}, expected ~69.44"
     );
 }

--- a/apps/nec-cli/tests/scriptability_contract.rs
+++ b/apps/nec-cli/tests/scriptability_contract.rs
@@ -184,8 +184,8 @@ fn bench_csv_stays_on_stderr_not_stdout() {
 
 #[test]
 fn load_table_stays_on_stdout_while_warnings_stay_on_stderr() {
-    // Phase-1: LD and GE are not parsed; they produce 'unknown card' warnings.
-    // The LOADS section does not appear in the report.
+    // GE is parsed; LD is still deferred in this phase and should warn.
+    // The LOADS section does not appear when LD is not parsed.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let deck = "GW 1 51 0 0 -5.282 0 0 5.282 0.001\nGE\nLD 2 1 26 26 5.0 1e-6 0.0\nXX 1 2 3\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
     let deck_path = write_temp_deck("scriptable-load-table-stream", deck);
@@ -215,8 +215,8 @@ fn load_table_stays_on_stdout_while_warnings_stay_on_stderr() {
         "Phase-1: no LOADS section expected when LD is not parsed, got:\n{stdout}"
     );
     assert!(
-        stderr.contains("warning: line 2: unknown card 'GE'"),
-        "expected unknown-card warning for GE in stderr, got:\n{stderr}"
+        !stderr.contains("unknown card 'GE'"),
+        "GE should be parsed and should not warn as unknown, got:\n{stderr}"
     );
     assert!(
         stderr.contains("warning: line 3: unknown card 'LD'"),

--- a/corpus/reference-results.json
+++ b/corpus/reference-results.json
@@ -760,81 +760,81 @@
       "wires": 1,
       "sources": 1,
       "ground": "PEC",
-      "reference_source": "fnec Hallen solver (regression reference; PEC image far-field); updated to free-space (GN not parsed in Phase-1 parser)",
+      "reference_source": "fnec Hallen solver (regression reference; PEC image far-field)",
       "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
+        "real_ohm": 81.914743,
+        "imag_ohm": 16.416629
       },
       "pattern_samples": [
         {
           "theta_deg": 10.0,
           "phi_deg": 0.0,
-          "gain_db": -15.0778,
-          "gain_v_db": -15.0778,
+          "gain_db": -8.9913,
+          "gain_v_db": -8.9913,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 20.0,
           "phi_deg": 0.0,
-          "gain_db": -9.0037,
-          "gain_v_db": -9.0037,
+          "gain_db": -3.2428,
+          "gain_v_db": -3.2428,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 30.0,
           "phi_deg": 0.0,
-          "gain_db": -5.422,
-          "gain_v_db": -5.422,
+          "gain_db": -0.5836,
+          "gain_v_db": -0.5836,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 40.0,
           "phi_deg": 0.0,
-          "gain_db": -2.8961,
-          "gain_v_db": -2.8961,
+          "gain_db": -0.3009,
+          "gain_v_db": -0.3009,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 50.0,
           "phi_deg": 0.0,
-          "gain_db": -1.0106,
-          "gain_v_db": -1.0106,
+          "gain_db": -4.1173,
+          "gain_v_db": -4.1173,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 60.0,
           "phi_deg": 0.0,
-          "gain_db": 0.391,
-          "gain_v_db": 0.391,
+          "gain_db": -15.3003,
+          "gain_v_db": -15.3003,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 70.0,
           "phi_deg": 0.0,
-          "gain_db": 1.3714,
-          "gain_v_db": 1.3714,
+          "gain_db": 2.0188,
+          "gain_v_db": 2.0188,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 80.0,
           "phi_deg": 0.0,
-          "gain_db": 1.9545,
-          "gain_v_db": 1.9545,
+          "gain_db": 7.0069,
+          "gain_v_db": 7.0069,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         },
         {
           "theta_deg": 90.0,
           "phi_deg": 0.0,
-          "gain_db": 2.1483,
-          "gain_v_db": 2.1483,
+          "gain_db": 8.422,
+          "gain_v_db": 8.422,
           "gain_h_db": -999.99,
           "axial_ratio": 0.0
         }
@@ -1038,10 +1038,10 @@
       "wires": 1,
       "sources": 1,
       "ground": "perfect conductor (infinite)",
-      "reference_source": "fnec Hall\u00e9n solver with GN=1 PEC image-method ground (regression); updated to free-space (GN not parsed in Phase-1 parser)",
+      "reference_source": "fnec Hall\u00e9n solver with GN=1 PEC image-method ground (regression)",
       "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
+        "real_ohm": 81.914743,
+        "imag_ohm": 16.416629
       },
       "external_reference_candidate": {
         "source": "nec2c 1.3.1 on Arch Linux (deck copy with XQ appended)",
@@ -1054,26 +1054,28 @@
         "R_absolute_ohm": 0.05,
         "X_absolute_ohm": 0.05,
         "Current_amplitude_dB": 0.0001,
-        "Current_phase_deg": 0.1
+        "Current_phase_deg": 0.1,
+        "ExternalR_absolute_ohm": 8.0,
+        "ExternalX_absolute_ohm": 30.0
       },
       "current_samples": [
         {
           "wire_id": 1,
           "segment_id": 1,
-          "amplitude_db": 2.167828e-07,
-          "phase_deg": -86.2964
+          "amplitude_db": 2.022629e-4,
+          "phase_deg": 106.7530
         },
         {
           "wire_id": 1,
           "segment_id": 26,
-          "amplitude_db": 0.01323928,
-          "phase_deg": -10.604
+          "amplitude_db": 1.196980e-2,
+          "phase_deg": -11.3326
         },
         {
           "wire_id": 1,
           "segment_id": 51,
-          "amplitude_db": 2.167828e-07,
-          "phase_deg": -86.2964
+          "amplitude_db": 3.026640e-4,
+          "phase_deg": -78.3656
         }
       ],
       "status": "GN=1 PEC image-method support active; regression-gated in CI. External reference candidate captured via nec2c 1.3.1 with XQ-appended deck copy, and now CI-gated with absolute external R/X thresholds. ExternalR gate tightened 10\u21928 on 2026-04-29 (actual |dR|=7.12)."
@@ -1086,10 +1088,10 @@
       "wires": 1,
       "sources": 1,
       "ground": "finite ground GN0 (simple Fresnel approximation)",
-      "reference_source": "fnec Hallen solver with GN=0 simple finite-ground model (regression); updated to free-space (GN not parsed in Phase-1 parser)",
+      "reference_source": "fnec Hallen solver with GN=0 simple finite-ground model (regression)",
       "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
+        "real_ohm": 78.170459,
+        "imag_ohm": 14.95465
       },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
@@ -1112,10 +1114,10 @@
       "wires": 1,
       "sources": 1,
       "ground": "finite conductivity GN2 (scoped runtime path; simple finite-ground approximation)",
-      "reference_source": "fnec Hall\u00e9n solver with GN2 scoped finite-ground path (regression); updated to free-space (GN not parsed in Phase-1 parser)",
+      "reference_source": "fnec Hall\u00e9n solver with GN2 scoped finite-ground path (regression)",
       "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
+        "real_ohm": 78.170459,
+        "imag_ohm": 14.95465
       },
       "tolerance_gates": {
         "R_percent_rel": 0.1,
@@ -1138,23 +1140,15 @@
       "wires": 1,
       "sources": 1,
       "ground": "finite conductivity GN2 buried-wire class (unsupported guardrail)",
-      "reference_source": "fnec runtime guardrail contract (PH2-CHK-002); updated to free-space (GN type 2 not parsed in Phase-1 parser)",
+      "reference_source": "fnec runtime guardrail contract (PH2-CHK-002)",
+      "expected_hallen_error_contains": "unsupported buried-wire geometry for active ground model",
       "expected_warning_substrings": [],
       "forbidden_warning_substrings": [
-        "unsupported buried-wire geometry for active ground model"
+        "GN type 2 is not yet supported; treating this deck as free-space"
       ],
       "expected_warning_counts": {},
-      "tolerance_gates": {
-        "R_absolute_ohm": 0.05,
-        "X_absolute_ohm": 0.05,
-        "R_percent_rel": 0.1,
-        "X_percent_rel": 0.1
-      },
-      "status": "PH2-CHK-002 unsupported-class guardrail contract: buried-wire active-ground requests fail fast with actionable diagnostics instead of silently solving.",
-      "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
-      }
+      "tolerance_gates": {},
+      "status": "PH2-CHK-002 unsupported-class guardrail contract: buried-wire active-ground requests fail fast with actionable diagnostics instead of silently solving."
     },
     "dipole-gn2-near-ground-51seg": {
       "deck_file": "dipole-gn2-near-ground-51seg.nec",
@@ -1164,10 +1158,10 @@
       "wires": 1,
       "sources": 1,
       "ground": "finite conductivity GN2 near-ground class",
-      "reference_source": "fnec Hall\u00e9n solver with GN2 scoped finite-ground path on low above-ground geometry (regression); updated to free-space (GN not parsed in Phase-1 parser)",
+      "reference_source": "fnec Hall\u00e9n solver with GN2 scoped finite-ground path on low above-ground geometry (regression)",
       "feedpoint_impedance": {
-        "real_ohm": 74.242874,
-        "imag_ohm": 13.899516
+        "real_ohm": 69.436745,
+        "imag_ohm": 16.705598
       },
       "tolerance_gates": {
         "R_percent_rel": 0.1,

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -4,12 +4,12 @@
 //! Minimal Phase-1 NEC deck parser.
 //!
 //! Parses the cards required to run a basic dipole simulation:
-//! `CM`, `CE`, `GW`, `EX`, `FR`, `RP`, `EN`.
+//! `CM`, `CE`, `GW`, `GE`, `GN`, `EX`, `FR`, `RP`, `EN`.
 //!
 //! Unknown cards produce a [`ParseError::UnknownCard`] but do not stop
 //! parsing — callers decide whether to treat them as fatal.
 
-use nec_model::card::{Card, CommentCard, EnCard, ExCard, FrCard, GwCard, RpCard};
+use nec_model::card::{Card, CommentCard, EnCard, ExCard, FrCard, GeCard, GnCard, GwCard, RpCard};
 use nec_model::deck::NecDeck;
 
 /// A parse error.
@@ -121,6 +121,39 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                         parse_f64(lineno, "GW", 8, &fields[7])?,
                     ],
                     radius: parse_f64(lineno, "GW", 9, &fields[8])?,
+                }));
+            }
+            "GE" => {
+                let fields = parse_fields(rest);
+                let ground_reflection_flag = if fields.is_empty() {
+                    0
+                } else {
+                    parse_i32(lineno, "GE", 1, &fields[0])?
+                };
+                deck.cards.push(Card::Ge(GeCard {
+                    ground_reflection_flag,
+                }));
+            }
+            "GN" => {
+                let fields = parse_fields(rest);
+                require_fields(lineno, "GN", &fields, 1)?;
+                // GN I1 NRADL I3 I4 EPSE SIG
+                // We currently only consume I1 and optional EPSE/SIG.
+                let eps_r = if fields.len() > 4 {
+                    Some(parse_f64(lineno, "GN", 5, &fields[4])?)
+                } else {
+                    None
+                };
+                let sigma = if fields.len() > 5 {
+                    Some(parse_f64(lineno, "GN", 6, &fields[5])?)
+                } else {
+                    None
+                };
+
+                deck.cards.push(Card::Gn(GnCard {
+                    ground_type: parse_i32(lineno, "GN", 1, &fields[0])?,
+                    eps_r,
+                    sigma,
                 }));
             }
             "EX" => {
@@ -243,6 +276,17 @@ fn parse_u32(lineno: usize, card: &str, field: usize, s: &str) -> Result<u32, Pa
         })
 }
 
+fn parse_i32(lineno: usize, card: &str, field: usize, s: &str) -> Result<i32, ParseError> {
+    s.parse::<f64>()
+        .map(|v| v as i32)
+        .map_err(|_| ParseError::BadField {
+            line: lineno,
+            card: card.to_string(),
+            field,
+            raw: s.to_string(),
+        })
+}
+
 fn parse_f64(lineno: usize, card: &str, field: usize, s: &str) -> Result<f64, ParseError> {
     s.parse::<f64>().map_err(|_| ParseError::BadField {
         line: lineno,
@@ -259,7 +303,9 @@ fn parse_f64(lineno: usize, card: &str, field: usize, s: &str) -> Result<f64, Pa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nec_model::card::{Card, CommentCard, EnCard, ExCard, FrCard, GwCard, RpCard};
+    use nec_model::card::{
+        Card, CommentCard, EnCard, ExCard, FrCard, GeCard, GnCard, GwCard, RpCard,
+    };
 
     /// Minimal half-wave dipole deck used as golden round-trip fixture.
     /// EX format: I1=type I2=tag I3=seg I4=aux-int F1=vr F2=vi
@@ -398,6 +444,56 @@ EN
                 i4: 3,
                 voltage_real: 1.5,
                 voltage_imag: -0.25,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_gn_type_and_optional_medium_params() {
+        let input = "GW 1 3 0 0 1 0 0 4 0.001\nGN 2 0 0 0 13.0 0.005\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+
+        let gn =
+            result.deck.cards.iter().find_map(
+                |c| {
+                    if let Card::Gn(gn) = c {
+                        Some(gn)
+                    } else {
+                        None
+                    }
+                },
+            );
+        assert_eq!(
+            gn,
+            Some(&GnCard {
+                ground_type: 2,
+                eps_r: Some(13.0),
+                sigma: Some(0.005),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_ge_defaults_flag_to_zero_when_omitted() {
+        let input = "GW 1 3 0 0 1 0 0 4 0.001\nGE\nEN\n";
+        let result = parse(input).expect("parse must succeed");
+        assert!(result.warnings.is_empty());
+
+        let ge =
+            result.deck.cards.iter().find_map(
+                |c| {
+                    if let Card::Ge(ge) = c {
+                        Some(ge)
+                    } else {
+                        None
+                    }
+                },
+            );
+        assert_eq!(
+            ge,
+            Some(&GeCard {
+                ground_reflection_flag: 0
             })
         );
     }


### PR DESCRIPTION
Restores GN/GE parsing in nec_parser and re-activates ground behavior contracts that were simplified in the Phase-1 baseline.

Includes:
- Parser support for GE and GN cards (including GN medium parameters)
- Ground diagnostics tests updated for active GN/GE behavior
- Scriptability contract updated (GE no longer warns as unknown)
- Ground corpus reference results restored for active ground cases (including PEC RP case)

Validation:
- cargo fmt
- cargo check
- cargo test