### PR TITLE
feat(gui): add vars-file support for $VAR template decks

### DIFF
--- a/apps/nec-gui/Cargo.toml
+++ b/apps/nec-gui/Cargo.toml
@@ -24,4 +24,5 @@ nec_parser  = { workspace = true }
 nec_solver  = { workspace = true }
 nec_project = { workspace = true }
 num-complex = { workspace = true }
+toml        = { workspace = true }
 iced        = "0.13"

--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -72,6 +72,9 @@ pub enum CurrentsPhase {
 pub struct AppState {
     /// Path to the NEC deck file as entered by the user.
     pub deck_path: String,
+    /// Optional path to a `.toml` or `.json` variable-substitution file.
+    /// When non-empty, `$VAR` tokens in the deck are substituted before parsing.
+    pub vars_path: String,
     /// Current active tab.
     pub active_tab: ActiveTab,
     /// Single-frequency solver phase.
@@ -103,6 +106,7 @@ impl Default for AppState {
     fn default() -> Self {
         Self {
             deck_path: String::new(),
+            vars_path: String::new(),
             active_tab: ActiveTab::default(),
             phase: SolvePhase::default(),
             sweep_start: "14.0".into(),
@@ -134,6 +138,8 @@ pub enum Message {
     // ── Global ────────────────────────────────────────────────────────────
     /// User typed a new deck path.
     DeckPathChanged(String),
+    /// User typed a new vars file path.
+    VarsPathChanged(String),
     /// User switched tabs.
     TabSelected(ActiveTab),
     // ── Single-frequency tab ──────────────────────────────────────────────
@@ -179,6 +185,9 @@ impl AppState {
                 if matches!(self.phase, SolvePhase::Failed(_)) {
                     self.phase = SolvePhase::Idle;
                 }
+            }
+            Message::VarsPathChanged(p) => {
+                self.vars_path = p.clone();
             }
             Message::TabSelected(tab) => {
                 self.active_tab = tab.clone();

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -41,8 +41,13 @@ impl FnecGui {
 
         if spawn_solve {
             let path = PathBuf::from(self.state.deck_path.clone());
+            let vars: Option<String> = if self.state.vars_path.is_empty() {
+                None
+            } else {
+                Some(self.state.vars_path.clone())
+            };
             Task::perform(
-                async move { solve_deck_path(&path) },
+                async move { solve_deck_path(&path, vars.as_deref()) },
                 Message::SolveComplete,
             )
         } else if spawn_sweep {
@@ -51,8 +56,13 @@ impl FnecGui {
             match self.state.sweep_params() {
                 Ok((start, end, step)) => {
                     let path = PathBuf::from(self.state.deck_path.clone());
+                    let vars: Option<String> = if self.state.vars_path.is_empty() {
+                        None
+                    } else {
+                        Some(self.state.vars_path.clone())
+                    };
                     Task::perform(
-                        async move { sweep_deck_path(&path, start, end, step) },
+                        async move { sweep_deck_path(&path, vars.as_deref(), start, end, step) },
                         Message::SweepComplete,
                     )
                 }
@@ -66,8 +76,13 @@ impl FnecGui {
             match self.state.pattern_phi() {
                 Ok(phi_deg) => {
                     let path = PathBuf::from(self.state.deck_path.clone());
+                    let vars: Option<String> = if self.state.vars_path.is_empty() {
+                        None
+                    } else {
+                        Some(self.state.vars_path.clone())
+                    };
                     Task::perform(
-                        async move { pattern_slice_deck_path(&path, phi_deg) },
+                        async move { pattern_slice_deck_path(&path, vars.as_deref(), phi_deg) },
                         Message::PatternComplete,
                     )
                 }
@@ -78,8 +93,13 @@ impl FnecGui {
             }
         } else if spawn_currents {
             let path = PathBuf::from(self.state.deck_path.clone());
+            let vars: Option<String> = if self.state.vars_path.is_empty() {
+                None
+            } else {
+                Some(self.state.vars_path.clone())
+            };
             Task::perform(
-                async move { current_distribution_deck_path(&path) },
+                async move { current_distribution_deck_path(&path, vars.as_deref()) },
                 Message::CurrentsComplete,
             )
         } else {
@@ -121,6 +141,19 @@ impl FnecGui {
         .spacing(8)
         .align_y(iced::Alignment::Center);
 
+        // ── Optional variable-substitution file row ──────────────────────
+        let vars_row = row![
+            text("Vars file:").width(Length::Fixed(80.0)),
+            text_input(
+                "Optional: path to .toml or .json vars file (for $VAR decks)…",
+                &self.state.vars_path,
+            )
+            .on_input(Message::VarsPathChanged)
+            .width(Length::Fill),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
         // ── Active tab content ───────────────────────────────────────────
         let tab_content: Element<Message> = match self.state.active_tab {
             ActiveTab::Solve => self.solve_view(),
@@ -129,7 +162,7 @@ impl FnecGui {
             ActiveTab::Currents => self.currents_view(),
         };
 
-        let content = column![tab_bar, path_row, tab_content]
+        let content = column![tab_bar, path_row, vars_row, tab_content]
             .spacing(12)
             .padding(20);
 

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -4,6 +4,7 @@
 //! Single-frequency Hallen solve — thin wrapper around `nec_solver` for use
 //! by the GUI.  Returns the first feedpoint impedance found in the deck.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use nec_model::card::Card;
@@ -14,6 +15,92 @@ use nec_solver::{
     solve_hallen, wire_endpoints_from_segs, FarFieldPoint,
 };
 use num_complex::Complex64;
+
+// ---------------------------------------------------------------------------
+// Variable-substitution helper
+// ---------------------------------------------------------------------------
+
+/// Load a flat string-to-string variable map from a `.toml` or `.json` file.
+///
+/// Accepts TOML (default) or JSON (detected by `.json` extension) flat
+/// key-value maps.  Integer and float values are accepted and converted to
+/// strings.  Returns `Err` with a human-readable message on any failure.
+fn load_vars(path: &Path) -> Result<HashMap<String, String>, String> {
+    let src = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read vars file '{}': {e}", path.display()))?;
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    if ext == "json" {
+        // Minimal flat-JSON-object parser (avoids serde_json in deps).
+        let s = src.trim();
+        if !s.starts_with('{') || !s.ends_with('}') {
+            return Err(format!(
+                "'{}': JSON vars file must be a top-level object",
+                path.display()
+            ));
+        }
+        let inner = s[1..s.len() - 1].trim();
+        let mut map = HashMap::new();
+        if inner.is_empty() {
+            return Ok(map);
+        }
+        // Naive split on top-level commas (no nested objects supported).
+        for raw_pair in inner.split(',') {
+            let pair = raw_pair.trim();
+            if pair.is_empty() {
+                continue;
+            }
+            let colon = pair
+                .find(':')
+                .ok_or_else(|| format!("'{}': malformed JSON pair: {pair}", path.display()))?;
+            let raw_key = pair[..colon].trim().trim_matches('"');
+            let raw_val = pair[colon + 1..].trim().trim_matches('"');
+            map.insert(raw_key.to_string(), raw_val.to_string());
+        }
+        Ok(map)
+    } else {
+        let table: toml::Table = toml::from_str(&src)
+            .map_err(|e| format!("'{}': TOML parse error: {e}", path.display()))?;
+        let mut map = HashMap::new();
+        for (k, v) in table {
+            match v {
+                toml::Value::String(s) => {
+                    map.insert(k, s);
+                }
+                toml::Value::Integer(i) => {
+                    map.insert(k, i.to_string());
+                }
+                toml::Value::Float(f) => {
+                    map.insert(k, format!("{f}"));
+                }
+                other => {
+                    return Err(format!(
+                        "'{}': variable '{k}' has unsupported type {} — use strings or numbers",
+                        path.display(),
+                        other.type_str()
+                    ));
+                }
+            }
+        }
+        Ok(map)
+    }
+}
+
+/// Apply variable substitution to `input` if `vars_path` is provided.
+/// Returns the (possibly substituted) string or an error.
+fn apply_vars(input: &str, vars_path: Option<&str>) -> Result<String, String> {
+    if let Some(vp) = vars_path {
+        let vars = load_vars(Path::new(vp))?;
+        nec_parser::template::substitute(input, &vars).map_err(|e| e.to_string())
+    } else {
+        Ok(input.to_owned())
+    }
+}
 
 /// Result of a successful single-frequency solve.
 #[derive(Debug, Clone, PartialEq)]
@@ -37,11 +124,15 @@ pub struct SweepPoint {
 /// Run a Hallen solve on the NEC deck at `path` and return the feedpoint
 /// impedance at the first frequency found in the `FR` card.
 ///
+/// If `vars_path` is `Some(path)`, the file is loaded as a variable map and
+/// `$VAR` tokens in the deck are substituted before parsing.
+///
 /// Returns `Err` with a human-readable message if the file cannot be read,
 /// parsed, or solved.
-pub fn solve_deck_path(path: &Path) -> Result<SolveResult, String> {
+pub fn solve_deck_path(path: &Path, vars_path: Option<&str>) -> Result<SolveResult, String> {
     let input = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
     solve_deck_str(&input)
 }
 
@@ -139,14 +230,17 @@ fn feedpoint_impedance(
 ///
 /// `start_mhz`, `end_mhz`, `step_mhz` define the linear sweep.  The geometry
 /// and excitation vector are built once and reused for every frequency point.
+/// If `vars_path` is `Some(path)`, `$VAR` tokens are substituted before parsing.
 pub fn sweep_deck_path(
     path: &std::path::Path,
+    vars_path: Option<&str>,
     start_mhz: f64,
     end_mhz: f64,
     step_mhz: f64,
 ) -> Result<Vec<SweepPoint>, String> {
     let input = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
     sweep_deck_str(&input, start_mhz, end_mhz, step_mhz)
 }
 
@@ -242,9 +336,15 @@ pub struct PatternPoint {
 ///
 /// `phi_deg` selects the azimuth plane.  θ is sampled in 5° steps from 0° to
 /// 180° (37 points), giving a full elevation cut.
-pub fn pattern_slice_deck_path(path: &Path, phi_deg: f64) -> Result<Vec<PatternPoint>, String> {
+/// If `vars_path` is `Some(path)`, `$VAR` tokens are substituted before parsing.
+pub fn pattern_slice_deck_path(
+    path: &Path,
+    vars_path: Option<&str>,
+    phi_deg: f64,
+) -> Result<Vec<PatternPoint>, String> {
     let input = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
     pattern_slice_deck_str(&input, phi_deg)
 }
 
@@ -288,9 +388,14 @@ pub struct CurrentPoint {
 }
 
 /// Compute the per-segment current distribution from the deck at `path`.
-pub fn current_distribution_deck_path(path: &Path) -> Result<Vec<CurrentPoint>, String> {
+/// If `vars_path` is `Some(path)`, `$VAR` tokens are substituted before parsing.
+pub fn current_distribution_deck_path(
+    path: &Path,
+    vars_path: Option<&str>,
+) -> Result<Vec<CurrentPoint>, String> {
     let input = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
     current_distribution_deck_str(&input)
 }
 

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -171,7 +171,7 @@ fn solve_corpus_dipole_freesp() {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
 
-    let result = solve_deck_path(&deck_path)
+    let result = solve_deck_path(&deck_path, None)
         .unwrap_or_else(|e| panic!("solve failed for corpus dipole: {e}"));
 
     // Reference impedance: Z ≈ 73 + j42 Ω (Hallen, 14.2 MHz).
@@ -187,9 +187,10 @@ fn solve_corpus_dipole_freesp() {
 /// solve_deck_path returns Err for a non-existent file.
 #[test]
 fn solve_deck_path_nonexistent_file_returns_err() {
-    let result = solve_deck_path(std::path::Path::new(
-        "/tmp/does-not-exist-fnec-gui-test.nec",
-    ));
+    let result = solve_deck_path(
+        std::path::Path::new("/tmp/does-not-exist-fnec-gui-test.nec"),
+        None,
+    );
     assert!(result.is_err(), "expected Err for nonexistent file");
     let msg = result.unwrap_err();
     assert!(


### PR DESCRIPTION
## Problem

Opening a template deck like `corpus/variable-dipole.nec` in the GUI produced:
```
Error: line 11: GW field 5: Cannot parse '-$HALF_LENGTH_M'
```
The GUI had no way to supply a variable-substitution file, so `$VAR` tokens reached the parser raw.

## Changes

- **`AppState`**: add `vars_path: String` field and `VarsPathChanged` message
- **GUI view**: add a 'Vars file' input row (below the deck path row); accepts any `.toml` or `.json` variable-map file
- **`solve.rs`**: add `load_vars()` + `apply_vars()` helpers; update all four `*_deck_path()` signatures to accept `vars_path: Option<&str>`; substitution is applied before parsing
- **`Cargo.toml`**: add `toml` workspace dep
- **`gui_smoke.rs`**: update two call sites for the new signature

## Usage

Set 'Deck file' to `corpus/variable-dipole.nec` and 'Vars file' to `corpus/dipole-vars.toml`, then click Solve.