### PR TITLE
refactor(cli): complete orchestration extraction; close CLI backlog item

### DIFF
--- a/apps/nec-cli/src/bench.rs
+++ b/apps/nec-cli/src/bench.rs
@@ -1,0 +1,80 @@
+use super::solve_session::BenchRecord;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BenchFormat {
+    Human,
+    Csv,
+    Json,
+}
+
+pub(super) fn epoch_millis_now() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+fn json_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+pub(super) fn emit_bench_csv_header() {
+    eprintln!(
+        "bench_csv:timestamp_unix_ms,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,exec,freq_mhz,abs_res,rel_res,diag_spread,sin_rel_res"
+    );
+}
+
+pub(super) fn emit_bench_record_csv(
+    target: &str,
+    deck: &str,
+    solver: &str,
+    run: usize,
+    elapsed_ms: u128,
+    bench: &BenchRecord,
+) {
+    eprintln!(
+        "bench_csv:{},{},{},{},{},ok,{},{},{},{},{:.6},{:.6e},{:.6e},{:.6e},{:.6e}",
+        epoch_millis_now(),
+        target,
+        deck,
+        solver,
+        run,
+        elapsed_ms,
+        bench.mode,
+        bench.pulse_rhs,
+        bench.exec,
+        bench.freq_mhz,
+        bench.abs_res,
+        bench.rel_res,
+        bench.diag_spread,
+        bench.sin_rel_res
+    );
+}
+
+pub(super) fn emit_bench_record_json(
+    target: &str,
+    deck: &str,
+    solver: &str,
+    run: usize,
+    elapsed_ms: u128,
+    bench: &BenchRecord,
+) {
+    eprintln!(
+        "bench_json:{{\"timestamp_unix_ms\":{},\"target\":\"{}\",\"deck\":\"{}\",\"solver\":\"{}\",\"run\":{},\"status\":\"ok\",\"elapsed_ms\":{},\"diag_mode\":\"{}\",\"pulse_rhs\":\"{}\",\"exec\":\"{}\",\"freq_mhz\":{:.6},\"abs_res\":{:.6e},\"rel_res\":{:.6e},\"diag_spread\":{:.6e},\"sin_rel_res\":{:.6e}}}",
+        epoch_millis_now(),
+        json_escape(target),
+        json_escape(deck),
+        json_escape(solver),
+        run,
+        elapsed_ms,
+        json_escape(&bench.mode),
+        json_escape(&bench.pulse_rhs),
+        json_escape(&bench.exec),
+        bench.freq_mhz,
+        bench.abs_res,
+        bench.rel_res,
+        bench.diag_spread,
+        bench.sin_rel_res
+    );
+}

--- a/apps/nec-cli/src/cli_args.rs
+++ b/apps/nec-cli/src/cli_args.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use super::{BenchFormat, ExecutionMode, PulseRhsMode, SolverMode};
+use super::bench::BenchFormat;
+use super::exec_profile::ExecutionMode;
+use super::solve_session::{PulseRhsMode, SolverMode};
 
 pub const USAGE: &str = "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--bench] [--bench-format <human|csv|json>] [--gpu-fr] <deck.nec>";
 

--- a/apps/nec-cli/src/exec_profile.rs
+++ b/apps/nec-cli/src/exec_profile.rs
@@ -1,6 +1,30 @@
-use super::ExecutionMode;
 use nec_accel::{dispatch_frequency_point, AccelRequestKind, DispatchDecision};
 use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExecutionMode {
+    Cpu,
+    Hybrid,
+    Gpu,
+}
+
+impl ExecutionMode {
+    pub(crate) fn as_cli_str(self) -> &'static str {
+        match self {
+            ExecutionMode::Cpu => "cpu",
+            ExecutionMode::Hybrid => "hybrid",
+            ExecutionMode::Gpu => "gpu",
+        }
+    }
+
+    pub(crate) fn as_diag_str(self) -> &'static str {
+        match self {
+            ExecutionMode::Cpu => "cpu",
+            ExecutionMode::Hybrid => "hybrid",
+            ExecutionMode::Gpu => "gpu(cpu-fallback)",
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum CompatibilityProfile {

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -1,24 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
+mod bench;
 mod cli_args;
 mod exec_profile;
 mod geometry_validation;
 mod solve_session;
 mod warnings;
 
+use bench::{emit_bench_csv_header, emit_bench_record_csv, emit_bench_record_json, BenchFormat};
 use cli_args::{parse_args, ParsedArgs, USAGE};
 use exec_profile::{
     auto_select_execution_mode, detect_compatibility_profile, startup_execution_probe,
     steer_execution_mode_by_profile, warn_compatibility_profile, CompatibilityProfile,
+    ExecutionMode,
 };
 use geometry_validation::{
     buried_wire_geometry_error, segment_intersection_error, sinusoidal_a4_topology_supported,
     source_risk_geometry_error,
-};
-use nec_accel::{
-    dispatch_frequency_point, execute_frequency_point, AccelRequestKind, DispatchDecision,
-    ExecutionPath,
 };
 use nec_model::card::Card;
 use nec_parser::parse;
@@ -26,170 +25,15 @@ use nec_solver::{
     build_excitation, build_geometry, ground_model_from_deck, rp_card_points,
     wire_endpoints_from_segs, FarFieldPoint,
 };
-use rayon::prelude::*;
 use solve_session::{
-    build_hybrid_lane_plan, frequencies_from_fr, solve_frequency_point, FrequencySolveResult,
+    execute_frequency_sweep, frequencies_from_fr, solve_frequency_point, PulseRhsMode, SolverMode,
     SweepPointSummary,
 };
 use std::process::ExitCode;
-use std::time::{SystemTime, UNIX_EPOCH};
 use warnings::{
     warn_deferred_ground_model, warn_execution_mode_fallback, warn_ge_ground_reflection_flag,
     warn_pulse_mode_experimental,
 };
-
-const C0: f64 = 299_792_458.0;
-const CONTINUITY_REL_RESIDUAL_MAX: f64 = 1e-3;
-const SINUSOIDAL_REL_RESIDUAL_MAX: f64 = 1e-2;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SolverMode {
-    Hallen,
-    Pulse,
-    Continuity,
-    Sinusoidal,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PulseRhsMode {
-    Raw,
-    Nec2,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExecutionMode {
-    Cpu,
-    Hybrid,
-    Gpu,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BenchFormat {
-    Human,
-    Csv,
-    Json,
-}
-
-impl SolverMode {
-    fn as_str(self) -> &'static str {
-        match self {
-            SolverMode::Hallen => "hallen",
-            SolverMode::Pulse => "pulse",
-            SolverMode::Continuity => "continuity",
-            SolverMode::Sinusoidal => "sinusoidal",
-        }
-    }
-}
-
-impl ExecutionMode {
-    pub(crate) fn as_cli_str(self) -> &'static str {
-        match self {
-            ExecutionMode::Cpu => "cpu",
-            ExecutionMode::Hybrid => "hybrid",
-            ExecutionMode::Gpu => "gpu",
-        }
-    }
-
-    pub(crate) fn as_diag_str(self) -> &'static str {
-        match self {
-            ExecutionMode::Cpu => "cpu",
-            ExecutionMode::Hybrid => "hybrid",
-            ExecutionMode::Gpu => "gpu(cpu-fallback)",
-        }
-    }
-}
-
-impl PulseRhsMode {
-    fn as_contract_str(self) -> &'static str {
-        match self {
-            PulseRhsMode::Raw => "Raw",
-            PulseRhsMode::Nec2 => "Nec2",
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct BenchRecord {
-    mode: String,
-    pulse_rhs: String,
-    exec: String,
-    freq_mhz: f64,
-    abs_res: f64,
-    rel_res: f64,
-    diag_spread: f64,
-    sin_rel_res: f64,
-}
-
-fn epoch_millis_now() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0)
-}
-
-fn json_escape(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-fn emit_bench_csv_header() {
-    eprintln!(
-        "bench_csv:timestamp_unix_ms,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,exec,freq_mhz,abs_res,rel_res,diag_spread,sin_rel_res"
-    );
-}
-
-fn emit_bench_record_csv(
-    target: &str,
-    deck: &str,
-    solver: &str,
-    run: usize,
-    elapsed_ms: u128,
-    bench: &BenchRecord,
-) {
-    eprintln!(
-        "bench_csv:{},{},{},{},{},ok,{},{},{},{},{:.6},{:.6e},{:.6e},{:.6e},{:.6e}",
-        epoch_millis_now(),
-        target,
-        deck,
-        solver,
-        run,
-        elapsed_ms,
-        bench.mode,
-        bench.pulse_rhs,
-        bench.exec,
-        bench.freq_mhz,
-        bench.abs_res,
-        bench.rel_res,
-        bench.diag_spread,
-        bench.sin_rel_res
-    );
-}
-
-fn emit_bench_record_json(
-    target: &str,
-    deck: &str,
-    solver: &str,
-    run: usize,
-    elapsed_ms: u128,
-    bench: &BenchRecord,
-) {
-    eprintln!(
-        "bench_json:{{\"timestamp_unix_ms\":{},\"target\":\"{}\",\"deck\":\"{}\",\"solver\":\"{}\",\"run\":{},\"status\":\"ok\",\"elapsed_ms\":{},\"diag_mode\":\"{}\",\"pulse_rhs\":\"{}\",\"exec\":\"{}\",\"freq_mhz\":{:.6},\"abs_res\":{:.6e},\"rel_res\":{:.6e},\"diag_spread\":{:.6e},\"sin_rel_res\":{:.6e}}}",
-        epoch_millis_now(),
-        json_escape(target),
-        json_escape(deck),
-        json_escape(solver),
-        run,
-        elapsed_ms,
-        json_escape(&bench.mode),
-        json_escape(&bench.pulse_rhs),
-        json_escape(&bench.exec),
-        bench.freq_mhz,
-        bench.abs_res,
-        bench.rel_res,
-        bench.diag_spread,
-        bench.sin_rel_res
-    );
-}
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
@@ -353,101 +197,20 @@ fn main() -> ExitCode {
         )
     };
 
-    let timed_solve_one = |freq_hz: f64| {
-        let t0 = std::time::Instant::now();
-        let result = solve_one(freq_hz);
-        (result, t0.elapsed().as_millis())
-    };
-
-    let solved: Vec<(usize, Result<FrequencySolveResult, String>, u128)> = if matches!(
-        execution_mode,
-        ExecutionMode::Hybrid
-    ) && freqs_hz.len()
-        > 1
-    {
-        let lane_plan = build_hybrid_lane_plan(freqs_hz.len());
-
-        let mut solved = Vec::with_capacity(freqs_hz.len());
-
-        let cpu_results: Vec<(usize, Result<FrequencySolveResult, String>, u128)> = lane_plan
-            .cpu_indices
-            .par_iter()
-            .copied()
-            .map(|idx| {
-                let (result, elapsed_ms) = timed_solve_one(freqs_hz[idx]);
-                (idx, result, elapsed_ms)
-            })
-            .collect();
-        solved.extend(cpu_results);
-
-        let gpu_dispatch: Vec<(usize, DispatchDecision)> = lane_plan
-            .gpu_candidate_indices
-            .iter()
-            .copied()
-            .map(|idx| {
-                (
-                    idx,
-                    dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, freqs_hz[idx]),
-                )
-            })
-            .collect();
-
-        let gpu_fallback_results: Vec<(
-            usize,
-            ExecutionPath,
-            Result<FrequencySolveResult, String>,
-            u128,
-        )> = gpu_dispatch
-            .into_iter()
-            .map(|(idx, decision)| {
-                let t0 = std::time::Instant::now();
-                let (path, result) = execute_frequency_point(decision, || solve_one(freqs_hz[idx]));
-                let elapsed_ms = t0.elapsed().as_millis();
-                (idx, path, result, elapsed_ms)
-            })
-            .collect();
-
-        let gpu_fallback_count = gpu_fallback_results
-            .iter()
-            .filter(|(_, path, _, _)| matches!(path, ExecutionPath::CpuFallback))
-            .count();
-        let gpu_stub_count = gpu_fallback_results
-            .iter()
-            .filter(|(_, path, _, _)| matches!(path, ExecutionPath::GpuStubEmulation))
-            .count();
-
-        if gpu_fallback_count > 0 {
-            eprintln!(
-                "warning: --exec hybrid scheduled {gpu_fallback_count} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback"
-            );
-        }
-        if gpu_stub_count > 0 {
-            eprintln!(
-                "warning: --exec hybrid dispatched {gpu_stub_count} frequency point(s) to accelerator stub backend; solving with CPU emulation"
-            );
-        }
-
-        solved.extend(
-            gpu_fallback_results
-                .into_iter()
-                .map(|(idx, _, result, elapsed_ms)| (idx, result, elapsed_ms)),
-        );
-
-        solved
-    } else {
-        freqs_hz
-            .iter()
-            .copied()
-            .enumerate()
-            .map(|(idx, freq_hz)| {
-                let (result, elapsed_ms) = timed_solve_one(freq_hz);
-                (idx, result, elapsed_ms)
-            })
-            .collect()
-    };
-
-    let mut solved = solved;
+    let (mut solved, gpu_fallback_count, gpu_stub_count) =
+        execute_frequency_sweep(&freqs_hz, execution_mode, solve_one);
     solved.sort_by_key(|(idx, _, _)| *idx);
+
+    if gpu_fallback_count > 0 {
+        eprintln!(
+            "warning: --exec hybrid scheduled {gpu_fallback_count} frequency point(s) for GPU-candidate lane, but GPU kernels are not yet wired; running those points on CPU fallback"
+        );
+    }
+    if gpu_stub_count > 0 {
+        eprintln!(
+            "warning: --exec hybrid dispatched {gpu_stub_count} frequency point(s) to accelerator stub backend; solving with CPU emulation"
+        );
+    }
 
     if enable_benchmarking && bench_format == BenchFormat::Csv {
         emit_bench_csv_header();

--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -1,8 +1,55 @@
-use super::{
-    BenchRecord, ExecutionMode, PulseRhsMode, SolverMode, C0, CONTINUITY_REL_RESIDUAL_MAX,
-    SINUSOIDAL_REL_RESIDUAL_MAX,
-};
+use super::exec_profile::ExecutionMode;
 use nec_model::card::Card;
+
+pub(super) const C0: f64 = 299_792_458.0;
+pub(super) const CONTINUITY_REL_RESIDUAL_MAX: f64 = 1e-3;
+pub(super) const SINUSOIDAL_REL_RESIDUAL_MAX: f64 = 1e-2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SolverMode {
+    Hallen,
+    Pulse,
+    Continuity,
+    Sinusoidal,
+}
+
+impl SolverMode {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            SolverMode::Hallen => "hallen",
+            SolverMode::Pulse => "pulse",
+            SolverMode::Continuity => "continuity",
+            SolverMode::Sinusoidal => "sinusoidal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PulseRhsMode {
+    Raw,
+    Nec2,
+}
+
+impl PulseRhsMode {
+    pub(super) fn as_contract_str(self) -> &'static str {
+        match self {
+            PulseRhsMode::Raw => "Raw",
+            PulseRhsMode::Nec2 => "Nec2",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct BenchRecord {
+    pub(super) mode: String,
+    pub(super) pulse_rhs: String,
+    pub(super) exec: String,
+    pub(super) freq_mhz: f64,
+    pub(super) abs_res: f64,
+    pub(super) rel_res: f64,
+    pub(super) diag_spread: f64,
+    pub(super) sin_rel_res: f64,
+}
 use nec_report::{
     render_text_report, CurrentRow, FeedpointRow, LoadRow, PatternRow, ReportInput, SourceRow,
 };
@@ -614,4 +661,104 @@ pub(super) fn solve_frequency_point(
         bench,
         sweep_summary,
     })
+}
+
+/// Execute a frequency sweep, handling both sequential and hybrid-parallel dispatch.
+///
+/// Returns results indexed by frequency position, unsorted. The caller is responsible
+/// for sorting by index and emitting per-result warnings.
+pub(super) fn execute_frequency_sweep<F>(
+    freqs_hz: &[f64],
+    execution_mode: ExecutionMode,
+    solve_one: F,
+) -> (
+    Vec<(usize, Result<FrequencySolveResult, String>, u128)>,
+    usize,
+    usize,
+)
+where
+    F: Fn(f64) -> Result<FrequencySolveResult, String> + Sync,
+{
+    use nec_accel::{
+        dispatch_frequency_point, execute_frequency_point, AccelRequestKind, ExecutionPath,
+    };
+    use rayon::prelude::*;
+
+    let timed_solve_one = |freq_hz: f64| {
+        let t0 = std::time::Instant::now();
+        let result = solve_one(freq_hz);
+        (result, t0.elapsed().as_millis())
+    };
+
+    if matches!(execution_mode, ExecutionMode::Hybrid) && freqs_hz.len() > 1 {
+        let lane_plan = build_hybrid_lane_plan(freqs_hz.len());
+
+        let mut solved = Vec::with_capacity(freqs_hz.len());
+
+        let cpu_results: Vec<(usize, Result<FrequencySolveResult, String>, u128)> = lane_plan
+            .cpu_indices
+            .par_iter()
+            .copied()
+            .map(|idx| {
+                let (result, elapsed_ms) = timed_solve_one(freqs_hz[idx]);
+                (idx, result, elapsed_ms)
+            })
+            .collect();
+        solved.extend(cpu_results);
+
+        let gpu_dispatch: Vec<(usize, nec_accel::DispatchDecision)> = lane_plan
+            .gpu_candidate_indices
+            .iter()
+            .copied()
+            .map(|idx| {
+                (
+                    idx,
+                    dispatch_frequency_point(AccelRequestKind::HybridGpuCandidate, freqs_hz[idx]),
+                )
+            })
+            .collect();
+
+        let gpu_fallback_results: Vec<(
+            usize,
+            ExecutionPath,
+            Result<FrequencySolveResult, String>,
+            u128,
+        )> = gpu_dispatch
+            .into_iter()
+            .map(|(idx, decision)| {
+                let t0 = std::time::Instant::now();
+                let (path, result) = execute_frequency_point(decision, || solve_one(freqs_hz[idx]));
+                let elapsed_ms = t0.elapsed().as_millis();
+                (idx, path, result, elapsed_ms)
+            })
+            .collect();
+
+        let gpu_fallback_count = gpu_fallback_results
+            .iter()
+            .filter(|(_, path, _, _)| matches!(path, ExecutionPath::CpuFallback))
+            .count();
+        let gpu_stub_count = gpu_fallback_results
+            .iter()
+            .filter(|(_, path, _, _)| matches!(path, ExecutionPath::GpuStubEmulation))
+            .count();
+
+        solved.extend(
+            gpu_fallback_results
+                .into_iter()
+                .map(|(idx, _, result, elapsed_ms)| (idx, result, elapsed_ms)),
+        );
+
+        (solved, gpu_fallback_count, gpu_stub_count)
+    } else {
+        let solved = freqs_hz
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(idx, freq_hz)| {
+                let (result, elapsed_ms) = timed_solve_one(freq_hz);
+                (idx, result, elapsed_ms)
+            })
+            .collect();
+        (solved, 0, 0)
+    }
 }

--- a/apps/nec-cli/src/warnings.rs
+++ b/apps/nec-cli/src/warnings.rs
@@ -4,7 +4,8 @@
 use nec_model::card::Card;
 use nec_solver::GroundModel;
 
-use super::{ExecutionMode, SolverMode};
+use super::exec_profile::ExecutionMode;
+use super::solve_session::SolverMode;
 
 pub(super) fn warn_execution_mode_fallback(execution_mode: ExecutionMode) {
     match execution_mode {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -76,12 +76,13 @@ last_updated: 2026-04-30
 
 ## Review-driven follow-ups (2026-04-29)
 
-- [ ] **CLI orchestration extraction / Owner: CLI+Core APIs / Target: Phase 2-3**
+- [x] **CLI orchestration extraction / Owner: CLI+Core APIs / Target: Phase 2-3**
 	Resolution criteria: `apps/nec-cli/src/main.rs` is reduced to frontend wiring; argument parsing, solve-session orchestration, and FR sweep coordination are extracted into reusable units that can be tested without spawning the CLI binary.
 	- 2026-04-29 progress: started the extraction by moving CLI option parsing and usage-contract text into `apps/nec-cli/src/cli_args.rs`, leaving `main.rs` with a narrower frontend-wiring role.
 	- 2026-04-29 progress: extracted compatibility-profile detection/steering and startup execution auto-probe policy into `apps/nec-cli/src/exec_profile.rs`, further shrinking policy logic embedded in `main.rs`.
 	- 2026-04-30 progress: extracted per-frequency solve-session logic (all math helpers, pulse-source constraint helpers, report builders, `FrequencySolveResult`, `SweepPointSummary`, `PulseCurrentSourceConstraint`, `HybridLanePlan`, `frequencies_from_fr`, `build_hybrid_lane_plan`, and `solve_frequency_point`) into `apps/nec-cli/src/solve_session.rs`; `main.rs` now contains only frontend wiring, geometry validation, and warning helpers.
 	- 2026-04-30 progress: extracted geometry validation helpers (`sinusoidal_a4_topology_supported`, `points_close`, `segment_intersection_error`, `source_risk_geometry_error`, `buried_wire_geometry_error`, and private math helpers `segments_share_endpoint`, `segment_closest_distance_and_params`, `dot3`, `find_or_insert_node`) into `apps/nec-cli/src/geometry_validation.rs`; extracted all warning functions into `apps/nec-cli/src/warnings.rs`; `main.rs` now contains only frontend wiring, enums/constants, bench-emit helpers, and `fn main()`.
+	- 2026-04-30 resolution: all resolution criteria met. Moved shared types (`SolverMode`, `PulseRhsMode`, `BenchRecord`, constants) to `solve_session.rs`; moved `ExecutionMode` to `exec_profile.rs`; extracted bench-emit helpers into new `bench.rs`; extracted hybrid-parallel sweep dispatch into `execute_frequency_sweep()` in `solve_session.rs`. `main.rs` is now 393 lines (down from 628) containing only `fn main()` frontend wiring and unit tests. All six extracted modules are independently importable and testable without spawning the CLI binary.
 
 - [x] **Parser fuzz harness / Owner: Parser / Target: Phase 2**
 	Resolution criteria: a `cargo-fuzz` target exists for `nec_parser`, seed inputs are checked in, and contributor docs describe how to run the fuzz target locally.


### PR DESCRIPTION
## Summary

Completes the CLI orchestration extraction backlog item by distributing the remaining types and logic that were still living in `main.rs` into the modules that own them.

## Changes

### New module: `bench.rs`
- `BenchFormat` enum
- `epoch_millis_now()`, `json_escape()`, `emit_bench_csv_header()`, `emit_bench_record_csv()`, `emit_bench_record_json()`

### `exec_profile.rs`
- Added `ExecutionMode` enum + impls (was importing it from `super::`; now owns it)

### `solve_session.rs`
- Added `SolverMode`, `PulseRhsMode`, `BenchRecord`, solver constants (`C0`, `CONTINUITY_REL_RESIDUAL_MAX`, `SINUSOIDAL_REL_RESIDUAL_MAX`)
- Added `execute_frequency_sweep()`: hybrid-parallel + sequential sweep dispatch extracted from `main()`

### `cli_args.rs`, `warnings.rs`
- Updated `use super::{...}` imports to reference the new owning modules

### `main.rs`
- Removed all enum/struct/constant definitions (now live in owning modules)
- Removed all bench-emit helper functions
- Replaced ~100-line hybrid dispatch block with single `execute_frequency_sweep()` call
- **628 → 393 lines**; `fn main()` is now frontend wiring only

### `docs/backlog.md`
- Closed item `CLI orchestration extraction` with resolution note

## Testing
All tests pass (`cargo test`). No behaviour changes — pure structural refactor.