### PR TITLE
chore: bump version to 0.4.0 — Phase 3 complete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Simon Keimer (DC0SK)"]
 license = "GPL-3.0-only"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fnec-rust
 
-![version](https://img.shields.io/badge/version-0.3.0-blue)
+![version](https://img.shields.io/badge/version-0.4.0-blue)
 ![license](https://img.shields.io/badge/license-GPL--3.0--only-blue)
 
 fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practical compatibility with 4nec2, while keeping the codebase modular, testable, and portable.

--- a/SBOM.spdx.json
+++ b/SBOM.spdx.json
@@ -1,20 +1,34 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2026-04-25T14:31:03Z",
+    "created": "2026-05-02T18:04:54Z",
     "creators": [
       "Tool: cargo-sbom-v0.10.0"
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://spdx.org/spdxdocs/fnec-rust-6e2e3265-c590-4fd6-abd1-be3a85e77f51",
+  "documentNamespace": "https://spdx.org/spdxdocs/fnec-rust-18438e44-a696-4a8b-a33c-2ce5dd1160f8",
   "files": [
     {
       "SPDXID": "SPDXRef-File-fnec",
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
+        }
+      ],
+      "fileName": "./Cargo.lock",
+      "fileTypes": [
+        "SOURCE",
+        "TEXT"
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-File-nec_gui",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -28,7 +42,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -42,7 +56,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -56,7 +70,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -70,7 +84,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -84,7 +98,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -98,7 +112,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -112,7 +126,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -126,7 +140,7 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "03c648831f78a24591adc30fc5c6afbd64b2a8c0"
+          "checksumValue": "21e964588a305f0d76a18854db86b83faee603e2"
         }
       ],
       "fileName": "./Cargo.lock",
@@ -139,22 +153,4349 @@
   "name": "fnec-rust",
   "packages": [
     {
-      "SPDXID": "SPDXRef-Package-nec-cli-0.2.0",
-      "description": "fnec CLI frontend — run NEC decks and projects from the command line",
+      "SPDXID": "SPDXRef-Package-objc2-core-location-0.2.2",
+      "description": "Bindings to the CoreLocation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-core-location@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-core-location",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wgpu-hal-0.19.5",
+      "description": "WebGPU hardware abstraction layer",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wgpu-hal@0.19.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wgpu.rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wgpu-hal",
+      "versionInfo": "0.19.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--graphics-0.13.0",
+      "description": "A bunch of backend-agnostic types that can be leveraged to build a renderer for iced",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_graphics@0.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_graphics",
+      "versionInfo": "0.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1",
+      "description": "Generated API for experimental wayland protocol extensions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-protocols-experimental@20250721.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-protocols-experimental",
+      "versionInfo": "20250721.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bumpalo-3.20.2",
+      "description": "A fast bump allocation arena for Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bumpalo@3.20.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bumpalo",
+      "versionInfo": "3.20.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-bindgen-0.57.1",
+      "description": "Rust bindings generator and runtime support for WIT and the component model.\nUsed when compiling Rust programs to the component model.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-bindgen@0.57.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-bindgen",
+      "versionInfo": "0.57.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hashbrown-0.17.0",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hashbrown@0.17.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hashbrown",
+      "versionInfo": "0.17.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--core-1.0.228",
+      "description": "Serde traits only, with no support for derive -- use the `serde` crate instead",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_core@1.0.228",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://serde.rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_core",
+      "versionInfo": "1.0.228"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-csd-frame-0.3.0",
+      "description": "Common trait and types for wayland CSD interop",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-csd-frame@0.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-csd-frame",
+      "versionInfo": "0.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-simdutf8-0.1.5",
+      "description": "SIMD-accelerated UTF-8 validation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/simdutf8@0.1.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rusticstuff/simdutf8",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "simdutf8",
+      "versionInfo": "0.1.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tiny-xlib-0.2.5",
+      "description": "A tiny Xlib wrapper for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tiny-xlib@0.2.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-windowing/tiny-xlib",
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "tiny-xlib",
+      "versionInfo": "0.2.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rangemap-1.7.1",
+      "description": "Map and set data structures whose keys are stored as ranges.\n\nContiguous and overlapping ranges that map to the same value are coalesced into a single range.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rangemap@1.7.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/jeffparsons/rangemap",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rangemap",
+      "versionInfo": "1.7.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-lock-3.4.2",
+      "description": "Async synchronization primitives",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-lock@3.4.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-lock",
+      "versionInfo": "3.4.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dtor-0.8.1",
+      "description": "__attribute__((destructor)) for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dtor@0.8.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "dtor",
+      "versionInfo": "0.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-prettyplease-0.2.37",
+      "description": "A minimal `syn` syntax tree pretty-printer",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/prettyplease@0.2.37",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "prettyplease",
+      "versionInfo": "0.2.37"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "description": "Bindings to Core Foundation for macOS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/core-foundation-sys@0.8.7",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/servo/core-foundation-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "core-foundation-sys",
+      "versionInfo": "0.8.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-core-graphics-0.23.2",
+      "description": "Bindings to Core Graphics for macOS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/core-graphics@0.23.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/servo/core-foundation-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "core-graphics",
+      "versionInfo": "0.23.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-typenum-1.20.0",
+      "description": "Typenum is a Rust library for type-level numbers evaluated at\n    compile time. It currently supports bits, unsigned integers, and signed\n    integers. It also provides a type-level array of type-level numbers, but its\n    implementation is incomplete.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/typenum@1.20.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "typenum",
+      "versionInfo": "1.20.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-symbols-0.2.2",
+      "description": "Bindings to the Symbols framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-symbols@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-symbols",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-anyhow-1.0.102",
+      "description": "Flexible concrete Error type built on std::error::Error",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/anyhow@1.0.102",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "anyhow",
+      "versionInfo": "1.0.102"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-percent-encoding-2.3.2",
+      "description": "Percent encoding and decoding",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/percent-encoding@2.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "percent-encoding",
+      "versionInfo": "2.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-encode-4.1.0",
+      "description": "Objective-C type-encoding representation and parsing",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-encode@4.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-encode",
+      "versionInfo": "4.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-half-2.7.1",
+      "description": "Half-precision floating point f16 and bf16 types for Rust implementing the IEEE 754-2008 standard binary16 and bfloat16 types.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/half@2.7.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "half",
+      "versionInfo": "2.7.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-downcast-rs-1.2.1",
+      "description": "Trait object downcasting support using only safe Rust. It supports type\nparameters, associated types, and type constraints.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/downcast-rs@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "downcast-rs",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dark-light-1.1.1",
+      "description": "Detect if dark mode or light mode is enabled",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dark-light@1.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "dark-light",
+      "versionInfo": "1.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-core-0.3.32",
+      "description": "The core traits and types in for the `futures` library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-core@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-core",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crypto-common-0.1.7",
+      "description": "Common cryptographic traits",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crypto-common@0.1.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crypto-common",
+      "versionInfo": "0.1.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasip2-1.0.3-plus-wasi-0.2.9",
+      "description": "WASIp2 API bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasip2@1.0.3%2Bwasi-0.2.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasip2",
+      "versionInfo": "1.0.3+wasi-0.2.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crossbeam-epoch-0.9.18",
+      "description": "Epoch-based garbage collection",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crossbeam-epoch@0.9.18",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crossbeam-epoch",
+      "versionInfo": "0.9.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-scopeguard-1.2.0",
+      "description": "A RAII scope guard that will run a given closure when it goes out of scope,\neven if the code between panics (assuming unwinding panic).\n\nDefines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as\nshorthands for guards with one of the implemented strategies.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/scopeguard@1.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "scopeguard",
+      "versionInfo": "1.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tempfile-3.27.0",
+      "description": "A library for managing temporary files and directories.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tempfile@3.27.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://stebalien.com/projects/tempfile-rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "tempfile",
+      "versionInfo": "3.27.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--wgpu-0.13.5",
+      "description": "A renderer for iced on top of wgpu",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_wgpu@0.13.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_wgpu",
+      "versionInfo": "0.13.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-r-efi-5.3.0",
+      "description": "UEFI Reference Specification Protocol Constants and Definitions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/r-efi@5.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/r-efi/r-efi/wiki",
+      "licenseConcluded": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
+      "licenseDeclared": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
+      "name": "r-efi",
+      "versionInfo": "5.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-x11-dl-2.21.0",
+      "description": "X11 library bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/x11-dl@2.21.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "x11-dl",
+      "versionInfo": "2.21.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-x11rb-protocol-0.13.2",
+      "description": "Rust bindings to X11",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/x11rb-protocol@0.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "x11rb-protocol",
+      "versionInfo": "0.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec-gui-0.4.0",
+      "description": "fnec GUI frontend — modern task-oriented antenna modeling interface (iced)",
       "downloadLocation": "NONE",
       "licenseConcluded": "GPL-3.0",
       "licenseDeclared": "GPL-3.0",
-      "name": "nec-cli",
-      "versionInfo": "0.2.0"
+      "name": "nec-gui",
+      "versionInfo": "0.4.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec--model-0.2.0",
+      "SPDXID": "SPDXRef-Package-unicode-xid-0.2.6",
+      "description": "Determine whether characters have the XID_Start\nor XID_Continue properties according to\nUnicode Standard Annex #31.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-xid@0.2.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/unicode-rs/unicode-xid",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-xid",
+      "versionInfo": "0.2.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crc32fast-1.5.0",
+      "description": "Fast, SIMD-accelerated CRC32 (IEEE) checksum computation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crc32fast@1.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crc32fast",
+      "versionInfo": "1.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-android--system--properties-0.1.5",
+      "description": "Minimal Android system properties wrapper",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/android_system_properties@0.1.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/nical/android_system_properties",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "android_system_properties",
+      "versionInfo": "0.1.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-core-foundation-0.9.4",
+      "description": "Bindings to Core Foundation for macOS",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/core-foundation@0.9.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/servo/core-foundation-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "core-foundation",
+      "versionInfo": "0.9.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bit-vec-0.6.3",
+      "description": "A vector of bits",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bit-vec@0.6.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/contain-rs/bit-vec",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bit-vec",
+      "versionInfo": "0.6.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec--solver-0.4.0",
+      "description": "NEC2 MoM solver: matrix assembly, linear solve, postprocessing (currents, impedance, patterns)",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec_solver",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tracing-attributes-0.1.31",
+      "description": "Procedural macro attributes for automatically instrumenting functions.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tracing-attributes@0.1.31",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://tokio.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tracing-attributes",
+      "versionInfo": "0.1.31"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-approx-0.5.1",
+      "description": "Approximate floating point equality comparisons and assertions.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/approx@0.5.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/brendanzab/approx",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "approx",
+      "versionInfo": "0.5.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-redox--users-0.4.6",
+      "description": "A Rust library to access Redox users and groups functionality",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/redox_users@0.4.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "redox_users",
+      "versionInfo": "0.4.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--aarch64--gnullvm-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_aarch64_gnullvm@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_aarch64_gnullvm",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jni-macros-0.22.4",
+      "description": "Procedural macros for the jni crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jni-macros@0.22.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "jni-macros",
+      "versionInfo": "0.22.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec--model-0.4.0",
       "description": "Domain model for NEC structures: geometry, sources, ground, frequency sweeps, requests",
       "downloadLocation": "NONE",
       "licenseConcluded": "GPL-3.0",
       "licenseDeclared": "GPL-3.0",
       "name": "nec_model",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-thiserror-1.0.69",
+      "description": "derive(Error)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/thiserror@1.0.69",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "thiserror",
+      "versionInfo": "1.0.69"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-sha1-0.10.6",
+      "description": "SHA-1 hash function",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/sha1@0.10.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "sha1",
+      "versionInfo": "0.10.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-block-0.1.6",
+      "description": "Rust interface for Apple's C language extension of blocks.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/block@0.1.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "block",
+      "versionInfo": "0.1.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-uniform-type-identifiers-0.2.2",
+      "description": "Bindings to the UniformTypeIdentifiers framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-uniform-type-identifiers@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-uniform-type-identifiers",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-palette-0.7.6",
+      "description": "Convert and manage colors with a focus on correctness, flexibility and ease of use.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/palette@0.7.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "palette",
+      "versionInfo": "0.7.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ndk-sys-0.6.0-plus-11769913",
+      "description": "FFI bindings for the Android NDK",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ndk-sys@0.6.0%2B11769913",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-mobile/ndk",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ndk-sys",
+      "versionInfo": "0.6.0+11769913"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-equivalent-1.0.2",
+      "description": "Traits for key comparison in maps.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/equivalent@1.0.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "equivalent",
+      "versionInfo": "1.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-task-0.3.32",
+      "description": "Tools for working with tasks.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-task@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-task",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "description": "Generated API for the officials wayland protocol extensions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-protocols@0.32.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-protocols",
+      "versionInfo": "0.32.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-linux-raw-sys-0.9.4",
+      "description": "Generated bindings for Linux's userspace API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/linux-raw-sys@0.9.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "linux-raw-sys",
+      "versionInfo": "0.9.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-roxmltree-0.20.0",
+      "description": "Represent an XML as a read-only tree.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/roxmltree@0.20.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "roxmltree",
+      "versionInfo": "0.20.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-error-code-3.3.2",
+      "description": "Error code",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/error-code@3.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSL-1.0",
+      "licenseDeclared": "BSL-1.0",
+      "name": "error-code",
+      "versionInfo": "3.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-log-0.4.29",
+      "description": "A lightweight logging facade for Rust\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/log@0.4.29",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "log",
+      "versionInfo": "0.4.29"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hashbrown-0.12.3",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hashbrown@0.12.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hashbrown",
+      "versionInfo": "0.12.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-event-listener-5.4.1",
+      "description": "Notify async tasks or threads",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/event-listener@5.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "event-listener",
+      "versionInfo": "5.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-instant-0.1.13",
+      "description": "Unmaintained, consider using web-time instead - A partial replacement for std::time::Instant that works on WASM to.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/instant@0.1.13",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "name": "instant",
+      "versionInfo": "0.1.13"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-either-1.15.0",
+      "description": "The enum `Either` with variants `Left` and `Right` is a general purpose sum type with two cases.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/either@1.15.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "either",
+      "versionInfo": "1.15.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-script-0.5.8",
+      "description": "This crate exposes the Unicode `Script` and `Script_Extension` properties from [UAX #24](http://www.unicode.org/reports/tr24/)\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-script@0.5.8",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/unicode-rs/unicode-script",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-script",
+      "versionInfo": "0.5.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-x11rb-0.13.2",
+      "description": "Rust bindings to X11",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/x11rb@0.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "x11rb",
+      "versionInfo": "0.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bitflags-2.11.1",
+      "description": "A macro to generate structures which behave like bitflags.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bitflags@2.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bitflags/bitflags",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bitflags",
+      "versionInfo": "2.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--futures-0.13.2",
+      "description": "Commands, subscriptions, and future executors for iced",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_futures@0.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_futures",
+      "versionInfo": "0.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--gnu-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_gnu@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_gnu",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-quartz-core-0.3.2",
+      "description": "Bindings to the QuartzCore/CoreAnimation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-quartz-core@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "objc2-quartz-core",
+      "versionInfo": "0.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-naga-0.19.2",
+      "description": "Shader translation infrastructure",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/naga@0.19.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "naga",
+      "versionInfo": "0.19.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-enumflags2--derive-0.7.12",
+      "description": "Do not use directly, use the reexport in the `enumflags2` crate. This allows for better compatibility across versions.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/enumflags2_derive@0.7.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "enumflags2_derive",
+      "versionInfo": "0.7.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dirs-sys-0.3.7",
+      "description": "System-level helper functions for the dirs and directories crates.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dirs-sys@0.3.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "dirs-sys",
+      "versionInfo": "0.3.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec-cli-0.4.0",
+      "description": "fnec CLI frontend — run NEC decks and projects from the command line",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec-cli",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hex-0.4.3",
+      "description": "Encoding and decoding data into/from hexadecimal representation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hex@0.4.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hex",
+      "versionInfo": "0.4.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml--edit-0.22.27",
+      "description": "Yet another format-preserving TOML parser.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml_edit@0.22.27",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml_edit",
+      "versionInfo": "0.22.27"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--msvc-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_msvc@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_msvc",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-linux-raw-sys-0.4.15",
+      "description": "Generated bindings for Linux's userspace API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/linux-raw-sys@0.4.15",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "linux-raw-sys",
+      "versionInfo": "0.4.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-core-foundation-0.3.2",
+      "description": "Bindings to the CoreFoundation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-core-foundation@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "objc2-core-foundation",
+      "versionInfo": "0.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-signal-0.2.14",
+      "description": "Async signal handling",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-signal@0.2.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-signal",
+      "versionInfo": "0.2.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-memoffset-0.9.1",
+      "description": "offset_of functionality for Rust structs.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/memoffset@0.9.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "memoffset",
+      "versionInfo": "0.9.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--core-0.13.2",
+      "description": "The essential ideas of iced",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_core@0.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_core",
+      "versionInfo": "0.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-siphasher-1.0.2",
+      "description": "SipHash-2-4, SipHash-1-3 and 128-bit variants in pure Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/siphasher@1.0.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://docs.rs/siphasher",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "siphasher",
+      "versionInfo": "1.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winapi-i686-pc-windows-gnu-0.4.0",
+      "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winapi-i686-pc-windows-gnu@0.4.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "winapi-i686-pc-windows-gnu",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winapi-util-0.1.11",
+      "description": "A dumping ground for high level safe wrappers over windows-sys.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winapi-util@0.1.11",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/BurntSushi/winapi-util",
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "winapi-util",
+      "versionInfo": "0.1.11"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zbus--names-3.0.0",
+      "description": "A collection of D-Bus bus names types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zbus_names@3.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zbus_names",
+      "versionInfo": "3.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-presser-0.3.1",
+      "description": "A crate to help you copy things into raw buffers without invoking spooky action at a distance (undefined behavior).",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/presser@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/EmbarkStudios/presser",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "presser",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-core-0.52.0",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-core@0.52.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-core",
+      "versionInfo": "0.52.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-block-buffer-0.10.4",
+      "description": "Buffer type for block processing of data",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/block-buffer@0.10.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "block-buffer",
+      "versionInfo": "0.10.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gpu-descriptor-types-0.1.2",
+      "description": "Core types of gpu-descriptor crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/gpu-descriptor-types@0.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/zakarumych/gpu-descriptor",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "gpu-descriptor-types",
+      "versionInfo": "0.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-app-kit-0.2.2",
+      "description": "Bindings to the AppKit framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-app-kit@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-app-kit",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-blocking-1.6.2",
+      "description": "A thread pool for isolating blocking I/O in async programs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/blocking@1.6.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "blocking",
+      "versionInfo": "1.6.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-errno-0.3.14",
+      "description": "Cross-platform interface to the `errno` variable.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/errno@0.3.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "errno",
+      "versionInfo": "0.3.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml-0.8.23",
+      "description": "A native Rust encoder and decoder of TOML-formatted files and streams. Provides\nimplementations of the standard Serialize/Deserialize traits for TOML data to\nfacilitate deserializing and serializing Rust structures.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml@0.8.23",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml",
+      "versionInfo": "0.8.23"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml--datetime-0.6.11",
+      "description": "A TOML-compatible datetime type",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml_datetime@0.6.11",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml_datetime",
+      "versionInfo": "0.6.11"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-thiserror-impl-1.0.69",
+      "description": "Implementation detail of the `thiserror` crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/thiserror-impl@1.0.69",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "thiserror-impl",
+      "versionInfo": "1.0.69"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-executor-0.3.32",
+      "description": "Executors for asynchronous tasks based on the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-executor@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-executor",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-foundation-0.3.2",
+      "description": "Bindings to the Foundation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-foundation@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-foundation",
+      "versionInfo": "0.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-quick-xml-0.39.2",
+      "description": "High performance xml reader and writer",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/quick-xml@0.39.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "quick-xml",
+      "versionInfo": "0.39.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-codespan-reporting-0.11.1",
+      "description": "Beautiful diagnostic reporting for text-based programming languages",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/codespan-reporting@0.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/brendanzab/codespan",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "codespan-reporting",
+      "versionInfo": "0.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-ccc-0.2.0",
+      "description": "Unicode Canonical Combining Class detection",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-ccc@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-ccc",
       "versionInfo": "0.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wgpu-types-0.19.2",
+      "description": "WebGPU types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wgpu-types@0.19.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wgpu.rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wgpu-types",
+      "versionInfo": "0.19.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-num--enum-0.7.6",
+      "description": "Procedural macros to make inter-operation between primitives and enums easier.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/num_enum@0.7.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-3-Clause OR MIT OR Apache-2.0",
+      "licenseDeclared": "BSD-3-Clause OR MIT OR Apache-2.0",
+      "name": "num_enum",
+      "versionInfo": "0.7.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-core-data-0.2.2",
+      "description": "Bindings to the CoreData framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-core-data@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-core-data",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-cloud-kit-0.2.2",
+      "description": "Bindings to the CloudKit framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-cloud-kit@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-cloud-kit",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-calloop-wayland-source-0.3.0",
+      "description": "A wayland-rs client event source for callloop",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/calloop-wayland-source@0.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "calloop-wayland-source",
+      "versionInfo": "0.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-android-activity-0.6.1",
+      "description": "Glue for building Rust applications on Android with NativeActivity or GameActivity",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/android-activity@0.6.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-mobile/android-activity",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "android-activity",
+      "versionInfo": "0.6.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-0.5.2",
+      "description": "Objective-C interface and runtime bindings",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2@0.5.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2",
+      "versionInfo": "0.5.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-range-alloc-0.1.5",
+      "description": "Generic range allocator",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/range-alloc@0.1.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/gfx-rs/range-alloc",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "range-alloc",
+      "versionInfo": "0.1.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-properties-0.1.4",
+      "description": "Query character Unicode properties according to\nUAX #44 and UTR #51.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-properties@0.1.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/unicode-rs/unicode-properties",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-properties",
+      "versionInfo": "0.1.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rayon-1.12.0",
+      "description": "Simple work-stealing parallelism for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rayon@1.12.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rayon",
+      "versionInfo": "1.12.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-termcolor-1.4.1",
+      "description": "A simple cross platform library for writing colored text to a terminal.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/termcolor@1.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/BurntSushi/termcolor",
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "termcolor",
+      "versionInfo": "1.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-contacts-0.2.2",
+      "description": "Bindings to the Contacts framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-contacts@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-contacts",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-semver-1.0.28",
+      "description": "Parser and evaluator for Cargo's flavor of Semantic Versioning",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/semver@1.0.28",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "semver",
+      "versionInfo": "1.0.28"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fast-srgb8-1.0.0",
+      "description": "Very fast conversions between linear float and 8-bit sRGB (with no_std support).",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fast-srgb8@1.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/thomcc/fast-srgb8",
+      "licenseConcluded": "MIT OR Apache-2.0 OR CC0-1.0",
+      "licenseDeclared": "MIT OR Apache-2.0 OR CC0-1.0",
+      "name": "fast-srgb8",
+      "versionInfo": "1.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gpu-alloc-0.6.0",
+      "description": "Implementation agnostic memory allocator for Vulkan like APIs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/gpu-alloc@0.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/zakarumych/gpu-alloc",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "gpu-alloc",
+      "versionInfo": "0.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustc-hash-2.1.2",
+      "description": "A speedy, non-cryptographic hashing algorithm used by rustc",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustc-hash@2.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "rustc-hash",
+      "versionInfo": "2.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rand-0.8.6",
+      "description": "Random number generators and other randomness functionality.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rand@0.8.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-random.github.io/book",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rand",
+      "versionInfo": "0.8.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-clipboard--wayland-0.2.2",
+      "description": "A library to obtain access to the clipboard of a Wayland window",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/clipboard_wayland@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "clipboard_wayland",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-core-image-0.2.2",
+      "description": "Bindings to the CoreImage framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-core-image@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-core-image",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-orbclient-0.3.54",
+      "description": "The Orbital Client Library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/orbclient@0.3.54",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "orbclient",
+      "versionInfo": "0.3.54"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-pin-project-1.1.11",
+      "description": "A crate for safe and ergonomic pin-projection.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/pin-project@1.1.11",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "pin-project",
+      "versionInfo": "1.1.11"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zvariant-4.2.0",
+      "description": "D-Bus & GVariant encoding & decoding",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zvariant@4.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zvariant",
+      "versionInfo": "4.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec-tui-0.4.0",
+      "description": "fnec TUI frontend — terminal interface for batch runs and quick inspection (ratatui)",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec-tui",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc-sys-0.3.5",
+      "description": "Raw bindings to the Objective-C runtime and ABI",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc-sys@0.3.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc-sys",
+      "versionInfo": "0.3.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-sys-0.59.0",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-sys@0.59.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-sys",
+      "versionInfo": "0.59.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jni-sys-0.3.1",
+      "description": "Rust definitions corresponding to jni.h",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jni-sys@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "jni-sys",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libloading-0.7.4",
+      "description": "Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libloading@0.7.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "name": "libloading",
+      "versionInfo": "0.7.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-segmentation-1.13.2",
+      "description": "This crate provides Grapheme Cluster, Word and Sentence boundaries\naccording to Unicode Standard Annex #29 rules.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-segmentation@1.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/unicode-rs/unicode-segmentation",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-segmentation",
+      "versionInfo": "1.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-protocols-wlr-0.3.12",
+      "description": "Generated API for the WLR wayland protocol extensions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-protocols-wlr@0.3.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-protocols-wlr",
+      "versionInfo": "0.3.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-smithay-client-toolkit-0.19.2",
+      "description": "Toolkit for making client wayland applications.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/smithay-client-toolkit@0.19.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "smithay-client-toolkit",
+      "versionInfo": "0.19.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-phf--macros-0.11.3",
+      "description": "Macros to generate types in the phf crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/phf_macros@0.11.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "phf_macros",
+      "versionInfo": "0.11.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-combine-4.6.7",
+      "description": "Fast parser combinators on arbitrary streams with zero-copy support.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/combine@4.6.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "combine",
+      "versionInfo": "4.6.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-cursor-0.31.14",
+      "description": "Bindings to libwayland-cursor.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-cursor@0.31.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-cursor",
+      "versionInfo": "0.31.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-foreign-types-macros-0.2.3",
+      "description": "An internal crate used by foreign-types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/foreign-types-macros@0.2.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "foreign-types-macros",
+      "versionInfo": "0.2.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nix-0.29.0",
+      "description": "Rust friendly bindings to *nix APIs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/nix@0.29.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "nix",
+      "versionInfo": "0.29.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-scoped-tls-1.0.1",
+      "description": "Library implementation of the standard library's old `scoped_thread_local!`\nmacro for providing scoped access to thread local storage (TLS) so any type can\nbe stored into TLS.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/scoped-tls@1.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/alexcrichton/scoped-tls",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "scoped-tls",
+      "versionInfo": "1.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-component-0.244.0",
+      "description": "Tooling for working with `*.wit` and component files together.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-component@0.244.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-component",
+      "versionInfo": "0.244.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winapi-x86--64-pc-windows-gnu-0.4.0",
+      "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winapi-x86_64-pc-windows-gnu@0.4.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "winapi-x86_64-pc-windows-gnu",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-uds--windows-1.2.1",
+      "description": "Unix Domain Sockets for Windows!",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/uds_windows@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "uds_windows",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bitflags-1.3.2",
+      "description": "A macro to generate structures which behave like bitflags.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bitflags@1.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bitflags/bitflags",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bitflags",
+      "versionInfo": "1.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-digest-0.10.7",
+      "description": "Traits for cryptographic hash functions and message authentication codes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/digest@0.10.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "digest",
+      "versionInfo": "0.10.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ctor-0.10.1",
+      "description": "__attribute__((constructor)) for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ctor@0.10.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "ctor",
+      "versionInfo": "0.10.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc-0.2.7",
+      "description": "Objective-C Runtime bindings and wrapper for Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc@0.2.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc",
+      "versionInfo": "0.2.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crunchy-0.2.4",
+      "description": "Crunchy unroller: deterministically unroll constant loops",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crunchy@0.2.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/eira-fransham/crunchy",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "crunchy",
+      "versionInfo": "0.2.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-renderdoc-sys-1.1.0",
+      "description": "Low-level bindings to the RenderDoc API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/renderdoc-sys@1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "renderdoc-sys",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-allocator-api2-0.2.21",
+      "description": "Mirror of Rust's allocator API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/allocator-api2@0.2.21",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/zakarumych/allocator-api2",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "allocator-api2",
+      "versionInfo": "0.2.21"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-window--clipboard-0.4.1",
+      "description": "A library to obtain clipboard access from a `raw-window-handle`",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/window_clipboard@0.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "window_clipboard",
+      "versionInfo": "0.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-sctk-adwaita-0.10.1",
+      "description": "Adwaita-like SCTK Frame",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/sctk-adwaita@0.10.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "sctk-adwaita",
+      "versionInfo": "0.10.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced-0.13.1",
+      "description": "A cross-platform GUI library inspired by Elm",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced@0.13.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced",
+      "versionInfo": "0.13.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec--report-0.4.0",
+      "description": "Result reporting and export: 4nec2-like text output, plotting data preparation",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec_report",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--gnu-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_gnu@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_gnu",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-paste-1.0.15",
+      "description": "Macros for all your token pasting needs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/paste@1.0.15",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "paste",
+      "versionInfo": "1.0.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-flate2-1.1.9",
+      "description": "DEFLATE compression and decompression exposed as Read/BufRead/Write streams.\nSupports miniz_oxide and multiple zlib implementations. Supports zlib, gzip,\nand raw deflate streams.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/flate2@1.1.9",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-lang/flate2-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "flate2",
+      "versionInfo": "1.1.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-bidi-mirroring-0.2.0",
+      "description": "Unicode Bidi Mirroring property detection",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-bidi-mirroring@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-bidi-mirroring",
+      "versionInfo": "0.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-malloc--buf-0.0.6",
+      "description": "Structs for handling malloc'd memory passed to Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/malloc_buf@0.0.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "malloc_buf",
+      "versionInfo": "0.0.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tiny-skia-0.11.4",
+      "description": "A tiny Skia subset ported to Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tiny-skia@0.11.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "name": "tiny-skia",
+      "versionInfo": "0.11.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ab--glyph-0.2.32",
+      "description": "API for loading, scaling, positioning and rasterizing OpenType font glyphs.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ab_glyph@0.2.32",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "ab_glyph",
+      "versionInfo": "0.2.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-atomic-waker-1.1.2",
+      "description": "A synchronization primitive for task wakeup",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/atomic-waker@1.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "atomic-waker",
+      "versionInfo": "1.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jni-0.22.4",
+      "description": "Rust bindings to the JNI",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jni@0.22.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "jni",
+      "versionInfo": "0.22.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dconf--rs-0.3.0",
+      "description": "A Rust API for interacting with dconf.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dconf_rs@0.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "dconf_rs",
+      "versionInfo": "0.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hexf-parse-0.2.1",
+      "description": "Parses hexadecimal floats (see also hexf)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hexf-parse@0.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/lifthrasiir/hexf",
+      "licenseConcluded": "CC0-1.0",
+      "licenseDeclared": "CC0-1.0",
+      "name": "hexf-parse",
+      "versionInfo": "0.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-leb128fmt-0.1.0",
+      "description": "A library to encode and decode LEB128 compressed integers.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/leb128fmt@0.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "leb128fmt",
+      "versionInfo": "0.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--msvc-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_msvc@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_msvc",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libloading-0.8.9",
+      "description": "Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libloading@0.8.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "name": "libloading",
+      "versionInfo": "0.8.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustix-0.38.44",
+      "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustix@0.38.44",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "rustix",
+      "versionInfo": "0.38.44"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-core-graphics-types-0.1.3",
+      "description": "Bindings for some fundamental Core Graphics types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/core-graphics-types@0.1.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/servo/core-foundation-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "core-graphics-types",
+      "versionInfo": "0.1.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-bidi-0.3.18",
+      "description": "Implementation of the Unicode Bidirectional Algorithm",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-bidi@0.3.18",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-bidi",
+      "versionInfo": "0.3.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-user-notifications-0.2.2",
+      "description": "Bindings to the UserNotifications framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-user-notifications@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-user-notifications",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-com-0.6.0",
+      "description": "Utilities for implementing COM Client and Servers\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/com@0.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "com",
+      "versionInfo": "0.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec--parser-0.4.0",
+      "description": "NEC2/4nec2-tolerant deck parser with diagnostics and dialect auto-detection",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec_parser",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-swash-0.1.19",
+      "description": "Font introspection, complex text shaping and glyph rendering.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/swash@0.1.19",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/dfrg/swash",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "swash",
+      "versionInfo": "0.1.19"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-static--assertions-1.1.0",
+      "description": "Compile-time assertions to ensure that invariants are met.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/static_assertions@1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/nvzqz/static-assertions-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "static_assertions",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gethostname-1.1.0",
+      "description": "gethostname for all platforms",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/gethostname@1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://codeberg.org/swsnr/gethostname.rs",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "gethostname",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-syn-2.0.117",
+      "description": "Parser for Rust source code",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/syn@2.0.117",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "syn",
+      "versionInfo": "2.0.117"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking-2.2.1",
+      "description": "Thread parking and unparking",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking@2.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/smol-rs/parking",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "parking",
+      "versionInfo": "2.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-svg--fmt-0.4.5",
+      "description": "Very simple debugging utilities to dump shapes in SVG format.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/svg_fmt@0.4.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "svg_fmt",
+      "versionInfo": "0.4.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ndk-sys-0.5.0-plus-25.2.9519653",
+      "description": "FFI bindings for the Android NDK",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ndk-sys@0.5.0%2B25.2.9519653",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-mobile/ndk",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ndk-sys",
+      "versionInfo": "0.5.0+25.2.9519653"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-fs-2.2.0",
+      "description": "Async filesystem primitives",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-fs@2.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/smol-rs/async-fs",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-fs",
+      "versionInfo": "2.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-detect-desktop-environment-0.2.0",
+      "description": "Autodetect the desktop environment",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/detect-desktop-environment@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/demurgos/detect-desktop-environment",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "detect-desktop-environment",
+      "versionInfo": "0.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dlv-list-0.3.0",
+      "description": "Semi-doubly linked list implemented using a vector",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dlv-list@0.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/sgodwincs/dlv-list-rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "dlv-list",
+      "versionInfo": "0.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-futures-0.4.70",
+      "description": "Bridging the gap between Rust Futures and JavaScript Promises",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-futures@0.4.70",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-futures",
+      "versionInfo": "0.4.70"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ndk-context-0.1.1",
+      "description": "Handles for accessing Android APIs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ndk-context@0.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-windowing/android-ndk-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ndk-context",
+      "versionInfo": "0.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-web-sys-0.3.97",
+      "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/web-sys@0.3.97",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/web-sys/index.html",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "web-sys",
+      "versionInfo": "0.3.97"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-pin-utils-0.1.0",
+      "description": "Utilities for pinning\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/pin-utils@0.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "pin-utils",
+      "versionInfo": "0.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-ui-kit-0.2.2",
+      "description": "Bindings to the UIKit framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-ui-kit@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-ui-kit",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rand--core-0.6.4",
+      "description": "Core random number generator traits and tools for implementation.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rand_core@0.6.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-random.github.io/book",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rand_core",
+      "versionInfo": "0.6.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml--edit-0.25.11-plus-spec-1.1.0",
+      "description": "Yet another format-preserving TOML parser.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml_edit@0.25.11%2Bspec-1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml_edit",
+      "versionInfo": "0.25.11+spec-1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-slotmap-1.1.1",
+      "description": "Slotmap data structure",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/slotmap@1.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib",
+      "licenseDeclared": "Zlib",
+      "name": "slotmap",
+      "versionInfo": "1.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-getrandom-0.3.4",
+      "description": "A small cross-platform library for retrieving random data from system source",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/getrandom@0.3.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "getrandom",
+      "versionInfo": "0.3.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec--project-0.4.0",
+      "description": "Project container: run configuration, variants, result cache, .nec and Markdown import/export",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec_project",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hashbrown-0.14.5",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hashbrown@0.14.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hashbrown",
+      "versionInfo": "0.14.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-drm-fourcc-2.2.0",
+      "description": "Provides an enum with every valid Direct Rendering Manager (DRM) format fourcc",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/drm-fourcc@2.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "drm-fourcc",
+      "versionInfo": "2.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_x86_64_gnullvm@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_x86_64_gnullvm",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-smallvec-1.15.1",
+      "description": "'Small vector' optimization: store up to a small number of items on the stack",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/smallvec@1.15.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "smallvec",
+      "versionInfo": "1.15.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ordered-multimap-0.4.3",
+      "description": "Insertion ordered multimap",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ordered-multimap@0.4.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/sgodwincs/ordered-multimap-rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "ordered-multimap",
+      "versionInfo": "0.4.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-cursor-icon-1.2.0",
+      "description": "Cross platform cursor icon type",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/cursor-icon@1.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "cursor-icon",
+      "versionInfo": "1.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-num--enum--derive-0.7.6",
+      "description": "Internal implementation details for ::num_enum (Procedural macros to make inter-operation between primitives and enums easier)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/num_enum_derive@0.7.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-3-Clause OR MIT OR Apache-2.0",
+      "licenseDeclared": "BSD-3-Clause OR MIT OR Apache-2.0",
+      "name": "num_enum_derive",
+      "versionInfo": "0.7.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--winit-0.13.0",
+      "description": "A runtime for iced on top of winit",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_winit@0.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_winit",
+      "versionInfo": "0.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120",
+      "description": "Implementation APIs for the `#[wasm_bindgen]` attribute",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-macro-support@0.2.120",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-macro-support",
+      "versionInfo": "0.2.120"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crossbeam-deque-0.8.6",
+      "description": "Concurrent work-stealing deque",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crossbeam-deque@0.8.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crossbeam-deque",
+      "versionInfo": "0.8.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--i686--gnullvm-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_i686_gnullvm@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_i686_gnullvm",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-palette--derive-0.7.6",
+      "description": "Automatically implement traits from the palette crate.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/palette_derive@0.7.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "palette_derive",
+      "versionInfo": "0.7.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-phf-0.11.3",
+      "description": "Runtime support for perfect hash function data structures",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/phf@0.11.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "phf",
+      "versionInfo": "0.11.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-event-listener-strategy-0.5.4",
+      "description": "Block or poll on event_listener easily",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/event-listener-strategy@0.5.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "event-listener-strategy",
+      "versionInfo": "0.5.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-phf--generator-0.11.3",
+      "description": "PHF generation logic",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/phf_generator@0.11.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "phf_generator",
+      "versionInfo": "0.11.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-self--cell-1.2.2",
+      "description": "Safe-to-use proc-macro-free self-referential structs in stable Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/self_cell@1.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR GPL-2.0",
+      "licenseDeclared": "Apache-2.0 OR GPL-2.0",
+      "name": "self_cell",
+      "versionInfo": "1.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0",
+      "description": "Procedural macro paired with the `wit-bindgen` crate.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-bindgen-rust-macro@0.51.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-bindgen-rust-macro",
+      "versionInfo": "0.51.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-bindgen-rust-0.51.0",
+      "description": "Rust bindings generator for WIT and the component model, typically used through\nthe `wit-bindgen` crate's `generate!` macro.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-bindgen-rust@0.51.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-bindgen-rust",
+      "versionInfo": "0.51.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-drm-sys-0.8.1",
+      "description": "Bindings to the Direct Rendering Manager API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/drm-sys@0.8.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "drm-sys",
+      "versionInfo": "0.8.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-adler2-2.0.1",
+      "description": "A simple clean-room implementation of the Adler-32 checksum",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/adler2@2.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "0BSD OR MIT OR Apache-2.0",
+      "licenseDeclared": "0BSD OR MIT OR Apache-2.0",
+      "name": "adler2",
+      "versionInfo": "2.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustix-1.1.4",
+      "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock-like syscalls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustix@1.1.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "rustix",
+      "versionInfo": "1.1.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zeno-0.2.3",
+      "description": "High performance, low level 2D path rasterization.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zeno@0.2.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/dfrg/zeno",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "zeno",
+      "versionInfo": "0.2.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--glyphon-0.6.0",
+      "description": "Fast, simple 2D text rendering for wgpu",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_glyphon@0.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/hecrj/glyphon.git",
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "iced_glyphon",
+      "versionInfo": "0.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dpi-0.1.2",
+      "description": "Types for handling UI scaling",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dpi@0.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 AND MIT",
+      "licenseDeclared": "Apache-2.0 AND MIT",
+      "name": "dpi",
+      "versionInfo": "0.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fastrand-2.4.1",
+      "description": "A simple and fast random number generator",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fastrand@2.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "fastrand",
+      "versionInfo": "2.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winreg-0.10.1",
+      "description": "Rust bindings to MS Windows Registry API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winreg@0.10.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "winreg",
+      "versionInfo": "0.10.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ndk-0.9.0",
+      "description": "Safe Rust bindings to the Android NDK",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ndk@0.9.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/rust-mobile/ndk",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ndk",
+      "versionInfo": "0.9.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hashbrown-0.15.5",
+      "description": "A Rust port of Google's SwissTable hash map",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hashbrown@0.15.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hashbrown",
+      "versionInfo": "0.15.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winnow-0.7.15",
+      "description": "A byte-oriented, zero-copy, parser combinators library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winnow@0.7.15",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "winnow",
+      "versionInfo": "0.7.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-yazi-0.1.6",
+      "description": "DEFLATE/zlib compression and decompression.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/yazi@0.1.6",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/dfrg/yazi",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "yazi",
+      "versionInfo": "0.1.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-memchr-2.8.0",
+      "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for\n1, 2 or 3 byte search and single substring search.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/memchr@2.8.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/BurntSushi/memchr",
+      "licenseConcluded": "Unlicense OR MIT",
+      "licenseDeclared": "Unlicense OR MIT",
+      "name": "memchr",
+      "versionInfo": "2.8.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--derive-1.0.228",
+      "description": "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_derive@1.0.228",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://serde.rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_derive",
+      "versionInfo": "1.0.228"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--repr-0.1.20",
+      "description": "Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_repr@0.1.20",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_repr",
+      "versionInfo": "0.1.20"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zbus-4.4.0",
+      "description": "API for D-Bus communication",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zbus@4.4.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zbus",
+      "versionInfo": "4.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows--aarch64--msvc-0.52.6",
+      "description": "Import lib for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows_aarch64_msvc@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows_aarch64_msvc",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc--exception-0.1.2",
+      "description": "Rust interface for Objective-C's throw and try/catch statements.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc_exception@0.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc_exception",
+      "versionInfo": "0.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-redox--syscall-0.2.16",
+      "description": "A Rust library to access raw Redox system calls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/redox_syscall@0.2.16",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "redox_syscall",
+      "versionInfo": "0.2.16"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-cosmic-text-0.12.1",
+      "description": "Pure Rust multi-line text handling",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/cosmic-text@0.12.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "cosmic-text",
+      "versionInfo": "0.12.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustc-hash-1.1.0",
+      "description": "speed, non-cryptographic hash used in rustc",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustc-hash@1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "rustc-hash",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-backend-0.3.15",
+      "description": "Low-level bindings to the Wayland protocol",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-backend@0.3.15",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-backend",
+      "versionInfo": "0.3.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-bindgen-0.51.0",
+      "description": "Rust bindings generator and runtime support for WIT and the component model.\nUsed when compiling Rust programs to the component model.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-bindgen@0.51.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-bindgen",
+      "versionInfo": "0.51.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ttf-parser-0.20.0",
+      "description": "A high-level, safe, zero-allocation TrueType font parser.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ttf-parser@0.20.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ttf-parser",
+      "versionInfo": "0.20.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-lru-0.12.5",
+      "description": "A LRU cache implementation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/lru@0.12.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/jeromefroe/lru-rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "lru",
+      "versionInfo": "0.12.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-io-surface-0.3.2",
+      "description": "Bindings to the IOSurface framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-io-surface@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "objc2-io-surface",
+      "versionInfo": "0.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-nec--accel-0.4.0",
+      "description": "Optional GPU acceleration backends for fnec-rust (wgpu compute, future: CUDA/Metal)",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "GPL-3.0",
+      "licenseDeclared": "GPL-3.0",
+      "name": "nec_accel",
+      "versionInfo": "0.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-signal-hook-registry-1.4.8",
+      "description": "Backend crate for signal-hook",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/signal-hook-registry@1.4.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "signal-hook-registry",
+      "versionInfo": "1.4.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking--lot-0.12.5",
+      "description": "More compact and efficient implementations of the standard synchronization primitives.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking_lot@0.12.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "parking_lot",
+      "versionInfo": "0.12.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-lite-2.6.1",
+      "description": "Futures, streams, and async I/O combinators",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-lite@2.6.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/smol-rs/futures-lite",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "futures-lite",
+      "versionInfo": "2.6.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasmparser-0.244.0",
+      "description": "A simple event-driven library for parsing WebAssembly binary files.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasmparser@0.244.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasmparser",
+      "versionInfo": "0.244.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-channel-0.3.32",
+      "description": "Channels for asynchronous communication using futures-rs.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-channel@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-channel",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerocopy-derive-0.8.48",
+      "description": "Custom derive for traits from the zerocopy crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerocopy-derive@0.8.48",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "licenseDeclared": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "name": "zerocopy-derive",
+      "versionInfo": "0.8.48"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-endi-1.1.1",
+      "description": "A simple endian-handling library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/endi@1.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "endi",
+      "versionInfo": "1.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libredox-0.1.16",
+      "description": "Redox stable ABI",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libredox@0.1.16",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "libredox",
+      "versionInfo": "0.1.16"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-lock--api-0.4.14",
+      "description": "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/lock_api@0.4.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "lock_api",
+      "versionInfo": "0.4.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "description": "Interoperability library for Rust Windowing applications.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/raw-window-handle@0.6.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "raw-window-handle",
+      "versionInfo": "0.6.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dlib-0.5.3",
+      "description": "Helper macros for handling manually loading optional system libraries.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dlib@0.5.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "dlib",
+      "versionInfo": "0.5.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rand--chacha-0.3.1",
+      "description": "ChaCha random number generator\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rand_chacha@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-random.github.io/book",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rand_chacha",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wgpu-0.19.4",
+      "description": "Rusty WebGPU API wrapper",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wgpu@0.19.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wgpu.rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wgpu",
+      "versionInfo": "0.19.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-client-0.31.14",
+      "description": "Bindings to the standard C implementation of the wayland protocol, client side.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-client@0.31.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-client",
+      "versionInfo": "0.31.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gpu-descriptor-0.2.4",
+      "description": "Implementation agnostic descriptor allocator for Vulkan like APIs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/gpu-descriptor@0.2.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/zakarumych/gpu-descriptor",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "gpu-descriptor",
+      "versionInfo": "0.2.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-link-0.2.1",
+      "description": "Linking for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-link@0.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-link",
+      "versionInfo": "0.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zmij-1.0.21",
+      "description": "A double-to-string conversion algorithm based on Schubfach and yy",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zmij@1.0.21",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zmij",
+      "versionInfo": "1.0.21"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tracing-core-0.1.36",
+      "description": "Core primitives for application-level tracing.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tracing-core@0.1.36",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://tokio.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tracing-core",
+      "versionInfo": "0.1.36"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "description": "A lightweight version of pin-project written with declarative macros.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/pin-project-lite@0.2.17",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "pin-project-lite",
+      "versionInfo": "0.2.17"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tinyvec-1.11.0",
+      "description": "`tinyvec` provides 100% safe vec-like data structures.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tinyvec@1.11.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "tinyvec",
+      "versionInfo": "1.11.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-sys-0.31.11",
+      "description": "FFI bindings to the various libwayland-*.so libraries. You should only need this crate if you are working on custom wayland protocol extensions. Look at the crate wayland-client for usable bindings.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-sys@0.31.11",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-sys",
+      "versionInfo": "0.31.11"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-executor-1.14.0",
+      "description": "Async executor",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-executor@1.14.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-executor",
+      "versionInfo": "1.14.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ahash-0.8.12",
+      "description": "A non-cryptographic hash function using AES-NI for high performance",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ahash@0.8.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ahash",
+      "versionInfo": "0.8.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-foreign-types-0.5.0",
+      "description": "A framework for Rust wrappers over C APIs",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/foreign-types@0.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "foreign-types",
+      "versionInfo": "0.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--runtime-0.13.2",
+      "description": "A renderer-agnostic runtime for iced",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_runtime@0.13.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_runtime",
+      "versionInfo": "0.13.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hassle-rs-0.11.0",
+      "description": "HLSL compiler library, this crate provides an FFI layer and idiomatic rust wrappers for the new DXC HLSL compiler and validator.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hassle-rs@0.11.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/Traverse-Research/hassle-rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "hassle-rs",
+      "versionInfo": "0.11.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-bindgen-core-0.51.0",
+      "description": "Low-level support for bindings generation based on WIT files for use with\n`wit-bindgen-cli` and other languages.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-bindgen-core@0.51.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wit-bindgen",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-bindgen-core",
+      "versionInfo": "0.51.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-0.3.32",
+      "description": "An implementation of futures and streams featuring zero allocations,\ncomposability, and iterator-like interfaces.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-png-0.17.16",
+      "description": "PNG decoding and encoding library in pure Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/png@0.17.16",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "png",
+      "versionInfo": "0.17.16"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ash-0.37.3-plus-1.3.251",
+      "description": "Vulkan bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ash@0.37.3%2B1.3.251",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ash",
+      "versionInfo": "0.37.3+1.3.251"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-com--macros-0.6.0",
+      "description": "COM crate macros\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/com_macros@0.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "com_macros",
+      "versionInfo": "0.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-proc-macro2-1.0.106",
+      "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/proc-macro2@1.0.106",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "proc-macro2",
+      "versionInfo": "1.0.106"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ab--glyph--rasterizer-0.1.10",
+      "description": "Coverage rasterization for lines, quadratic & cubic beziers",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ab_glyph_rasterizer@0.1.10",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "ab_glyph_rasterizer",
+      "versionInfo": "0.1.10"
     },
     {
       "SPDXID": "SPDXRef-Package-num-traits-0.2.19",
@@ -174,6 +4515,329 @@
       "versionInfo": "0.2.19"
     },
     {
+      "SPDXID": "SPDXRef-Package-async-channel-2.5.0",
+      "description": "Async multi-producer multi-consumer channel",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-channel@2.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-channel",
+      "versionInfo": "2.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-sys-0.52.0",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-sys@0.52.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-sys",
+      "versionInfo": "0.52.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jni-sys-macros-0.4.1",
+      "description": "Macros for jni-sys crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jni-sys-macros@0.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "jni-sys-macros",
+      "versionInfo": "0.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-linux-raw-sys-0.12.1",
+      "description": "Generated bindings for Linux's userspace API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/linux-raw-sys@0.12.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "linux-raw-sys",
+      "versionInfo": "0.12.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dirs-4.0.0",
+      "description": "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dirs@4.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "dirs",
+      "versionInfo": "4.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-simd-adler32-0.3.9",
+      "description": "A SIMD-accelerated Adler-32 hash algorithm implementation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/simd-adler32@0.3.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "simd-adler32",
+      "versionInfo": "0.3.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-miniz--oxide-0.8.9",
+      "description": "DEFLATE compression and decompression library rewritten in Rust based on miniz",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/miniz_oxide@0.8.9",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide",
+      "licenseConcluded": "MIT OR Zlib OR Apache-2.0",
+      "licenseDeclared": "MIT OR Zlib OR Apache-2.0",
+      "name": "miniz_oxide",
+      "versionInfo": "0.8.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-euclid-0.22.14",
+      "description": "Geometry primitives",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/euclid@0.22.14",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "euclid",
+      "versionInfo": "0.22.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
+      "description": "Experimental WASI API bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasi@0.11.1%2Bwasi-snapshot-preview1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasi",
+      "versionInfo": "0.11.1+wasi-snapshot-preview1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-plain-0.2.3",
+      "description": "A small Rust library that allows users to reinterpret data of certain types safely.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/plain@0.2.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/randomites/plain",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "plain",
+      "versionInfo": "0.2.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-redox--syscall-0.7.4",
+      "description": "A Rust library to access raw Redox system calls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/redox_syscall@0.7.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "redox_syscall",
+      "versionInfo": "0.7.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-calloop-0.14.4",
+      "description": "A callback-based event loop",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/calloop@0.14.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "calloop",
+      "versionInfo": "0.14.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ordered-stream-0.2.0",
+      "description": "Streams that are ordered relative to external events",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ordered-stream@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ordered-stream",
+      "versionInfo": "0.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tracing-0.1.44",
+      "description": "Application-level tracing for Rust.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tracing@0.1.44",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://tokio.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "tracing",
+      "versionInfo": "0.1.44"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glam-0.25.0",
+      "description": "A simple and fast 3D math library for games and graphics",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/glam@0.25.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "glam",
+      "versionInfo": "0.25.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fontdb-0.16.2",
+      "description": "A simple, in-memory font database with CSS-like queries.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fontdb@0.16.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "fontdb",
+      "versionInfo": "0.16.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustversion-1.0.22",
+      "description": "Conditional compilation according to rustc compiler version",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustversion@1.0.22",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rustversion",
+      "versionInfo": "1.0.22"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-once--cell-1.21.4",
+      "description": "Single assignment cells and lazy values.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/once_cell@1.21.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "once_cell",
+      "versionInfo": "1.21.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-softbuffer-0.4.8",
+      "description": "Cross-platform software buffer",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/softbuffer@0.4.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "softbuffer",
+      "versionInfo": "0.4.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-core-graphics-0.3.2",
+      "description": "Bindings to the CoreGraphics framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-core-graphics@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "objc2-core-graphics",
+      "versionInfo": "0.3.2"
+    },
+    {
       "SPDXID": "SPDXRef-Package-num-complex-0.4.6",
       "description": "Complex numbers implementation for Rust",
       "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
@@ -191,129 +4855,3099 @@
       "versionInfo": "0.4.6"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec--parser-0.2.0",
-      "description": "NEC2/4nec2-tolerant deck parser with diagnostics and dialect auto-detection",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec_parser",
+      "SPDXID": "SPDXRef-Package-thiserror-2.0.18",
+      "description": "derive(Error)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/thiserror@2.0.18",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "thiserror",
+      "versionInfo": "2.0.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-arrayvec-0.7.6",
+      "description": "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/arrayvec@0.7.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "arrayvec",
+      "versionInfo": "0.7.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-xcursor-0.3.10",
+      "description": "A library for loading XCursor themes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/xcursor@0.3.10",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "xcursor",
+      "versionInfo": "0.3.10"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde-1.0.228",
+      "description": "A generic serialization/deserialization framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde@1.0.228",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://serde.rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde",
+      "versionInfo": "1.0.228"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-redox--syscall-0.4.1",
+      "description": "A Rust library to access raw Redox system calls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/redox_syscall@0.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "redox_syscall",
+      "versionInfo": "0.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-owned--ttf--parser-0.25.1",
+      "description": "ttf-parser plus support for owned data",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/owned_ttf_parser@0.25.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "owned_ttf_parser",
+      "versionInfo": "0.25.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-cpufeatures-0.2.17",
+      "description": "Lightweight runtime CPU feature detection for aarch64, loongarch64, and x86/x86_64 targets, \nwith no_std support and support for mobile targets including Android and iOS\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/cpufeatures@0.2.17",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "cpufeatures",
+      "versionInfo": "0.2.17"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking--lot--core-0.9.12",
+      "description": "An advanced API for creating custom synchronization primitives.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking_lot_core@0.9.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "parking_lot_core",
+      "versionInfo": "0.9.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasip3-0.4.0-plus-wasi-0.3.0-rc-2026-01-06",
+      "description": "WASIp3 API bindings for Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasip3@0.4.0%2Bwasi-0.3.0-rc-2026-01-06",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasip3",
+      "versionInfo": "0.4.0+wasi-0.3.0-rc-2026-01-06"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-xkbcommon-dl-0.4.2",
+      "description": "Dynamically loaded xkbcommon and xkbcommon-x11 Rust bindings.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/xkbcommon-dl@0.4.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "xkbcommon-dl",
+      "versionInfo": "0.4.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-recursion-1.1.1",
+      "description": "Recursion for async functions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-recursion@1.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "async-recursion",
+      "versionInfo": "1.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glow-0.13.1",
+      "description": "GL on Whatever: a set of bindings to run GL (Open GL, OpenGL ES, and WebGL) anywhere, and avoid target-specific code.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/glow@0.13.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/grovesNL/glow.git",
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "glow",
+      "versionInfo": "0.13.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-trait-0.1.89",
+      "description": "Type erasure for async trait methods",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-trait@0.1.89",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "async-trait",
+      "versionInfo": "0.1.89"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libc-0.2.186",
+      "description": "Raw FFI bindings to platform libraries like libc.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libc@0.2.186",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "libc",
+      "versionInfo": "0.2.186"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-id-arena-2.3.0",
+      "description": "A simple, id-based arena.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/id-arena@2.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "id-arena",
+      "versionInfo": "2.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-js-sys-0.3.97",
+      "description": "Bindings for all JS global objects and functions in all JS environments like\nNode.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/js-sys@0.3.97",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "js-sys",
+      "versionInfo": "0.3.97"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gpu-allocator-0.25.0",
+      "description": "Memory allocator for GPU memory in Vulkan and DirectX 12",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/gpu-allocator@0.25.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/Traverse-Research/gpu-allocator",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "gpu-allocator",
+      "versionInfo": "0.25.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-0.52.0",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows@0.52.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows",
+      "versionInfo": "0.52.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ppv-lite86-0.2.21",
+      "description": "Cross-platform cryptography-oriented low-level SIMD library.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ppv-lite86@0.2.21",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ppv-lite86",
+      "versionInfo": "0.2.21"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-drm-0.14.1",
+      "description": "Safe, low-level bindings to the Direct Rendering Manager API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/drm@0.14.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "drm",
+      "versionInfo": "0.14.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-metal-0.2.2",
+      "description": "Bindings to the Metal framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-metal@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-metal",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-indexmap-2.14.0",
+      "description": "A hash table with consistent order and fast iteration.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/indexmap@2.14.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "indexmap",
+      "versionInfo": "2.14.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-foreign-types-shared-0.3.1",
+      "description": "An internal crate used by foreign-types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/foreign-types-shared@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "foreign-types-shared",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "description": "Bindings to the Foundation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-foundation@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-foundation",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zbus--macros-4.4.0",
+      "description": "proc-macros for zbus",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zbus_macros@4.4.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zbus_macros",
+      "versionInfo": "4.4.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-etagere-0.2.15",
+      "description": "Dynamic 2D texture atlas allocation using the shelf packing algorithm.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/etagere@0.2.15",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "etagere",
+      "versionInfo": "0.2.15"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--tiny--skia-0.13.0",
+      "description": "A software renderer for iced on top of tiny-skia",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_tiny_skia@0.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_tiny_skia",
+      "versionInfo": "0.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-android-properties-0.2.2",
+      "description": "Rust-based Android properties wrapper",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/android-properties@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/miklelappo/android-properties",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "android-properties",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "description": "Concurrent multi-producer multi-consumer queue",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/concurrent-queue@2.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "concurrent-queue",
+      "versionInfo": "2.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-getrandom-0.4.2",
+      "description": "A small cross-platform library for retrieving random data from system source",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/getrandom@0.4.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "getrandom",
+      "versionInfo": "0.4.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-libm-0.2.16",
+      "description": "libm in pure Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/libm@0.2.16",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "libm",
+      "versionInfo": "0.2.16"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-util-0.3.32",
+      "description": "Common utilities and extension traits for the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-util@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-util",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-timer-0.2.5",
+      "description": "Abstraction over std::time::Instant and futures-timer that works on WASM",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-timer@0.2.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wasm-timer",
+      "versionInfo": "0.2.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml--write-0.1.2",
+      "description": "A low-level interface for writing out TOML\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml_write@0.1.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml_write",
+      "versionInfo": "0.1.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-polling-3.11.0",
+      "description": "Portable interface to epoll, kqueue, event ports, and IOCP",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/polling@3.11.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "polling",
+      "versionInfo": "3.11.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-metadata-0.244.0",
+      "description": "Read and manipulate WebAssembly metadata",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-metadata@0.244.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasm-metadata",
+      "versionInfo": "0.244.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glutin--wgl--sys-0.5.0",
+      "description": "The wgl bindings for glutin",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/glutin_wgl_sys@0.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "glutin_wgl_sys",
+      "versionInfo": "0.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-block2-0.5.1",
+      "description": "Apple's C language extension of blocks",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/block2@0.5.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "block2",
+      "versionInfo": "0.5.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-pin-project-internal-1.1.11",
+      "description": "Implementation detail of the `pin-project` crate.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/pin-project-internal@1.1.11",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "pin-project-internal",
+      "versionInfo": "1.1.11"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-targets-0.52.6",
+      "description": "Import libs for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-targets@0.52.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-targets",
+      "versionInfo": "0.52.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking--lot-0.11.2",
+      "description": "More compact and efficient implementations of the standard synchronization primitives.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking_lot@0.11.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "parking_lot",
+      "versionInfo": "0.11.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-simd--cesu8-1.1.1",
+      "description": "An extremely fast, SIMD accelerated, encoding and decoding library for CESU-8 and Modified UTF-8.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/simd_cesu8@1.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/seancroach/simd_cesu8",
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "simd_cesu8",
+      "versionInfo": "1.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-strict-num-0.1.1",
+      "description": "A collection of bounded numeric types",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/strict-num@0.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "strict-num",
+      "versionInfo": "0.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-jni-sys-0.4.1",
+      "description": "Rust definitions corresponding to jni.h",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/jni-sys@0.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "jni-sys",
+      "versionInfo": "0.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-sys-locale-0.3.2",
+      "description": "Small and lightweight library to obtain the active system locale",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/sys-locale@0.3.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "sys-locale",
+      "versionInfo": "0.3.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-parking--lot--core-0.8.6",
+      "description": "An advanced API for creating custom synchronization primitives.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/parking_lot_core@0.8.6",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "parking_lot_core",
+      "versionInfo": "0.8.6"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-spirv-0.3.0-plus-sdk-1.3.268.0",
+      "description": "Rust definition of SPIR-V structs and enums",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/spirv@0.3.0%2Bsdk-1.3.268.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "spirv",
+      "versionInfo": "0.3.0+sdk-1.3.268.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gpu-alloc-types-0.3.0",
+      "description": "Core types of gpu-alloc crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/gpu-alloc-types@0.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/zakarumych/gpu-alloc",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "gpu-alloc-types",
+      "versionInfo": "0.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-calloop-0.13.0",
+      "description": "A callback-based event loop",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/calloop@0.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "calloop",
+      "versionInfo": "0.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "description": "Easy support for interacting between JS and Rust.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen@0.2.120",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen",
+      "versionInfo": "0.2.120"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--json-1.0.149",
+      "description": "A JSON serialization file format",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_json@1.0.149",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_json",
+      "versionInfo": "1.0.149"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zvariant--derive-4.2.0",
+      "description": "D-Bus & GVariant encoding & decoding",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zvariant_derive@4.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zvariant_derive",
+      "versionInfo": "4.2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "description": "Utilities for concurrent programming",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/crossbeam-utils@0.8.21",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "crossbeam-utils",
+      "versionInfo": "0.8.21"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-sink-0.3.32",
+      "description": "The asynchronous `Sink` trait for the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-sink@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-sink",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-macro-0.3.32",
+      "description": "The futures-rs procedural macro implementations.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-macro@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-macro",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-kurbo-0.10.4",
+      "description": "A 2D curves library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/kurbo@0.10.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "kurbo",
+      "versionInfo": "0.10.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-itoa-1.0.18",
+      "description": "Fast integer primitive to string conversion",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/itoa@1.0.18",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "itoa",
+      "versionInfo": "1.0.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fdeflate-0.3.7",
+      "description": "Fast specialized deflate implementation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fdeflate@0.3.7",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/image-rs/fdeflate",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "fdeflate",
+      "versionInfo": "0.3.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winit-0.30.13",
+      "description": "Cross-platform window creation library.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winit@0.30.13",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "winit",
+      "versionInfo": "0.30.13"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-cfg-if-1.0.4",
+      "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/cfg-if@1.0.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "cfg-if",
+      "versionInfo": "1.0.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml--datetime-1.1.1-plus-spec-1.1.0",
+      "description": "A TOML-compatible datetime type",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml_datetime@1.1.1%2Bspec-1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml_datetime",
+      "versionInfo": "1.1.1+spec-1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-heck-0.5.0",
+      "description": "heck is a case conversion library.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/heck@0.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "heck",
+      "versionInfo": "0.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-font-types-0.7.3",
+      "description": "Scalar types used in fonts.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/font-types@0.7.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "font-types",
+      "versionInfo": "0.7.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-guillotiere-0.6.2",
+      "description": "A dynamic 2D texture atlas allocator with fast deallocation.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/guillotiere@0.6.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "guillotiere",
+      "versionInfo": "0.6.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ttf-parser-0.25.1",
+      "description": "A high-level, safe, zero-allocation font parser for TrueType, OpenType, and AAT.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ttf-parser@0.25.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ttf-parser",
+      "versionInfo": "0.25.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-toml--parser-1.1.2-plus-spec-1.1.0",
+      "description": "Yet another format-preserving TOML parser.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/toml_parser@1.1.2%2Bspec-1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "toml_parser",
+      "versionInfo": "1.1.2+spec-1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-thiserror-impl-2.0.18",
+      "description": "Implementation detail of the `thiserror` crate",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/thiserror-impl@2.0.18",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "thiserror-impl",
+      "versionInfo": "2.0.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-proc-macro-crate-3.5.0",
+      "description": "Replacement for crate (macro_rules keyword) in proc-macros\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/proc-macro-crate@3.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "proc-macro-crate",
+      "versionInfo": "3.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-phf--shared-0.11.3",
+      "description": "Support code shared by PHF libraries",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/phf_shared@0.11.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "phf_shared",
+      "versionInfo": "0.11.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-com--macros--support-0.6.0",
+      "description": "Support library for COM crate macros\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/com_macros_support@0.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "com_macros_support",
+      "versionInfo": "0.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-xkeysym-0.2.1",
+      "description": "A library for working with X11 keysyms",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/xkeysym@0.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "xkeysym",
+      "versionInfo": "0.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-encoder-0.244.0",
+      "description": "A low-level WebAssembly encoder.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-encoder@0.244.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wasm-encoder",
+      "versionInfo": "0.244.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-metal-0.27.0",
+      "description": "Rust bindings for Metal",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/metal@0.27.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/gfx-rs/metal-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "metal",
+      "versionInfo": "0.27.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ttf-parser-0.21.1",
+      "description": "A high-level, safe, zero-allocation font parser for TrueType, OpenType, and AAT.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ttf-parser@0.21.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ttf-parser",
+      "versionInfo": "0.21.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-as-raw-xcb-connection-1.0.1",
+      "description": "Trait to facilitate interoperatibility with libxcb C API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/as-raw-xcb-connection@1.0.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "as-raw-xcb-connection",
+      "versionInfo": "1.0.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-quartz-core-0.2.2",
+      "description": "Bindings to the QuartzCore/CoreAnimation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-quartz-core@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-quartz-core",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-broadcast-0.7.2",
+      "description": "Async broadcast channels",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-broadcast@0.7.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "async-broadcast",
+      "versionInfo": "0.7.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zvariant--utils-2.1.0",
+      "description": "Various utilities used internally by the zvariant crate.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zvariant_utils@2.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "zvariant_utils",
+      "versionInfo": "2.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rustybuzz-0.14.1",
+      "description": "A complete harfbuzz shaping algorithm port to Rust.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rustybuzz@0.14.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "rustybuzz",
+      "versionInfo": "0.14.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-generic-array-0.14.7",
+      "description": "Generic types implementing functionality of arrays",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/generic-array@0.14.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "generic-array",
+      "versionInfo": "0.14.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-link-presentation-0.2.2",
+      "description": "Bindings to the LinkPresentation framework",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2-link-presentation@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2-link-presentation",
+      "versionInfo": "0.2.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-protocols-plasma-0.3.12",
+      "description": "Generated API for the Plasma wayland protocol extensions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-protocols-plasma@0.3.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-protocols-plasma",
+      "versionInfo": "0.3.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-windows-sys-0.61.2",
+      "description": "Rust for Windows",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/windows-sys@0.61.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "windows-sys",
+      "versionInfo": "0.61.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-ahash-0.7.8",
+      "description": "A non-cryptographic hash function using AES-NI for high performance",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/ahash@0.7.8",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "ahash",
+      "versionInfo": "0.7.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-shared-0.2.120",
+      "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal\ndependency.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-shared@0.2.120",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-shared",
+      "versionInfo": "0.2.120"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bytemuck--derive-1.10.2",
+      "description": "derive proc-macros for `bytemuck`",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bytemuck_derive@1.10.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "bytemuck_derive",
+      "versionInfo": "1.10.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-fontconfig-parser-0.5.8",
+      "description": "fontconfig file parser in pure Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/fontconfig-parser@0.5.8",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/Riey/fontconfig-parser",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "fontconfig-parser",
+      "versionInfo": "0.5.8"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-profiling-1.0.17",
+      "description": "This crate provides a very thin abstraction over other profiler crates.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/profiling@1.0.17",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/aclysma/profiling",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "profiling",
+      "versionInfo": "1.0.17"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-objc2-0.6.4",
+      "description": "Objective-C interface and runtime bindings",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/objc2@0.6.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "objc2",
+      "versionInfo": "0.6.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-getrandom-0.2.17",
+      "description": "A small cross-platform library for retrieving random data from system source",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/getrandom@0.2.17",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "getrandom",
+      "versionInfo": "0.2.17"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wasm-bindgen-macro-0.2.120",
+      "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wasm-bindgen-macro@0.2.120",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wasm-bindgen.github.io/wasm-bindgen/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wasm-bindgen-macro",
+      "versionInfo": "0.2.120"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-redox--syscall-0.5.18",
+      "description": "A Rust library to access raw Redox system calls",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/redox_syscall@0.5.18",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "redox_syscall",
+      "versionInfo": "0.5.18"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-skrifa-0.22.3",
+      "description": "Metadata reader and glyph scaler for OpenType fonts.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/skrifa@0.22.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "skrifa",
+      "versionInfo": "0.22.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--widget-0.13.4",
+      "description": "The built-in widgets for iced",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_widget@0.13.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_widget",
+      "versionInfo": "0.13.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-zerocopy-0.8.48",
+      "description": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/zerocopy@0.8.48",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "licenseDeclared": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "name": "zerocopy",
+      "versionInfo": "0.8.48"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-calloop-wayland-source-0.4.1",
+      "description": "A wayland-rs client event source for callloop",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/calloop-wayland-source@0.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "calloop-wayland-source",
+      "versionInfo": "0.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-smithay-client-toolkit-0.20.0",
+      "description": "Toolkit for making client wayland applications.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/smithay-client-toolkit@0.20.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "smithay-client-toolkit",
+      "versionInfo": "0.20.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-syn-1.0.109",
+      "description": "Parser for Rust source code",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/syn@1.0.109",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "syn",
+      "versionInfo": "1.0.109"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-slab-0.4.12",
+      "description": "Pre-allocated storage for a uniform data type",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/slab@0.4.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "slab",
+      "versionInfo": "0.4.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winapi-0.3.9",
+      "description": "Raw FFI bindings for all of Windows API.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winapi@0.3.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "winapi",
+      "versionInfo": "0.3.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-by--address-1.2.1",
+      "description": "Wrapper for comparing and hashing pointers by address",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/by_address@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "by_address",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-process-2.5.0",
+      "description": "Async interface for working with processes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-process@2.5.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-process",
+      "versionInfo": "2.5.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-iced--renderer-0.13.0",
+      "description": "The official renderer for iced",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/iced_renderer@0.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://iced.rs",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "iced_renderer",
+      "versionInfo": "0.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-piper-0.2.5",
+      "description": "An asynchronous single-consumer single-producer pipe for bytes.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/piper@0.2.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "piper",
+      "versionInfo": "0.2.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wit-parser-0.244.0",
+      "description": "Tooling for parsing `*.wit` files and working with their contents.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wit-parser@0.244.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser",
+      "licenseConcluded": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR Apache-2.0 OR MIT",
+      "name": "wit-parser",
+      "versionInfo": "0.244.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bytes-1.11.1",
+      "description": "Types and traits for working with bytes",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bytes@1.11.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "bytes",
+      "versionInfo": "1.11.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-winnow-1.0.2",
+      "description": "A byte-oriented, zero-copy, parser combinators library",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/winnow@1.0.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "winnow",
+      "versionInfo": "1.0.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bytemuck-1.25.0",
+      "description": "A crate for mucking around with piles of bytes.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bytemuck@1.25.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "bytemuck",
+      "versionInfo": "1.25.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-enumflags2-0.7.12",
+      "description": "Enum-based bit flags",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/enumflags2@0.7.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "enumflags2",
+      "versionInfo": "0.7.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-hermit-abi-0.5.2",
+      "description": "Hermit system calls definitions.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/hermit-abi@0.5.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "hermit-abi",
+      "versionInfo": "0.5.2"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tinyvec--macros-0.1.1",
+      "description": "Some macros for tiny containers",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tinyvec_macros@0.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0 OR Zlib",
+      "licenseDeclared": "MIT OR Apache-2.0 OR Zlib",
+      "name": "tinyvec_macros",
+      "versionInfo": "0.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-read-fonts-0.22.7",
+      "description": "Reading OpenType font files.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/read-fonts@0.22.7",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "read-fonts",
+      "versionInfo": "0.22.7"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-ident-1.0.24",
+      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-ident@1.0.24",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "(MIT OR Apache-2.0) AND Unicode-3.0",
+      "licenseDeclared": "(MIT OR Apache-2.0) AND Unicode-3.0",
+      "name": "unicode-ident",
+      "versionInfo": "1.0.24"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-quote-1.0.45",
+      "description": "Quasi-quoting macro quote!(...)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/quote@1.0.45",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "quote",
+      "versionInfo": "1.0.45"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-linebreak-0.1.5",
+      "description": "Implementation of the Unicode Line Breaking Algorithm",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-linebreak@0.1.5",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/axelf4/unicode-linebreak",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "unicode-linebreak",
+      "versionInfo": "0.1.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-drm-ffi-0.9.1",
+      "description": "Safe, low-level bindings to the Direct Rendering Manager API",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/drm-ffi@0.9.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "drm-ffi",
+      "versionInfo": "0.9.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-arrayref-0.3.9",
+      "description": "Macros to take array references of slices",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/arrayref@0.3.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-2-Clause",
+      "licenseDeclared": "BSD-2-Clause",
+      "name": "arrayref",
+      "versionInfo": "0.3.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-io-2.6.0",
+      "description": "Async I/O and timers",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-io@2.6.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-io",
+      "versionInfo": "2.6.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-widestring-1.2.1",
+      "description": "A wide string Rust library for converting to and from wide strings, such as those often used in Windows API or other FFI libaries. Both `u16` and `u32` string types are provided, including support for UTF-16 and UTF-32, malformed encoding, C-style strings, etc.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/widestring@1.2.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "widestring",
+      "versionInfo": "1.2.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-khronos-egl-6.0.0",
+      "description": "Rust bindings for EGL",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/khronos-egl@6.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "khronos-egl",
+      "versionInfo": "6.0.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dispatch-0.2.0",
+      "description": "Rust wrapper for Apple's Grand Central Dispatch.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dispatch@0.2.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "dispatch",
       "versionInfo": "0.2.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec--accel-0.2.0",
-      "description": "Optional GPU acceleration backends for fnec-rust (wgpu compute, future: CUDA/Metal)",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec_accel",
-      "versionInfo": "0.2.0"
+      "SPDXID": "SPDXRef-Package-smithay-clipboard-0.7.3",
+      "description": "Provides access to the wayland clipboard for client applications.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/smithay-clipboard@0.7.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "smithay-clipboard",
+      "versionInfo": "0.7.3"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec-gui-0.2.0",
-      "description": "fnec GUI frontend — modern task-oriented antenna modeling interface (iced)",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec-gui",
-      "versionInfo": "0.2.0"
+      "SPDXID": "SPDXRef-Package-r-efi-6.0.0",
+      "description": "UEFI Reference Specification Protocol Constants and Definitions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/r-efi@6.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/r-efi/r-efi/wiki",
+      "licenseConcluded": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
+      "licenseDeclared": "MIT OR Apache-2.0 OR LGPL-2.1-or-later",
+      "name": "r-efi",
+      "versionInfo": "6.0.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec--solver-0.2.0",
-      "description": "NEC2 MoM solver: matrix assembly, linear solve, postprocessing (currents, impedance, patterns)",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec_solver",
-      "versionInfo": "0.2.0"
+      "SPDXID": "SPDXRef-Package-rust-ini-0.18.0",
+      "description": "An Ini configuration file parsing library in Rust",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rust-ini@0.18.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "rust-ini",
+      "versionInfo": "0.18.0"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec-tui-0.2.0",
-      "description": "fnec TUI frontend — terminal interface for batch runs and quick inspection (ratatui)",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec-tui",
-      "versionInfo": "0.2.0"
+      "SPDXID": "SPDXRef-Package-smol--str-0.2.2",
+      "description": "small-string optimized string type with O(1) clone",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/smol_str@0.2.2",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "smol_str",
+      "versionInfo": "0.2.2"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec--project-0.2.0",
-      "description": "Project container: run configuration, variants, result cache, .nec and Markdown import/export",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec_project",
-      "versionInfo": "0.2.0"
+      "SPDXID": "SPDXRef-Package-memmap2-0.9.10",
+      "description": "Cross-platform Rust API for memory-mapped file IO",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/memmap2@0.9.10",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "memmap2",
+      "versionInfo": "0.9.10"
     },
     {
-      "SPDXID": "SPDXRef-Package-nec--report-0.2.0",
-      "description": "Result reporting and export: 4nec2-like text output, plotting data preparation",
-      "downloadLocation": "NONE",
-      "licenseConcluded": "GPL-3.0",
-      "licenseDeclared": "GPL-3.0",
-      "name": "nec_report",
-      "versionInfo": "0.2.0"
+      "SPDXID": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "description": "Wayland Scanner for generating rust APIs from XML wayland protocol files.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-scanner@0.31.10",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-scanner",
+      "versionInfo": "0.31.10"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-serde--spanned-0.6.9",
+      "description": "Serde-compatible spanned Value",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/serde_spanned@0.6.9",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "serde_spanned",
+      "versionInfo": "0.6.9"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-async-task-4.7.1",
+      "description": "Task abstraction for building executors",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/async-task@4.7.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0 OR MIT",
+      "licenseDeclared": "Apache-2.0 OR MIT",
+      "name": "async-task",
+      "versionInfo": "4.7.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-tiny-skia-path-0.11.4",
+      "description": "A tiny-skia Bezier path implementation",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/tiny-skia-path@0.11.4",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "name": "tiny-skia-path",
+      "versionInfo": "0.11.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-futures-io-0.3.32",
+      "description": "The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/futures-io@0.3.32",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://rust-lang.github.io/futures-rs",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "futures-io",
+      "versionInfo": "0.3.32"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-web-time-1.1.0",
+      "description": "Drop-in replacement for std::time for Wasm in browsers",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/web-time@1.1.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "web-time",
+      "versionInfo": "1.1.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-dispatch2-0.3.1",
+      "description": "Bindings and wrappers for Apple's Grand Central Dispatch (GCD)",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/dispatch2@0.3.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib OR Apache-2.0 OR MIT",
+      "licenseDeclared": "Zlib OR Apache-2.0 OR MIT",
+      "name": "dispatch2",
+      "versionInfo": "0.3.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-foldhash-0.1.5",
+      "description": "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/foldhash@0.1.5",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Zlib",
+      "licenseDeclared": "Zlib",
+      "name": "foldhash",
+      "versionInfo": "0.1.5"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-xdg-home-1.3.0",
+      "description": "The user's home directory as per XDG Specification",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/xdg-home@1.3.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "xdg-home",
+      "versionInfo": "1.3.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-bit-set-0.5.3",
+      "description": "A set of bits",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/bit-set@0.5.3",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/contain-rs/bit-set",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "bit-set",
+      "versionInfo": "0.5.3"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-unicode-width-0.1.14",
+      "description": "Determine displayed width of `char` and `str` types\naccording to Unicode Standard Annex #11 rules.\n",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/unicode-width@0.1.14",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://github.com/unicode-rs/unicode-width",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "unicode-width",
+      "versionInfo": "0.1.14"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wgpu-core-0.19.4",
+      "description": "WebGPU core logic on wgpu-hal",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wgpu-core@0.19.4",
+          "referenceType": "purl"
+        }
+      ],
+      "homepage": "https://wgpu.rs/",
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "wgpu-core",
+      "versionInfo": "0.19.4"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-d3d12-0.19.0",
+      "description": "Low level D3D12 API wrapper",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/d3d12@0.19.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "d3d12",
+      "versionInfo": "0.19.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-clipboard-win-5.4.1",
+      "description": "Provides simple way to interact with Windows clipboard.",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/clipboard-win@5.4.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "BSL-1.0",
+      "licenseDeclared": "BSL-1.0",
+      "name": "clipboard-win",
+      "versionInfo": "5.4.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-clipboard--macos-0.1.1",
+      "description": "A library to obtain access to the macOS clipboard",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/clipboard_macos@0.1.1",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "name": "clipboard_macos",
+      "versionInfo": "0.1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-rayon-core-1.13.0",
+      "description": "Core APIs for Rayon",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/rayon-core@1.13.0",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT OR Apache-2.0",
+      "licenseDeclared": "MIT OR Apache-2.0",
+      "name": "rayon-core",
+      "versionInfo": "1.13.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-wayland-protocols-misc-0.3.12",
+      "description": "Generated API for misc and deprecated wayland protocol extensions",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/wayland-protocols-misc@0.3.12",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "wayland-protocols-misc",
+      "versionInfo": "0.3.12"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-clipboard--x11-0.4.3",
+      "description": "A library to obtain access to the X11 clipboard",
+      "downloadLocation": "registry+https://github.com/rust-lang/crates.io-index",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/clipboard_x11@0.4.3",
+          "referenceType": "purl"
+        }
+      ],
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "clipboard_x11",
+      "versionInfo": "0.4.3"
     }
   ],
   "relationships": [
     {
-      "relatedSpdxElement": "SPDXRef-File-nec_parser",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--report-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--project-0.2.0"
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
     },
     {
-      "relatedSpdxElement": "SPDXRef-File-fnec-gui",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-cli-0.2.0"
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.8.6"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-cli-0.2.0"
+      "spdxElementId": "SPDXRef-Package-rayon-core-1.13.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-tui-0.2.0"
+      "spdxElementId": "SPDXRef-Package-futures-channel-0.3.32"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--accel-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-bumpalo-3.20.2",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--solver-0.2.0"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120"
     },
     {
-      "relatedSpdxElement": "SPDXRef-File-fnec-tui",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-linux-raw-sys-0.9.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-gui-0.2.0"
+      "spdxElementId": "SPDXRef-Package-drm-sys-0.8.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec-gui-0.2.0",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-fnec-gui"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
+      "relatedSpdxElement": "SPDXRef-Package-redox--users-0.4.6",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--report-0.2.0"
+      "spdxElementId": "SPDXRef-Package-dirs-sys-0.3.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clipboard--macos-0.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-window--clipboard-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-drm-0.14.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-xcursor-0.3.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-cursor-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-linebreak-0.1.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontdb-0.16.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-lite-2.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasi-0.11.1-plus-wasi-snapshot-preview1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-metadata-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-khronos-egl-6.0.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro-crate-3.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num--enum--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--edit-0.22.27",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml-0.8.23"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-0.51.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasip3-0.4.0-plus-wasi-0.3.0-rc-2026-01-06"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ahash-0.8.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-symbols-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-siphasher-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--shared-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-sys-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-allocator-0.25.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-signal-hook-registry-1.4.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-utils-0.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-io-surface-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-macro-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bit-set-0.5.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-io-surface-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--names-3.0.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-id-arena-2.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-quote-1.0.45"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-executor-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-semver-1.0.28",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-macros-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.70"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-xlib-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11-dl-2.21.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-lite-2.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-core-0.1.36",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-deque-0.8.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-core-1.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-js-sys-0.3.97"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-macros-0.22.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-0.32.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-types-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-link-presentation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-glutin--wgl--sys-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-lite-2.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-executor-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-quick-xml-0.39.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dlib-0.5.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-sys-0.31.11"
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-num-complex-0.4.6"
+      "spdxElementId": "SPDXRef-Package-euclid-0.22.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-approx-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--renderer-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--renderer-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-ffi-0.9.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--futures-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-pin-project-internal-1.1.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-bytemuck--derive-1.10.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-location-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-read-fonts-0.22.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-image-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-nec_parser"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-renderdoc-sys-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-event-listener-5.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-static--assertions-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-metal-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-macros-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--msvc-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--derive-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-lock-3.4.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-metal-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot--core-0.8.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.11.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zeno-0.2.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-swash-0.1.19"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-widestring-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-android--system--properties-0.1.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-misc-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-2.0.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-flate2-1.1.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-png-0.17.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-polling-3.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-bidi-0.3.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-x11rb-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--datetime-0.6.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.22.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-trait-0.1.89",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-parser-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-core-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-csd-frame-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking-2.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-event-listener-5.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-sys-0.31.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clipboard-win-5.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-window--clipboard-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-lru-0.12.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--glyphon-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-symbols-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml-0.8.23",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-fs-2.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cpufeatures-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-glow-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-0.38.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-window--clipboard-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-recursion-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com--macros--support-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-channel-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num--enum--derive-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num--enum-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-gpu-alloc-types-0.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-alloc-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-r-efi-6.0.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-signal-0.2.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--datetime-1.1.1-plus-spec-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc-0.2.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-d3d12-0.19.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--runtime-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--futures-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--runtime-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-errno-0.3.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-0.38.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-simd-adler32-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-miniz--oxide-0.8.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.14.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
     },
     {
       "relatedSpdxElement": "SPDXRef-File-fnec",
@@ -321,99 +7955,2004 @@
       "spdxElementId": "SPDXRef-DOCUMENT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--report-0.2.0",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-nec_report"
+      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-gui-0.4.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xdg-home-1.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-plasma-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand--core-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand--chacha-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-uniform-type-identifiers-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-trait-0.1.89"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-sys-0.59.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-kurbo-0.10.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.14.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crc32fast-1.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-png-0.17.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--project-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crossbeam-epoch-0.9.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-x86--64-pc-windows-gnu-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winapi-0.3.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-foundation-0.9.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-0.23.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-foreign-types-macros-0.2.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-uds--windows-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-window--clipboard-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-client-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-glow-0.13.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-naga-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayvec-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-kurbo-0.10.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cosmic-text-0.12.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--futures-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-malloc--buf-0.0.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc-0.2.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-xid-0.2.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-block2-0.5.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uds--windows-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-orbclient-0.3.54",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-palette-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clipboard--wayland-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-window--clipboard-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-spirv-0.3.0-plus-sdk-1.3.268.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustybuzz-0.14.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-swash-0.1.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fdeflate-0.3.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-png-0.17.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-wlr-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-blocking-1.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-fs-2.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.24",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-proc-macro2-1.0.106"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-xlib-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-1.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-types-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rust-ini-0.18.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--project-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zbus--macros-4.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--report-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--project-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ordered-stream-0.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-epoch-0.9.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crossbeam-deque-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tiny-xlib-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ahash-0.8.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hashbrown-0.14.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ahash-0.7.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hashbrown-0.12.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num--enum-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-descriptor-0.2.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-paste-1.0.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-2.0.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-wlr-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-metal-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-image-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.7.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ash-0.37.3-plus-1.3.251"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-1.0.109"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-gui-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-com--macros--support-0.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com--macros-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-0.38.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-bidi-mirroring-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-io-2.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.70",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-attributes-0.1.31",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-metal-0.27.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnu-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-5.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-lock-3.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-5.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--write-0.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.22.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dtor-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ctor-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--glyphon-0.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-image-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rangemap-1.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ordered-stream-0.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-enumflags2-0.7.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.70",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-naga-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-half-2.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-link-presentation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-user-notifications-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-app-kit-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ahash-0.7.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-xdg-home-1.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-codespan-reporting-0.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--core-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-polling-3.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerocopy-0.8.48",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ahash-0.8.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-khronos-egl-6.0.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec-gui-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-nec_gui"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-scanner-0.31.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slotmap-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontdb-0.16.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-graphics-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-allocator-api2-0.2.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hashbrown-0.14.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-gpu-allocator-0.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-encode-4.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-0.6.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--graphics-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--winit-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--core-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-graphics-types-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-0.23.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fontconfig-parser-0.5.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontdb-0.16.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-cloud-kit-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayvec-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-simd--cesu8-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-macros-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-allocator-0.25.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-channel-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-blocking-1.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-errno-0.3.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerocopy-0.8.48",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ppv-lite86-0.2.21"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnu-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasmparser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xkbcommon-dl-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-gpu-descriptor-0.2.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-glam-0.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ttf-parser-0.20.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontdb-0.16.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-x11rb-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard--x11-0.4.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-polling-3.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nix-0.29.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--macros-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-script-0.5.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-sys-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-sys-0.5.0-plus-25.2.9519653"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-self--cell-1.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking-2.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-tui-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-kurbo-0.10.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-properties-0.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-io-surface-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-graphics-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-com-0.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-read-fonts-0.22.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-skrifa-0.22.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cursor-icon-1.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-web-time-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.4.0",
       "relationshipType": "GENERATED_FROM",
       "spdxElementId": "SPDXRef-File-nec_project"
     },
     {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-phf--generator-0.11.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--macros-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-approx-0.5.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-0.38.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-enumflags2-0.7.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--syscall-0.5.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-metal-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-endi-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-svg--fmt-0.4.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-etagere-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc-sys-0.3.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-0.5.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerocopy-derive-0.8.48",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-0.8.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-context-0.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-0.14.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced-0.13.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-gui-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anyhow-1.0.102",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-sys-0.8.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-foundation-0.9.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-types-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-lock-3.4.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-plasma-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rayon-core-1.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-1.12.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-0.52.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dlv-list-0.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ordered-multimap-0.4.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-impl-2.0.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-2.0.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.32"
+    },
+    {
       "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-cli-0.2.0"
+      "spdxElementId": "SPDXRef-Package-nec--solver-0.4.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--solver-0.2.0"
+      "spdxElementId": "SPDXRef-Package-dispatch2-0.3.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--report-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-futures-lite-2.6.1",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-cli-0.2.0"
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--solver-0.2.0"
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
     },
     {
-      "relatedSpdxElement": "SPDXRef-File-nec_model",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.2.0",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-nec_parser"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-File-nec_report",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--project-0.2.0"
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.22.27"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.120",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-cli-0.2.0"
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120"
     },
     {
-      "relatedSpdxElement": "SPDXRef-File-nec_accel",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-rustix-0.38.44",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--project-0.2.0"
+      "spdxElementId": "SPDXRef-Package-calloop-0.13.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec-cli-0.2.0",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-fnec"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-wit-component-0.244.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec-cli-0.2.0"
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec-tui-0.2.0",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-fnec-tui"
+      "relatedSpdxElement": "SPDXRef-Package-rayon-1.12.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-async-io-2.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc--exception-0.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc-0.2.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memmap2-0.9.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-gethostname-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-miniz--oxide-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-flate2-1.1.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.17.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand-0.8.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--generator-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand--chacha-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-piper-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-graphics-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-core-0.19.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-client-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-etagere-0.2.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--glyphon-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-percent-encoding-2.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-types-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-1.1.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot-0.12.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zbus--names-3.0.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memoffset-0.9.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nix-0.29.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot-0.12.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-types-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smol--str-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.15.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasmparser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--repr-0.1.20",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand--core-0.6.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand--core-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-channel-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smithay-client-toolkit-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-sys-0.52.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-simd-adler32-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fdeflate-0.3.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-scopeguard-1.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-lock--api-0.4.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rand-0.8.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xkbcommon-dl-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayref-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-path-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winreg-0.10.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-sys-0.31.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasip2-1.0.3-plus-wasi-0.2.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-types-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quick-xml-0.39.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-scanner-0.31.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--core-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-heck-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-core-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-0.22.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-polling-3.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-segmentation-1.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-graphics-types-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-quartz-core-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-sys-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-sys-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-data-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-0.38.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-euclid-0.22.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-guillotiere-0.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-equivalent-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-broadcast-0.7.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-errno-0.3.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-signal-hook-registry-1.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--macros-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-profiling-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--users-0.4.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--parser-1.1.2-plus-spec-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.25.11-plus-spec-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-leb128fmt-0.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-encoder-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-phf-0.11.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fast-srgb8-1.0.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-glow-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-cloud-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-spirv-0.3.0-plus-sdk-1.3.268.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--repr-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-1.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--syscall-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-0.19.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anyhow-1.0.102",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-window--clipboard-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-downcast-rs-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-backend-0.3.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--macros-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-static--assertions-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--names-3.0.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-clipboard-0.7.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memmap2-0.9.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-channel-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cosmic-text-0.12.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-strict-num-0.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-path-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com--macros-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-location-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-polling-3.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num--enum--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-polling-3.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-0.9.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-half-2.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-wayland-source-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-polling-3.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.14.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memoffset-0.9.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uds--windows-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-wayland-source-0.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-plasma-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dispatch2-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-foundation-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crc32fast-1.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-flate2-1.1.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zerocopy-0.8.48",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-half-2.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ppv-lite86-0.2.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rand--chacha-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayvec-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libloading-0.7.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.59.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xdg-home-1.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-0.32.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-channel-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sha1-0.10.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot--core-0.9.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.12.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zvariant-4.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--widget-0.13.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-cursor-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-recursion-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-piper-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-blocking-1.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-graphics-types-0.1.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smithay-client-toolkit-0.20.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-clipboard-0.7.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-macro-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winreg-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-recursion-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-0.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-scanner-0.31.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-executor-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-sys-0.5.0-plus-25.2.9519653",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-gpu-descriptor-types-0.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-descriptor-0.2.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-xkeysym-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--users-0.4.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sys-locale-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-io-surface-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--graphics-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-graphics-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nix-0.29.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-sys-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dpi-0.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-sys-0.31.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hermit-abi-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-polling-3.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-termcolor-1.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--accel-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--macros-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libredox-0.1.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--users-0.4.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--macros-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.14.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dark-light-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-misc-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.2.17"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-misc-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-uniform-type-identifiers-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
       "relationshipType": "GENERATED_FROM",
       "spdxElementId": "SPDXRef-File-nec_model"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.2.0",
-      "relationshipType": "GENERATED_FROM",
-      "spdxElementId": "SPDXRef-File-nec_solver"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-File-nec_project",
-      "relationshipType": "DESCRIBES",
-      "spdxElementId": "SPDXRef-DOCUMENT"
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.4.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.27.0"
     },
     {
       "relatedSpdxElement": "SPDXRef-File-nec_solver",
@@ -421,24 +9960,3279 @@
       "spdxElementId": "SPDXRef-DOCUMENT"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-rust-ini-0.18.0",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--parser-0.2.0"
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--parser-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--project-0.2.0"
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
       "relationshipType": "DEPENDS_ON",
-      "spdxElementId": "SPDXRef-Package-nec--report-0.2.0"
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-misc-0.3.12"
     },
     {
-      "relatedSpdxElement": "SPDXRef-Package-nec--accel-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-web-sys-0.3.97"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sha1-0.10.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-2.0.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anyhow-1.0.102",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-core-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-cloud-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-plain-0.2.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ab--glyph--rasterizer-0.1.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ab--glyph-0.2.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-xkeysym-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-foreign-types-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--report-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasmparser-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hexf-parse-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-contacts-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ordered-multimap-0.4.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rust-ini-0.18.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasmparser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dconf--rs-0.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--graphics-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--renderer-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-enumflags2--derive-0.7.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dispatch2-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-graphics-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--graphics-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-com--macros-0.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--utils-2.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-drm-sys-0.8.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-ffi-0.9.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-foreign-types-macros-0.2.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-foreign-types-0.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-misc-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-gui-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-js-sys-0.3.97"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-wlr-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-strategy-0.5.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-channel-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-hal-0.19.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-lite-2.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-instant-0.1.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-khronos-egl-6.0.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-drm-fourcc-2.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-sys-macros-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-util-0.1.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-termcolor-1.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--solver-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-as-raw-xcb-connection-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--spanned-0.6.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.22.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--i686--gnullvm-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--renderer-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--json-1.0.149",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-sys-0.61.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-gpu-alloc-0.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayvec-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-xid-0.2.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.70",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libloading-0.8.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-signal-hook-registry-1.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gethostname-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-misc-0.3.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-task-4.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-blocking-1.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-lite-2.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-blocking-1.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-static--assertions-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dirs-sys-0.3.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dirs-4.0.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-uniform-type-identifiers-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-io-2.6.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-wlr-0.3.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num--enum--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-foundation-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dirs-sys-0.3.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bit-vec-0.6.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-bit-set-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--runtime-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anyhow-1.0.102",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dlib-0.5.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-phf--macros-0.11.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-core-0.1.36"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-blocking-1.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-client-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smithay-clipboard-0.7.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard--wayland-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-xkbcommon-dl-0.4.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-enumflags2--derive-0.7.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-enumflags2-0.7.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustversion-1.0.22",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num--enum-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cosmic-text-0.12.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--glyphon-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-0.19.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--glyphon-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec-gui-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-fnec-gui"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.24",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-2.0.117"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-semver-1.0.28",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasmparser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-attributes-0.1.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-phf--shared-0.11.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--generator-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard--macos-0.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasmparser-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--report-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-executor-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-either-1.15.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rayon-1.12.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-lite-2.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-encoder-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-prettyplease-0.2.37"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-plasma-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-sys-macros-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-prettyplease-0.2.37",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crypto-common-0.1.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-digest-0.10.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crossbeam-deque-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.5.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-blocking-1.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-link-presentation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-x11rb-protocol-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hassle-rs-0.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-piper-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-path-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.14.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-descriptor-0.2.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-d3d12-0.19.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-0.57.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasip2-1.0.3-plus-wasi-0.2.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--wgpu-0.13.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--renderer-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.70",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-prettyplease-0.2.37"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-instant-0.1.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.11.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-targets-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-core-0.52.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-1.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--syscall-0.2.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-5.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crc32fast-1.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ahash-0.8.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-lock-3.4.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-fs-2.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smol--str-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-contacts-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-location-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-enumflags2-0.7.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-roxmltree-0.20.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontconfig-parser-0.5.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nix-0.29.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winit-0.30.13",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-foreign-types-macros-0.2.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--utils-2.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-strategy-0.5.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-lock-3.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-combine-4.6.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-nec_project",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-png-0.17.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-1.0.109",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com--macros--support-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tempfile-3.27.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-uds--windows-1.2.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zvariant--utils-2.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--derive-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--accel-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--solver-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.14.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tinyvec--macros-0.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tinyvec-1.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-hal-0.19.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--core-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--futures-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-backend-0.3.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayref-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-combine-4.6.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-attributes-0.1.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--utils-2.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.22.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-location-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--gnullvm-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-errno-0.3.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sctk-adwaita-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ordered-stream-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-data-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-executor-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-csd-frame-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libloading-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-contacts-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-user-notifications-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-0.38.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block-buffer-0.10.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-digest-0.10.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xkbcommon-dl-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num-complex-0.4.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-foreign-types-shared-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-foreign-types-0.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smol--str-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crunchy-0.2.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-half-2.7.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-metal-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hex-0.4.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-task-4.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-instant-0.1.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-io-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--project-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-gui-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-user-notifications-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-enumflags2--derive-0.7.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bit-vec-0.6.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-plasma-0.3.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tiny-skia-0.11.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sctk-adwaita-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-task-4.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-executor-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-core-0.51.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-broadcast-0.7.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-d3d12-0.19.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libloading-0.7.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bit-set-0.5.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-detect-desktop-environment-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-cloud-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tinyvec-1.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontdb-0.16.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memmap2-0.9.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-fontdb-0.16.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-1.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-0.23.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-i686-pc-windows-gnu-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winapi-0.3.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zbus-4.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--project-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-channel-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-arrayvec-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-orbclient-0.3.54"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hashbrown-0.12.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ordered-multimap-0.4.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zmij-1.0.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-wlr-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zvariant--utils-2.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--macros-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.25.11-plus-spec-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-ui-kit-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-fnec-gui",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-clipboard--x11-0.4.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-window--clipboard-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-futures-0.4.70",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--futures-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-contacts-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-data-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anyhow-1.0.102",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tiny-skia-path-0.11.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winnow-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.25.11-plus-spec-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-segmentation-1.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec-cli-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-fnec"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-0.38.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-owned--ttf--parser-0.25.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ab--glyph-0.2.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--datetime-1.1.1-plus-spec-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.25.11-plus-spec-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-alloc-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-xkeysym-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xkbcommon-dl-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--aarch64--msvc-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-location-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-cloud-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-broadcast-0.7.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-5.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-broadcast-0.7.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasmparser-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-encoder-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--graphics-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--futures-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-csd-frame-0.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--futures-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zerocopy-derive-0.8.48"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-metal-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--msvc-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-errno-0.3.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zvariant--derive-4.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-2.0.117"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-js-sys-0.3.97"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-euclid-0.22.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-etagere-0.2.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-alloc-types-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-0.32.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-script-0.5.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot-0.12.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--derive-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-skrifa-0.22.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-swash-0.1.19"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-segmentation-1.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-quartz-core-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-macro-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-nec_parser",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-android-activity-0.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.24",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-shared-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-uniform-type-identifiers-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-nec_model",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--futures-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-metadata-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-core-0.51.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-core-0.52.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-0.52.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows--x86--64--gnullvm-0.52.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-windows-targets-0.52.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-client-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winnow-0.7.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-encode-4.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-0.5.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.52.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-malloc--buf-0.0.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-bytemuck--derive-1.10.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-miniz--oxide-0.8.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-png-0.17.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-error-code-3.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard-win-5.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml-0.8.23",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--project-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasip2-1.0.3-plus-wasi-0.2.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sys-locale-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-graphics-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-channel-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com--macros--support-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rayon-1.12.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-nec_accel",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-wlr-0.3.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-x11-dl-2.21.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fontdb-0.16.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-0.9.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-types-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nix-0.29.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-digest-0.10.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sha1-0.10.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-static--assertions-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--core-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--runtime-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-shared-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--derive-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-parser-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-concurrent-queue-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-event-listener-5.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--core-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-timer-0.2.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--futures-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-util-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-descriptor-types-0.1.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--project-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-polling-3.11.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ahash-0.7.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-phf--shared-0.11.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-0.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck--derive-1.10.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-bytemuck-1.25.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-termcolor-1.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-codespan-reporting-0.11.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-2.0.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard--x11-0.4.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-softbuffer-0.4.8",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--macros-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-pin-project-internal-1.1.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-data-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winnow-0.7.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--edit-0.22.27"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tracing-0.1.44",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-foldhash-0.1.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-hashbrown-0.15.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-guillotiere-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ctor-0.10.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-xlib-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-metadata-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-image-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-anyhow-1.0.102",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-metadata-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-cli-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-impl-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-1.0.69"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-segmentation-1.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-internal-1.1.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-pin-project-1.1.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasip3-0.4.0-plus-wasi-0.3.0-rc-2026-01-06",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-by--address-1.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro-crate-3.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--macros-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-futures-0.4.70"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde--spanned-0.6.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml-0.8.23"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-enumflags2--derive-0.7.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-link-presentation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking-2.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-lite-2.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ttf-parser-0.21.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dirs-4.0.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-atomic-waker-1.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-piper-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cursor-icon-1.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-csd-frame-0.3.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-as-raw-xcb-connection-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-xlib-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--accel-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-hassle-rs-0.11.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-data-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-profiling-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-2.0.117"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ab--glyph-0.2.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sctk-adwaita-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-tiny-skia-0.11.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-trait-0.1.89"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ccc-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-sys-0.31.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-backend-0.3.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasmparser-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-metadata-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tiny-skia-0.11.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-2.0.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--tiny--skia-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-foundation-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ash-0.37.3-plus-1.3.251",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-generic-array-0.14.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-block-buffer-0.10.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libredox-0.1.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-orbclient-0.3.54"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-io-2.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-time-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-js-sys-0.3.97"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-palette--derive-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-palette-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-as-raw-xcb-connection-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11rb-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-width-0.1.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-codespan-reporting-0.11.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-cursor-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.8.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-font-types-0.7.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-read-fonts-0.22.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-adler2-2.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-miniz--oxide-0.8.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--spanned-0.6.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-glow-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc-0.2.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard--macos-0.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--derive-1.0.228"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-scoped-tls-1.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-backend-0.3.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.5.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-data-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-image-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-app-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-getrandom-0.3.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ahash-0.8.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-encoder-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-metadata-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-indexmap-2.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smithay-client-toolkit-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sctk-adwaita-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-fnec-tui",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-executor-1.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--renderer-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-nec_report",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-x11rb-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-indexmap-2.14.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--runtime-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-0.32.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-web-sys-0.3.97"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-2.1.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--glyphon-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-itoa-1.0.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--json-1.0.149"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-foreign-types-macros-0.2.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-combine-4.6.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-user-notifications-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slotmap-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-glow-0.13.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cpufeatures-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sha1-0.10.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num--enum-0.7.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-lock-3.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--futures-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-lite-2.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-macro-support-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-attributes-0.1.31"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--report-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-typenum-1.20.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crypto-common-0.1.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.52.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-graphics-0.23.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytes-1.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--core-0.13.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-crossbeam-utils-0.8.21",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-concurrent-queue-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-complex-0.4.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec-gui-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android--system--properties-0.1.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-heck-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-backend-0.3.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-wlr-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memmap2-0.9.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-macros-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-task-4.7.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-process-2.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-core-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-sys-macros-0.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-sys-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-naga-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-bindgen-rust-0.51.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-cloud-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-core-foundation-0.9.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-0.23.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wasm-bindgen-0.2.120",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-web-time-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cursor-icon-1.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-x11-dl-2.21.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc-0.2.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dark-light-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--datetime-0.6.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-executor-1.14.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-profiling-1.0.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-lock--api-0.4.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.12.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-simd--cesu8-1.1.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-jni-0.22.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--model-0.4.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-nec--parser-0.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-link-0.2.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gethostname-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro-crate-3.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--derive-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--runtime-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--widget-0.13.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-sys-0.6.0-plus-11769913",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-glam-0.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--wgpu-0.13.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-2.0.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-cursor-0.31.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-pin-project-lite-0.2.17",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-event-listener-strategy-0.5.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-clipboard-0.7.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-1.0.109"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-sink-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-util-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-scanner-0.31.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ahash-0.8.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-skrifa-0.22.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-foundation-0.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cfg-if-1.0.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libloading-0.8.9"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-smallvec-1.15.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-lite-2.6.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-fs-2.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memchr-2.8.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winnow-1.0.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.59.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-0.38.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-phf--shared-0.11.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-phf--macros-0.11.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-presser-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-allocator-0.25.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-symbols-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-once--cell-1.21.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-bindgen-0.2.120"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-r-efi-5.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.3.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-5.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-event-listener-strategy-0.5.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml-0.8.23"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-core-location-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-user-notifications-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-lock--api-0.4.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot-0.11.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--edit-0.25.11-plus-spec-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-proc-macro-crate-3.5.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.7.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-libredox-0.1.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ttf-parser-0.21.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-cosmic-text-0.12.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-num--enum--derive-0.7.6"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-csd-frame-0.3.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-File-nec_gui",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-yazi-0.1.6",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-swash-0.1.19"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-redox--syscall-0.7.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-pin-project-internal-1.1.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dispatch2-0.3.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-image-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winnow-1.0.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml--parser-1.1.2-plus-spec-1.1.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dispatch-0.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-foundation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-quartz-core-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-ui-kit-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-parking--lot-0.11.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wasm-timer-0.2.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-android-properties-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-slab-0.4.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-signal-0.2.14"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-trait-0.1.89"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-web-time-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memmap2-0.9.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-process-2.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustix-1.1.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-backend-0.3.15"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-toml--datetime-0.6.11",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-toml-0.8.23"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-rustc-hash-1.1.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-metal-0.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-typenum-1.20.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-generic-array-0.14.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tracing-0.1.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-bytemuck--derive-1.10.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-cursor-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-prettyplease-0.2.37",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-event-listener-strategy-0.5.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-broadcast-0.7.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-winapi-0.3.9",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-dirs-sys-0.3.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-sctk-adwaita-0.10.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libm-0.2.16",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustybuzz-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-generic-array-0.14.7",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-crypto-common-0.1.7"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-foundation-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-user-notifications-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-sys-0.8.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-jni-sys-0.3.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-sys-0.6.0-plus-11769913"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-thiserror-1.0.69",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-allocator-0.25.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wit-parser-0.244.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wgpu-types-0.19.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--accel-0.4.0",
       "relationshipType": "GENERATED_FROM",
       "spdxElementId": "SPDXRef-File-nec_accel"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--repr-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-fastrand-2.4.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-tempfile-3.27.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-serde-1.0.228",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wit-component-0.244.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-raw-window-handle-0.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-1.0.109",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-com--macros-0.6.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ttf-parser-0.25.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-owned--ttf--parser-0.25.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-serde--repr-0.1.20"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-0.32.12",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-plasma-0.3.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--solver-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-nec_solver"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-dlib-0.5.3",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-xkbcommon-dl-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-syn-2.0.117",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-async-recursion-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-memmap2-0.9.10",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-sctk-adwaita-0.10.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-redox--syscall-0.5.18",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-parking--lot--core-0.9.12"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-1.3.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-png-0.17.16"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-0.52.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-gpu-allocator-0.25.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-num-traits-0.2.19",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-naga-0.19.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-futures-task-0.3.32",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-futures-executor-0.3.32"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-0.9.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-android-activity-0.6.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-drm-ffi-0.9.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-drm-0.14.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--tiny--skia-0.13.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--renderer-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-block2-0.5.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-core-location-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-windows-sys-0.61.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winapi-util-0.1.11"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-calloop-0.14.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-async-lock-3.4.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-zvariant-4.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus--names-3.0.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-simdutf8-0.1.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-simd--cesu8-1.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-getrandom-0.4.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-svg--fmt-0.4.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-guillotiere-0.6.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-memmap2-0.9.10"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-linux-raw-sys-0.12.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-1.1.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-proc-macro2-1.0.106",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zvariant--derive-4.2.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-js-sys-0.3.97",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-unicode-ident-1.0.24",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-syn-1.0.109"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-app-kit-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-clipboard--macos-0.1.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bytemuck-1.25.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-font-types-0.7.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-range-alloc-0.1.5",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-hal-0.19.5"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-iced--runtime-0.13.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-iced--winit-0.13.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-smithay-client-toolkit-0.20.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ndk-sys-0.6.0-plus-11769913",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-ndk-0.9.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-quote-1.0.45",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-thiserror-impl-2.0.18"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-linux-raw-sys-0.4.15",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-rustix-0.38.44"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-foreign-types-0.5.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-0.23.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec--report-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-nec_report"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-app-kit-0.2.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-link-presentation-0.2.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wayland-protocols-experimental-20250721.0.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-nec-tui-0.4.0",
+      "relationshipType": "GENERATED_FROM",
+      "spdxElementId": "SPDXRef-File-fnec-tui"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-bitflags-2.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-d3d12-0.19.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-log-0.4.29",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-libc-0.2.186",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-core-graphics-types-0.1.3"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-calloop-wayland-source-0.4.1"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-blocking-1.6.2",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-zbus-4.4.0"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-wayland-client-0.31.14",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-softbuffer-0.4.8"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-objc2-0.6.4",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-objc2-quartz-core-0.3.2"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-codespan-reporting-0.11.1",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-wgpu-core-0.19.4"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-cursor-icon-1.2.0",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-winit-0.30.13"
     }
   ],
   "spdxVersion": "SPDX-2.3"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ last_updated: 2026-05-02
 
 All notable documentation process changes are recorded here.
 
-## [0.3.0] — 2026-05-02
+## [0.4.0] — 2026-05-02
 ### Added
 
 - **PH3-CHK-012 (Phase 3 usability benchmark)**: Authored `docs/usability-benchmark-ph3.md` satisfying all three Phase 3 usability acceptance minima. Benchmark 1 records the 5-point frequency sweep from a blank `fnec-gui` project in exactly **7 explicit actions** with a step-by-step table. Benchmark 2 records an edit-run-inspect workflow comparison against xnec2c: fnec-gui completes in 4 steps (~15 s) vs. xnec2c's 5 steps (~22 s). The document includes the acceptance-minima checklist with all items ticked.

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -2,10 +2,50 @@
 project: fnec-rust
 doc: docs/releasenotes.md
 status: living
-last_updated: 2026-05-01
+last_updated: 2026-05-02
 ---
 
 # Release Notes
+
+## 0.4.0 — Phase 3 complete
+
+### GUI
+
+- **`fnec-gui` desktop application** (iced 0.13): dark-themed window with deck path field and four-tab layout: Solve, Sweep, Pattern, and Currents.
+- **Solve tab**: one-click single-frequency Hallen solve; displays frequency, Z_re, Z_im, and |Z|.
+- **Sweep tab**: frequency range input (Start / End / Step MHz), Run Sweep button, sortable four-column result table (Freq, Z_re, Z_im, |Z|). Column headers are clickable sort toggles.
+- **Pattern tab**: elevation-plane radiation pattern slice (37 points, 0–180° θ in 5° steps at a user-chosen φ angle) rendered as a text bar chart normalised to the peak gain.
+- **Currents tab**: per-segment current magnitude distribution bar chart for the loaded deck. Peak segment gets a full-width bar; bars are normalised 0–1.
+- Headless state-machine architecture: all GUI logic lives in `app_state.rs` (no iced dependency), tested by 47 smoke tests.
+
+### CLI
+
+- **`--sweep-config <file.toml>`**: batch frequency sweep from a TOML spec (linear range or explicit point list); one structured output block per frequency point.
+- **`--vars <file>`**: variable-substitution engine (`$VAR` tokens in NEC deck templates replaced from a flat TOML/JSON map at parse time).
+- **`fnec sweep --resonance <file.nec.toml>`**: binary-search resonance targeting; finds the wire length that minimises feedpoint reactance within user-defined bounds.
+
+### Project file
+
+- **`nec_project` crate**: versioned TOML project format (`ProjectFile`, `SolverConfig`, `NamedRun`) with serde round-trip and version-guard (`UnsupportedVersion`).
+- **Run history**: `RunHistory` / `RunRecord` / `ResultSummary` appended on each solve; queryable by count, last-run, and index.
+
+### Solver
+
+- GN type 0 finite-ground model active in Hallen impedance assembly (Fresnel-style complex image scaling from EPSE/SIG).
+- Non-collinear multi-wire Hallen support: junction detection (KCL rows), per-wire local cos(k·s) homogeneous vectors, passive-wire rhs=0.
+- EX type 1/4/5 first implementation slice in pulse-solver mode.
+- EX type 2 staged portability fallback (warning; treated as EX type 0).
+- PT and NT cards parsed with staged portability warnings.
+- TL `NSEG>1` lossless-line acceptance.
+- GN2 near-ground corpus contract added and passing.
+
+### Documentation
+
+- `docs/contributing.md` — build/test workflow, branch conventions, corpus-gate requirements.
+- `docs/plugin-api-design.md` — extension surface, safety model, EP-1 `DeckPostProcessor`, EP-2 `ResultFilter`.
+- `docs/project-format.md` — TOML project file format reference.
+- `docs/usability-benchmark-ph3.md` — Phase 3 usability benchmarks: 7-action 5-point sweep, edit-run-inspect comparison vs. xnec2c.
+- All Phase 3 usability acceptance minima satisfied.
 
 ## 0.2.0
 

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/sbom.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-05-02
 ---
 
 # SBOM


### PR DESCRIPTION
## Summary

Phase 3 (all 12 PH3-CHK items) is complete. This PR bumps the workspace version from 0.3.0 → 0.4.0 per the version bump process in `docs/steering.md`.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | `version` → `"0.4.0"` |
| `README.md` | Version badge updated to 0.4.0 |
| `docs/changelog.md` | `[0.3.0]` section renamed to `[0.4.0] — 2026-05-02` |
| `docs/releasenotes.md` | New `## 0.4.0 — Phase 3 complete` section: GUI (4 tabs), CLI (sweep-config, vars, resonance), project file, solver improvements, docs |
| `docs/sbom.md` | `last_updated` date updated |
| `SBOM.spdx.json` | Regenerated (`cargo sbom --output-format spdx_json_2_3`) |

## 0.4.0 highlights

- **`fnec-gui`**: four-tab desktop GUI (Solve, Sweep, Pattern, Currents) with 47 headless smoke tests
- **CLI**: `--sweep-config`, `--vars` (template substitution), `--resonance` binary-search targeting
- **`nec_project`**: versioned TOML project format with run history API
- **Solver**: GN0 finite-ground, non-collinear multi-wire Hallen, EX 1/4/5 pulse slices, GN2 near-ground corpus
- **Docs**: `contributing.md`, `plugin-api-design.md`, `project-format.md`, `usability-benchmark-ph3.md`

All Phase 3 usability acceptance minima satisfied.