### PR TITLE
feat: BL-IMPR-001/002 — unwrap audit clean + workspace clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "nec-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "nec_accel",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "nec-gui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "iced",
  "nec_model",
@@ -2138,18 +2138,19 @@ dependencies = [
  "nec_project",
  "nec_solver",
  "num-complex",
+ "toml",
 ]
 
 [[package]]
 name = "nec-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nec_project",
 ]
 
 [[package]]
 name = "nec_accel"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "nec_model",
@@ -2162,18 +2163,18 @@ dependencies = [
 
 [[package]]
 name = "nec_model"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "nec_parser"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nec_model",
 ]
 
 [[package]]
 name = "nec_project"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nec_model",
  "nec_parser",
@@ -2185,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "nec_report"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nec_model",
  "num-complex",
@@ -2193,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "nec_solver"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nec_accel",
  "nec_model",
@@ -2203,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "nec_worker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "nec_model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,24 @@ wgpu = "29"
 serde_json = "1"
 base64 = "0.22"
 sha2 = "0.10"
+
+# ---------------------------------------------------------------------------
+# Workspace-level lint configuration
+# ---------------------------------------------------------------------------
+# All crates opt in via `[lints] workspace = true` in their Cargo.toml.
+# Overrides are documented in the relevant crate's Cargo.toml.
+[workspace.lints.rust]
+unsafe_code   = "warn"
+unused_imports = "warn"
+
+[workspace.lints.clippy]
+# Pedantic subset we want across the workspace
+cloned_instead_of_copied  = "warn"
+manual_string_new          = "warn"
+redundant_closure_for_method_calls = "warn"
+semicolon_if_nothing_returned = "warn"
+# Lints suppressed workspace-wide (documented reason)
+# needless_range_loop: numerical code in nec_solver uses index arithmetic
+#   intentionally; suppressed file-level in linear.rs / basis.rs.
+# type_complexity / too_many_arguments: suppressed per-site in solve_session
+#   and geometry test helpers.

--- a/apps/nec-cli/Cargo.toml
+++ b/apps/nec-cli/Cargo.toml
@@ -31,3 +31,6 @@ toml        = { workspace = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 base64     = { workspace = true }
+
+[lints]
+workspace = true

--- a/apps/nec-cli/src/exec_profile.rs
+++ b/apps/nec-cli/src/exec_profile.rs
@@ -95,7 +95,7 @@ pub(super) fn warn_compatibility_profile(
 
 pub(super) fn startup_execution_probe(freq_points: usize) -> StartupExecutionProbe {
     let cpu_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
+        .map(std::num::NonZeroUsize::get)
         .unwrap_or(1);
     let gpu_available = matches!(
         dispatch_frequency_point(AccelRequestKind::GpuOnly, 14.2e6),

--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -87,7 +87,10 @@ pub(super) struct HybridLanePlan {
 }
 
 pub(super) fn l2_norm(v: &[Complex64]) -> f64 {
-    v.iter().map(|x| x.norm_sqr()).sum::<f64>().sqrt()
+    v.iter()
+        .map(num_complex::Complex::norm_sqr)
+        .sum::<f64>()
+        .sqrt()
 }
 
 pub(super) fn matrix_diagonal_spread(z: &ZMatrix) -> f64 {
@@ -676,7 +679,10 @@ pub(super) fn solve_frequency_point(
         let _ = compute_radiation_pattern(segs, &i_vec, freq_hz, &[pattern_points[0]], ground);
 
         // For stub, use a simple normalized reference (total current squared)
-        let norm_ref = i_vec.iter().map(|i| i.norm_sqr()).sum::<f64>();
+        let norm_ref = i_vec
+            .iter()
+            .map(num_complex::Complex::norm_sqr)
+            .sum::<f64>();
 
         let kernel = nec_accel::HallenFrGpuKernel::new(
             gpu_segments,
@@ -767,6 +773,7 @@ pub(super) fn solve_frequency_point(
 ///
 /// Returns results indexed by frequency position, unsorted. The caller is responsible
 /// for sorting by index and emitting per-result warnings.
+#[allow(clippy::type_complexity)]
 pub(super) fn execute_frequency_sweep<F>(
     freqs_hz: &[f64],
     execution_mode: ExecutionMode,

--- a/apps/nec-cli/tests/gpu_rp_exec.rs
+++ b/apps/nec-cli/tests/gpu_rp_exec.rs
@@ -41,10 +41,8 @@ fn parse_gain_total_column(stdout: &str) -> Vec<f64> {
                 }
             }
             // Any non-data line (empty or next section header) ends the table.
-            if !parts.is_empty() && !values.is_empty() {
-                if parts[0].parse::<f64>().is_err() {
-                    in_pattern = false;
-                }
+            if !parts.is_empty() && !values.is_empty() && parts[0].parse::<f64>().is_err() {
+                in_pattern = false;
             }
         }
     }

--- a/apps/nec-cli/tests/resonance_contract.rs
+++ b/apps/nec-cli/tests/resonance_contract.rs
@@ -112,7 +112,7 @@ fn resonance_search_worked_example_converges() {
         .parse()
         .unwrap_or_else(|_| panic!("CONVERGED_VALUE not a float: '{val_str}'\nstdout: {stdout}"));
     assert!(
-        val >= 4.5 && val <= 6.0,
+        (4.5..=6.0).contains(&val),
         "CONVERGED_VALUE {val:.4} m outside plausible [4.5, 6.0] range\nstdout: {stdout}"
     );
 
@@ -123,7 +123,7 @@ fn resonance_search_worked_example_converges() {
         .parse()
         .unwrap_or_else(|_| panic!("ITERATIONS not an integer: '{iters_str}'\nstdout: {stdout}"));
     assert!(
-        iters >= 1 && iters <= 52,
+        (1..=52).contains(&iters),
         "ITERATIONS {iters} outside plausible [1, 52] range\nstdout: {stdout}"
     );
 }

--- a/apps/nec-cli/tests/worker_integration.rs
+++ b/apps/nec-cli/tests/worker_integration.rs
@@ -66,7 +66,7 @@ fn test_capability_cache_roundtrip() {
 
     let fetched = cache.get("box1.local").expect("entry should be present");
     assert_eq!(fetched.cpu_threads, 16);
-    assert_eq!(fetched.gpu_available, true);
+    assert!(fetched.gpu_available);
     assert_eq!(fetched.wgpu_backend.as_deref(), Some("Vulkan"));
 
     assert!(cache.get("no-such-host").is_none());

--- a/apps/nec-gui/Cargo.toml
+++ b/apps/nec-gui/Cargo.toml
@@ -26,3 +26,6 @@ nec_project = { workspace = true }
 num-complex = { workspace = true }
 toml        = { workspace = true }
 iced        = "0.13"
+
+[lints]
+workspace = true

--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -375,8 +375,8 @@ impl AppState {
         if valid.is_empty() {
             return Vec::new();
         }
-        let max_g = valid.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-        let min_g = valid.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max_g = valid.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let min_g = valid.iter().copied().fold(f64::INFINITY, f64::min);
         let range = (max_g - min_g).max(1e-12);
 
         pts.iter()

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -743,7 +743,7 @@ fn current_distribution_peak_near_feedpoint() {
         .unwrap();
     // Feedpoint is segment 25 (0-based middle of 51), allow ±3.
     assert!(
-        peak_idx >= 22 && peak_idx <= 28,
+        (22..=28).contains(&peak_idx),
         "peak current at segment {peak_idx}, expected near 25"
     );
 }

--- a/apps/nec-tui/Cargo.toml
+++ b/apps/nec-tui/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/main.rs"
 
 [dependencies]
 nec_project = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nec_accel/Cargo.toml
+++ b/crates/nec_accel/Cargo.toml
@@ -24,3 +24,6 @@ pollster = { workspace = true }
 nec_solver = { workspace = true }
 nec_parser = { workspace = true }
 nec_model  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nec_accel/src/wgpu_device.rs
+++ b/crates/nec_accel/src/wgpu_device.rs
@@ -679,7 +679,7 @@ pub async fn run_rp_farfield_batch_wgpu(
     });
 
     // ---- single dispatch + single readback ----------------------------------
-    let n_workgroups = (n_points + 63) / 64;
+    let n_workgroups = n_points.div_ceil(64);
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("rp-batch-encoder"),
     });
@@ -710,7 +710,7 @@ pub async fn run_rp_farfield_batch_wgpu(
         return None;
     }
     let raw = slice.get_mapped_range();
-    let vals: &[f32] = bytemuck::cast_slice(&*raw);
+    let vals: &[f32] = bytemuck::cast_slice(&raw);
 
     let norm = if total_radiated > 0.0 {
         4.0 * std::f64::consts::PI / total_radiated
@@ -1033,7 +1033,7 @@ pub async fn fill_zmatrix_wgpu(segments: &[ZSegmentInput], freq_hz: f64) -> Opti
         return None;
     }
     let raw = slice.get_mapped_range();
-    let floats: &[f32] = bytemuck::cast_slice(&*raw);
+    let floats: &[f32] = bytemuck::cast_slice(&raw);
 
     let results: Vec<ZElem> = floats
         .chunks_exact(2)

--- a/crates/nec_model/Cargo.toml
+++ b/crates/nec_model/Cargo.toml
@@ -11,3 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/nec_parser/Cargo.toml
+++ b/crates/nec_parser/Cargo.toml
@@ -12,3 +12,6 @@ rust-version.workspace = true
 
 [dependencies]
 nec_model = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -113,19 +113,19 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 let fields = parse_fields(rest);
                 require_fields(lineno, "GW", &fields, 9)?;
                 deck.cards.push(Card::Gw(GwCard {
-                    tag: parse_u32(lineno, "GW", 1, &fields[0])?,
-                    segments: parse_u32(lineno, "GW", 2, &fields[1])?,
+                    tag: parse_u32(lineno, "GW", 1, fields[0])?,
+                    segments: parse_u32(lineno, "GW", 2, fields[1])?,
                     start: [
-                        parse_f64(lineno, "GW", 3, &fields[2])?,
-                        parse_f64(lineno, "GW", 4, &fields[3])?,
-                        parse_f64(lineno, "GW", 5, &fields[4])?,
+                        parse_f64(lineno, "GW", 3, fields[2])?,
+                        parse_f64(lineno, "GW", 4, fields[3])?,
+                        parse_f64(lineno, "GW", 5, fields[4])?,
                     ],
                     end: [
-                        parse_f64(lineno, "GW", 6, &fields[5])?,
-                        parse_f64(lineno, "GW", 7, &fields[6])?,
-                        parse_f64(lineno, "GW", 8, &fields[7])?,
+                        parse_f64(lineno, "GW", 6, fields[5])?,
+                        parse_f64(lineno, "GW", 7, fields[6])?,
+                        parse_f64(lineno, "GW", 8, fields[7])?,
                     ],
-                    radius: parse_f64(lineno, "GW", 9, &fields[8])?,
+                    radius: parse_f64(lineno, "GW", 9, fields[8])?,
                 }));
             }
             "GE" => {
@@ -133,7 +133,7 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 let ground_reflection_flag = if fields.is_empty() {
                     0
                 } else {
-                    parse_i32(lineno, "GE", 1, &fields[0])?
+                    parse_i32(lineno, "GE", 1, fields[0])?
                 };
                 deck.cards.push(Card::Ge(GeCard {
                     ground_reflection_flag,
@@ -145,18 +145,18 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 // GN I1 NRADL I3 I4 EPSE SIG
                 // We currently only consume I1 and optional EPSE/SIG.
                 let eps_r = if fields.len() > 4 {
-                    Some(parse_f64(lineno, "GN", 5, &fields[4])?)
+                    Some(parse_f64(lineno, "GN", 5, fields[4])?)
                 } else {
                     None
                 };
                 let sigma = if fields.len() > 5 {
-                    Some(parse_f64(lineno, "GN", 6, &fields[5])?)
+                    Some(parse_f64(lineno, "GN", 6, fields[5])?)
                 } else {
                     None
                 };
 
                 deck.cards.push(Card::Gn(GnCard {
-                    ground_type: parse_i32(lineno, "GN", 1, &fields[0])?,
+                    ground_type: parse_i32(lineno, "GN", 1, fields[0])?,
                     eps_r,
                     sigma,
                 }));
@@ -168,20 +168,20 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 // default to 0.0 if absent.
                 require_fields(lineno, "EX", &fields, 4)?;
                 let vr = if fields.len() > 4 {
-                    parse_f64(lineno, "EX", 5, &fields[4])?
+                    parse_f64(lineno, "EX", 5, fields[4])?
                 } else {
                     0.0
                 };
                 let vi = if fields.len() > 5 {
-                    parse_f64(lineno, "EX", 6, &fields[5])?
+                    parse_f64(lineno, "EX", 6, fields[5])?
                 } else {
                     0.0
                 };
                 deck.cards.push(Card::Ex(ExCard {
-                    excitation_type: parse_u32(lineno, "EX", 1, &fields[0])?,
-                    tag: parse_u32(lineno, "EX", 2, &fields[1])?,
-                    segment: parse_u32(lineno, "EX", 3, &fields[2])?,
-                    i4: parse_u32(lineno, "EX", 4, &fields[3])?,
+                    excitation_type: parse_u32(lineno, "EX", 1, fields[0])?,
+                    tag: parse_u32(lineno, "EX", 2, fields[1])?,
+                    segment: parse_u32(lineno, "EX", 3, fields[2])?,
+                    i4: parse_u32(lineno, "EX", 4, fields[3])?,
                     voltage_real: vr,
                     voltage_imag: vi,
                 }));
@@ -200,23 +200,23 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                     (2, 3) // shorthand: no I3/I4
                 };
                 deck.cards.push(Card::Fr(FrCard {
-                    step_type: parse_u32(lineno, "FR", 1, &fields[0])?,
-                    steps: parse_u32(lineno, "FR", 2, &fields[1])?,
-                    frequency_mhz: parse_f64(lineno, "FR", freq_idx + 1, &fields[freq_idx])?,
-                    step_mhz: parse_f64(lineno, "FR", step_idx + 1, &fields[step_idx])?,
+                    step_type: parse_u32(lineno, "FR", 1, fields[0])?,
+                    steps: parse_u32(lineno, "FR", 2, fields[1])?,
+                    frequency_mhz: parse_f64(lineno, "FR", freq_idx + 1, fields[freq_idx])?,
+                    step_mhz: parse_f64(lineno, "FR", step_idx + 1, fields[step_idx])?,
                 }));
             }
             "RP" => {
                 let fields = parse_fields(rest);
                 require_fields(lineno, "RP", &fields, 7)?;
                 deck.cards.push(Card::Rp(RpCard {
-                    mode: parse_u32(lineno, "RP", 1, &fields[0])?,
-                    n_theta: parse_u32(lineno, "RP", 2, &fields[1])?,
-                    n_phi: parse_u32(lineno, "RP", 3, &fields[2])?,
-                    theta0: parse_f64(lineno, "RP", 4, &fields[3])?,
-                    phi0: parse_f64(lineno, "RP", 5, &fields[4])?,
-                    d_theta: parse_f64(lineno, "RP", 6, &fields[5])?,
-                    d_phi: parse_f64(lineno, "RP", 7, &fields[6])?,
+                    mode: parse_u32(lineno, "RP", 1, fields[0])?,
+                    n_theta: parse_u32(lineno, "RP", 2, fields[1])?,
+                    n_phi: parse_u32(lineno, "RP", 3, fields[2])?,
+                    theta0: parse_f64(lineno, "RP", 4, fields[3])?,
+                    phi0: parse_f64(lineno, "RP", 5, fields[4])?,
+                    d_theta: parse_f64(lineno, "RP", 6, fields[5])?,
+                    d_phi: parse_f64(lineno, "RP", 7, fields[6])?,
                 }));
             }
             "LD" => {
@@ -226,25 +226,25 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 let fields = parse_fields(rest);
                 require_fields(lineno, "LD", &fields, 4)?;
                 let f1 = if fields.len() > 4 {
-                    parse_f64(lineno, "LD", 5, &fields[4])?
+                    parse_f64(lineno, "LD", 5, fields[4])?
                 } else {
                     0.0
                 };
                 let f2 = if fields.len() > 5 {
-                    parse_f64(lineno, "LD", 6, &fields[5])?
+                    parse_f64(lineno, "LD", 6, fields[5])?
                 } else {
                     0.0
                 };
                 let f3 = if fields.len() > 6 {
-                    parse_f64(lineno, "LD", 7, &fields[6])?
+                    parse_f64(lineno, "LD", 7, fields[6])?
                 } else {
                     0.0
                 };
                 deck.cards.push(Card::Ld(LdCard {
-                    load_type: parse_i32(lineno, "LD", 1, &fields[0])?,
-                    tag: parse_u32(lineno, "LD", 2, &fields[1])?,
-                    seg_first: parse_u32(lineno, "LD", 3, &fields[2])?,
-                    seg_last: parse_u32(lineno, "LD", 4, &fields[3])?,
+                    load_type: parse_i32(lineno, "LD", 1, fields[0])?,
+                    tag: parse_u32(lineno, "LD", 2, fields[1])?,
+                    seg_first: parse_u32(lineno, "LD", 3, fields[2])?,
+                    seg_last: parse_u32(lineno, "LD", 4, fields[3])?,
                     f1,
                     f2,
                     f3,
@@ -257,19 +257,19 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 let fields = parse_fields(rest);
                 require_fields(lineno, "TL", &fields, 8)?;
                 let f3 = if fields.len() > 8 {
-                    parse_f64(lineno, "TL", 9, &fields[8])?
+                    parse_f64(lineno, "TL", 9, fields[8])?
                 } else {
                     1.0
                 };
                 deck.cards.push(Card::Tl(TlCard {
-                    tag1: parse_u32(lineno, "TL", 1, &fields[0])?,
-                    segment1: parse_u32(lineno, "TL", 2, &fields[1])?,
-                    tag2: parse_u32(lineno, "TL", 3, &fields[2])?,
-                    segment2: parse_u32(lineno, "TL", 4, &fields[3])?,
-                    num_segments: parse_u32(lineno, "TL", 5, &fields[4])?,
-                    tl_type: parse_u32(lineno, "TL", 6, &fields[5])?,
-                    z0: parse_f64(lineno, "TL", 7, &fields[6])?,
-                    length: parse_f64(lineno, "TL", 8, &fields[7])?,
+                    tag1: parse_u32(lineno, "TL", 1, fields[0])?,
+                    segment1: parse_u32(lineno, "TL", 2, fields[1])?,
+                    tag2: parse_u32(lineno, "TL", 3, fields[2])?,
+                    segment2: parse_u32(lineno, "TL", 4, fields[3])?,
+                    num_segments: parse_u32(lineno, "TL", 5, fields[4])?,
+                    tl_type: parse_u32(lineno, "TL", 6, fields[5])?,
+                    z0: parse_f64(lineno, "TL", 7, fields[6])?,
+                    length: parse_f64(lineno, "TL", 8, fields[7])?,
                     f3,
                 }));
             }
@@ -280,7 +280,10 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 // solve time (replaces the previous "unknown card 'NT'" path).
                 let fields = parse_fields(rest);
                 deck.cards.push(Card::Nt(NtCard {
-                    raw_fields: fields.into_iter().map(|s| s.to_string()).collect(),
+                    raw_fields: fields
+                        .into_iter()
+                        .map(std::string::ToString::to_string)
+                        .collect(),
                 }));
             }
             "EN" => {
@@ -408,7 +411,12 @@ EN
             })
         );
         // CE (empty text)
-        assert_eq!(cards[1], Card::Comment(CommentCard { text: "".into() }));
+        assert_eq!(
+            cards[1],
+            Card::Comment(CommentCard {
+                text: String::new()
+            })
+        );
         // GW
         assert_eq!(
             cards[2],

--- a/crates/nec_project/Cargo.toml
+++ b/crates/nec_project/Cargo.toml
@@ -17,3 +17,6 @@ nec_solver  = { workspace = true }
 nec_report  = { workspace = true }
 serde       = { workspace = true }
 toml        = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nec_report/Cargo.toml
+++ b/crates/nec_report/Cargo.toml
@@ -13,3 +13,6 @@ rust-version.workspace = true
 [dependencies]
 nec_model = { workspace = true }
 num-complex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nec_report/src/lib.rs
+++ b/crates/nec_report/src/lib.rs
@@ -252,7 +252,7 @@ pub fn render_text_report(input: &ReportInput<'_>) -> String {
     out.push_str(&format!("FREQ_MHZ {:.6}\n", input.frequency_hz / 1e6));
     out.push_str(&format!("SOLVER_MODE {}\n", input.solver_mode));
     out.push_str(&format!("PULSE_RHS {}\n", input.pulse_rhs));
-    out.push_str("\n");
+    out.push('\n');
     out.push_str("FEEDPOINTS\n");
     out.push_str("TAG SEG V_RE V_IM I_RE I_IM Z_RE Z_IM\n");
 

--- a/crates/nec_solver/Cargo.toml
+++ b/crates/nec_solver/Cargo.toml
@@ -22,3 +22,6 @@ nec_accel   = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/nec_solver/src/basis.rs
+++ b/crates/nec_solver/src/basis.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
+// Numerical transform matrices are built with index arithmetic; suppress the
+// lint that suggests converting them to iterator-based loops.
+#![allow(clippy::needless_range_loop)]
+
 //! Current-basis utilities.
 //!
 //! This module provides a continuity-enforcing transform from internal node

--- a/crates/nec_solver/src/excitation.rs
+++ b/crates/nec_solver/src/excitation.rs
@@ -78,7 +78,7 @@ pub fn build_excitation(
 
     for card in &deck.cards {
         let Card::Ex(ex) = card else { continue };
-        apply_ex(&ex, segs, &mut v)?;
+        apply_ex(ex, segs, &mut v)?;
     }
 
     Ok(v)

--- a/crates/nec_solver/src/farfield.rs
+++ b/crates/nec_solver/src/farfield.rs
@@ -255,7 +255,7 @@ fn far_field_components_with_image(
 /// * `freq_hz`  — operating frequency in Hz.
 /// * `points`   — observation directions (θ, φ in degrees).
 /// * `ground`   — ground model; `PerfectConductor` adds PEC image contribution
-///               and restricts the pattern to the upper hemisphere (θ ≤ 90°).
+///   and restricts the pattern to the upper hemisphere (θ ≤ 90°).
 pub fn compute_radiation_pattern(
     segs: &[Segment],
     i_vec: &[Complex64],

--- a/crates/nec_solver/src/geometry.rs
+++ b/crates/nec_solver/src/geometry.rs
@@ -716,6 +716,7 @@ mod tests {
     // GM / GR tests
     // -------------------------------------------------------------------------
 
+    #[allow(clippy::too_many_arguments)]
     fn make_gm(
         tag_increment: u32,
         last_tag: u32,

--- a/crates/nec_solver/src/linear.rs
+++ b/crates/nec_solver/src/linear.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
+// Numerical matrix algorithms legitimately use index-based loops.
+#![allow(clippy::needless_range_loop)]
+
 //! Dense complex linear solver: LU factorisation with partial pivoting.
 //!
 //! Solves Z·I = V for the segment current vector I.

--- a/crates/nec_solver/src/matrix.rs
+++ b/crates/nec_solver/src/matrix.rs
@@ -593,7 +593,8 @@ mod tests {
     #[test]
     fn pec_ground_changes_hallen_matrix_element() {
         let s = make_seg(1, 1, 0, [0.0, 0.0, 1.0], DIR_Z, SEG_LEN, RADIUS);
-        let z_free = assemble_z_matrix_with_ground(&[s.clone()], FREQ, &GroundModel::FreeSpace);
+        let z_free =
+            assemble_z_matrix_with_ground(std::slice::from_ref(&s), FREQ, &GroundModel::FreeSpace);
         let z_pec = assemble_z_matrix_with_ground(&[s], FREQ, &GroundModel::PerfectConductor);
 
         let delta = z_pec.get(0, 0) - z_free.get(0, 0);
@@ -606,7 +607,8 @@ mod tests {
     #[test]
     fn gn0_ground_changes_hallen_matrix_element() {
         let s = make_seg(1, 1, 0, [0.0, 0.0, 1.0], DIR_Z, SEG_LEN, RADIUS);
-        let z_free = assemble_z_matrix_with_ground(&[s.clone()], FREQ, &GroundModel::FreeSpace);
+        let z_free =
+            assemble_z_matrix_with_ground(std::slice::from_ref(&s), FREQ, &GroundModel::FreeSpace);
         let z_gn0 = assemble_z_matrix_with_ground(
             &[s],
             FREQ,

--- a/crates/nec_worker/Cargo.toml
+++ b/crates/nec_worker/Cargo.toml
@@ -20,3 +20,6 @@ toml        = { workspace = true }
 num-complex = { workspace = true }
 base64      = { workspace = true }
 sha2        = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nec_worker/src/hosts.rs
+++ b/crates/nec_worker/src/hosts.rs
@@ -65,6 +65,7 @@ impl std::error::Error for HostsConfigError {}
 
 impl HostsConfig {
     /// Parse a `HostsConfig` from a TOML string.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self, toml::de::Error> {
         toml::from_str(s)
     }

--- a/crates/nec_worker/src/result_cache.rs
+++ b/crates/nec_worker/src/result_cache.rs
@@ -105,9 +105,9 @@ impl ResultCache {
     /// If the cache is at capacity, the oldest entry is evicted first.
     pub fn insert(&mut self, key: impl Into<String>, result: TaskResult) {
         let key = key.into();
-        if self.entries.contains_key(&key) {
+        if let Some(entry) = self.entries.get_mut(&key) {
             // Replace in-place; don't grow the insertion-order queue.
-            self.entries.insert(key, CacheEntry { result });
+            *entry = CacheEntry { result };
             return;
         }
         // Evict oldest if at capacity.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -251,8 +251,8 @@ The following items were identified during a project-wide review on 2026-04-30 a
 
 ### Code quality & robustness
 
-- [ ] **BL-IMPR-001 / Reduce `unwrap`/`expect` in core solver paths**: Audit `crates/nec_solver/src/{linear.rs,matrix.rs,excitation.rs,loads.rs}` and convert non-test `unwrap()` / `expect()` call sites to `Result` propagation or explicit panics with documented invariants. Resolution criteria: no `.unwrap()` / `.expect()` outside `#[cfg(test)]` in `nec_solver` core modules without an accompanying invariant comment; CI lint check optional.
-- [ ] **BL-IMPR-002 / Workspace `[lints]` table**: Add a workspace-level `[lints]` table in the root `Cargo.toml` that pins clippy and rustc warning levels, and selectively opts in to a curated `clippy::pedantic` subset. Resolution criteria: `cargo clippy --workspace --all-targets` runs clean under the new lints; per-crate overrides documented.
+- [x] **BL-IMPR-001 / Reduce `unwrap`/`expect` in core solver paths**: Audit `crates/nec_solver/src/{linear.rs,matrix.rs,excitation.rs,loads.rs}` and convert non-test `unwrap()` / `expect()` call sites to `Result` propagation or explicit panics with documented invariants. Resolution criteria: no `.unwrap()` / `.expect()` outside `#[cfg(test)]` in `nec_solver` core modules without an accompanying invariant comment; CI lint check optional.
+- [x] **BL-IMPR-002 / Workspace `[lints]` table**: Add a workspace-level `[lints]` table in the root `Cargo.toml` that pins clippy and rustc warning levels, and selectively opts in to a curated `clippy::pedantic` subset. Resolution criteria: `cargo clippy --workspace --all-targets` runs clean under the new lints; per-crate overrides documented.
 
 ### Test coverage
 


### PR DESCRIPTION
## Summary

### BL-IMPR-001: Solver unwrap/expect audit
Audited all four target files (`linear.rs`, `matrix.rs`, `excitation.rs`, `loads.rs`). All production-path code already uses `?` propagation; all `.unwrap()`/`.expect()` calls are inside `#[cfg(test)]` blocks. Resolution criteria met with no production code changes required.

### BL-IMPR-002: Workspace `[lints]` table
Added `[workspace.lints]` to root `Cargo.toml`:
- **rust**: `unsafe_code = warn`, `unused_imports = warn`
- **clippy**: `cloned_instead_of_copied`, `manual_string_new`, `redundant_closure_for_method_calls`, `semicolon_if_nothing_returned`

All 10 workspace members opt in via `[lints] workspace = true`.

### Pre-existing clippy warning cleanup
Fixed all warnings to establish a clean baseline before adding lints:
- File-level `needless_range_loop` suppression in `linear.rs`/`basis.rs` (matrix index arithmetic)
- `doc_overindented_list_items` in `farfield.rs`
- `map_entry` in `result_cache.rs` (use `get_mut`)
- `cloned_ref_to_slice_refs` in `matrix.rs` tests
- Per-site `allow` for `type_complexity`, `too_many_arguments`, `should_implement_trait`
- Auto-fixed: needless borrows in `nec_parser`, `cloned→copied` in GUI, redundant closures

**Result**: `cargo clippy --workspace --all-targets` now produces zero warnings.

## Checklist
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --workspace` passes
- [x] Backlog items BL-IMPR-001 and BL-IMPR-002 marked done