### PR TITLE
docs(backlog): close Hallen non-collinear investigation; add Phase 2 reformulation item

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -91,11 +91,19 @@ last_updated: 2026-04-30
 	Resolution criteria: at least one property-based invariant test is present in `nec_solver` for a physical reciprocity or symmetry law and is part of the normal test matrix.
 	- 2026-04-29 progress: added the first randomized Hallen reciprocity invariant in `crates/nec_solver/src/matrix.rs`, checking `A_ij = A_ji` across randomly parameterized collinear two-segment cases.
 
-- [ ] **Hallen non-collinear multi-wire breadth investigation / Owner: Solver / Target: Phase 2**
+- [x] **Hallen non-collinear multi-wire breadth investigation / Owner: Solver / Target: Phase 2**
 	Resolution criteria: document the exact Hallen topology boundary for current support (single-wire chains vs parallel collinear multi-wire arrays vs junctioned or non-collinear classes), capture at least one representative blocked corpus class plus one representative still-supported multi-wire class, and record a formulation decision for Phase 3 parity claims.
 	- 2026-04-30 progress: rusty-wire Phase 2 deck generation confirmed that the new `inverted-v-40m-90deg` reference deck fails in Hallen with `Hallen solver currently supports only collinear wire topologies aligned with the driven segment; non-collinear tags: [2]`.
 	- 2026-04-30 progress: existing `corpus/yagi-5elm-51seg.nec` evidence shows Hallen already handles multi-wire parallel collinear arrays, so the missing breadth is specifically junctioned or non-collinear multi-wire classes rather than all multi-wire Hallen support.
-	- 2026-04-30 progress: investigation output should close the current ambiguity around `--allow-noncollinear-hallen`, align `docs/roadmap.md` Phase 2 decision-gate wording with the actual supported topology classes, and point to the chosen next step: generalized formulation work, explicit hybrid-solver split, or documented deferral from parity claims.
+	- 2026-04-30 decision: hybrid fallback to pulse/continuity/sinusoidal is ruled out — all three collapse to the same pulse result (`-13.778 + j374.425 Ω`) which is a sign and magnitude mismatch against the reference (`13.463 - j896.032 Ω`), not a calibration delta. A fallback would silently produce a wrong answer. Deferring non-collinear and junctioned geometries from Phase 1 parity claims; correct support requires matrix reformulation (multi-port Hallen or rooftop-basis EFIE) tracked as a Phase 2 solver work item below.
+
+- [ ] **Non-collinear multi-wire Hallen reformulation / Owner: Solver / Target: Phase 2**
+	Resolution criteria: Hallen solver produces a physically plausible feedpoint impedance for at least one junctioned or non-collinear multi-wire corpus case (e.g. `dipole-loaded` top-hat geometry or an inverted-V) within a documented tolerance; the corpus-validation gate passes for that case; `--allow-noncollinear-hallen` either activates the new path or is removed.
+	Formulation options to evaluate in Phase 2:
+	1. Multi-port augmented Hallen: extend the current single-wire Hallen integral equation to a multi-port formulation that applies boundary conditions at wire junctions, using per-wire Green's function evaluation and a global coupling matrix.
+	2. Rooftop-basis EFIE: replace the Hallen kernel with a full Pocklington EFIE using rooftop basis functions that satisfy current-continuity across junctions natively, without a per-wire chain decomposition.
+	3. Segmented hybrid: detect junction topology at solve time and apply a generalised RHS projection per connected subgraph rather than per wire axis, keeping the single-port Hallen structure but extending it to junction coupling.
+	- 2026-04-30 context: investigation item closed; this item captures the Phase 2 delivery requirement. See `docs/solver-findings.md` §"Current --allow-noncollinear-hallen status" for the rationale and three-way decision space.
 
 - [ ] **Benchmark history trend capture / Owner: Performance / Target: Phase 5 prep**
 	Resolution criteria: repeated benchmark runs can be appended to a persistent history format and summarized by a tracked script without relying on ad hoc files in `tmp/`.


### PR DESCRIPTION
## Summary
Closes the `Hallen non-collinear multi-wire breadth investigation` backlog item with a formulation decision, and adds a new Phase 2 delivery work item.

**Decision recorded:**
- Hybrid fallback to pulse/continuity/sinusoidal is **ruled out** — all three produce the same wrong pulse result (`-13.778 + j374.425 Ω`) against the reference (`13.463 - j896.032 Ω`), a sign and magnitude mismatch that a fallback would silently propagate.
- Non-collinear and junctioned geometries are **deferred from Phase 1 parity claims**.
- Correct support requires matrix reformulation, tracked in the new Phase 2 item.

**New Phase 2 work item — three candidate formulation approaches:**
1. Multi-port augmented Hallen (per-wire Green's function + global coupling matrix)
2. Rooftop-basis EFIE (junction continuity natively satisfied)
3. Segmented hybrid (per-connected-subgraph RHS projection)

## Validation
- No code changes; pre-push hook clean