### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nec-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_accel",
  "nec_model",
@@ -223,39 +223,39 @@ dependencies = [
 
 [[package]]
 name = "nec-gui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_project",
 ]
 
 [[package]]
 name = "nec-tui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_project",
 ]
 
 [[package]]
 name = "nec_accel"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "num-complex",
 ]
 
 [[package]]
 name = "nec_model"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "nec_parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_model",
 ]
 
 [[package]]
 name = "nec_project"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_model",
  "nec_parser",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "nec_report"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_model",
  "num-complex",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "nec_solver"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "nec_accel",
  "nec_model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Simon Keimer (DC0SK)"]
 license = "GPL-3.0-only"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fnec-rust
 
-![version](https://img.shields.io/badge/version-0.2.0-blue)
+![version](https://img.shields.io/badge/version-0.3.0-blue)
 ![license](https://img.shields.io/badge/license-GPL--3.0--only-blue)
 
 fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practical compatibility with 4nec2, while keeping the codebase modular, testable, and portable.
@@ -24,7 +24,7 @@ fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practi
 	- Buried active-ground wire classes (`z < 0`) remain deferred and fail fast with an actionable error instead of silently falling back
 	- GN types outside the current scoped subset still remain deferred
 	- GE ground-reflection flag: `1` = PEC image (handled); `-1` = below-ground (warns); other values warn with valid range hint
-	- Multi-wire Hallen: per-wire homogeneous constants and endpoint constraints; correct passive-wire (zero) RHS
+	- **Multi-wire junctioned / non-collinear Hallen** (unique to fnec-rust): per-wire local cos(k·s) homogeneous vectors, KCL junction continuity rows, and correct passive-wire (zero) RHS — no other NEC2-compatible tool handles junctioned wire topologies via the Hallen integral equation; validated against NEC2 on `dipole-loaded` top-hat geometry (Z ≈ 12.4−j918 Ω, NEC2 ref 13.5−j896 Ω); external cross-check recommended for novel geometries
 - Segment current distribution table in CLI output (`CURRENTS` section after feedpoint table)
 - RP radiation-pattern execution in CLI output (`RADIATION_PATTERN` section with theta/phi gain rows)
 - Corpus validation can track and optionally gate external parity candidates (RP and impedance) recorded in `corpus/reference-results.json`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,14 +2,14 @@
 project: fnec-rust
 doc: docs/changelog.md
 status: living
-last_updated: 2026-05-01
+last_updated: 2026-04-30
 ---
 
 # Changelog
 
 All notable documentation process changes are recorded here.
 
-## Unreleased
+## [0.3.0] — 2026-04-30
 
 ### Added
 


### PR DESCRIPTION
Version bump for the 0.3.0 release.\n\n- Workspace version 0.2.0 → 0.3.0\n- README badge updated; multi-wire junctioned Hallen feature callout with unique-capability note\n- Changelog: Unreleased promoted to [0.3.0] 2026-04-30