### PR TITLE
feat: BL-IMPR-003/007 — nec_project unit tests + card support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ TAG SEG V_RE V_IM I_RE I_IM Z_RE Z_IM
 1 26 1.000000 0.000000 0.013013 -0.002436 74.242874 13.899516
 ```
 
-See [docs/cli-guide.md](docs/cli-guide.md) for full option reference.
+See [docs/cli-guide.md](docs/cli-guide.md) for full option reference and [docs/card-support-matrix.md](docs/card-support-matrix.md) for the NEC card support matrix.
 
 ## Support fnec-rust
 

--- a/crates/nec_project/src/lib.rs
+++ b/crates/nec_project/src/lib.rs
@@ -247,3 +247,199 @@ impl RunHistory {
         self.0.push(record);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    fn minimal_project() -> ProjectFile {
+        ProjectFile {
+            version: 1,
+            name: "test-dipole".to_string(),
+            deck_path: PathBuf::from("corpus/dipole-freesp-51seg.nec"),
+            solver: SolverConfig::default(),
+            runs: vec![],
+            history: RunHistory::default(),
+        }
+    }
+
+    fn make_run_record(label: &str, z_re: f64, z_im: f64) -> RunRecord {
+        RunRecord {
+            timestamp: "2026-05-05T12:00:00Z".to_string(),
+            solver: SolverConfig {
+                mode: label.to_string(),
+                pulse_rhs: "auto".to_string(),
+            },
+            result: ResultSummary {
+                impedance_re: z_re,
+                impedance_im: z_im,
+                peak_gain_dbi: None,
+                sweep_point_count: 1,
+            },
+        }
+    }
+
+    // ── SolverConfig ────────────────────────────────────────────────────────
+
+    #[test]
+    fn solver_config_default_is_hallen_auto() {
+        let sc = SolverConfig::default();
+        assert_eq!(sc.mode, "hallen");
+        assert_eq!(sc.pulse_rhs, "auto");
+    }
+
+    // ── ProjectFile round-trip ───────────────────────────────────────────────
+
+    #[test]
+    fn project_file_round_trips_minimal() {
+        let project = minimal_project();
+        let toml = project.to_toml().expect("serialise should succeed");
+        let loaded = ProjectFile::from_toml(&toml).expect("deserialise should succeed");
+        assert_eq!(loaded, project);
+    }
+
+    #[test]
+    fn project_file_round_trips_with_runs_and_history() {
+        let mut project = minimal_project();
+        project.runs.push(NamedRun {
+            name: "baseline".to_string(),
+            description: Some("Default Hallen solve".to_string()),
+            solver: None,
+        });
+        project.runs.push(NamedRun {
+            name: "loaded".to_string(),
+            description: None,
+            solver: Some(SolverConfig {
+                mode: "hallen".to_string(),
+                pulse_rhs: "1".to_string(),
+            }),
+        });
+        project
+            .history
+            .push(make_run_record("hallen", 74.24, 13.90));
+
+        let toml = project.to_toml().expect("serialise should succeed");
+        let loaded = ProjectFile::from_toml(&toml).expect("deserialise should succeed");
+        assert_eq!(loaded, project);
+    }
+
+    #[test]
+    fn project_file_toml_omits_empty_runs_and_history() {
+        let project = minimal_project();
+        let toml = project.to_toml().expect("serialise should succeed");
+        // Empty runs and empty history should not appear in the TOML output.
+        assert!(!toml.contains("[[runs]]"), "empty runs should be omitted");
+        assert!(
+            !toml.contains("[[history]]"),
+            "empty history should be omitted"
+        );
+    }
+
+    #[test]
+    fn project_file_round_trips_with_peak_gain() {
+        let mut project = minimal_project();
+        project.history.push(RunRecord {
+            timestamp: "2026-05-05T14:00:00Z".to_string(),
+            solver: SolverConfig::default(),
+            result: ResultSummary {
+                impedance_re: 74.24,
+                impedance_im: 13.90,
+                peak_gain_dbi: Some(2.15),
+                sweep_point_count: 3,
+            },
+        });
+
+        let toml = project.to_toml().expect("serialise should succeed");
+        let loaded = ProjectFile::from_toml(&toml).expect("deserialise should succeed");
+        assert_eq!(loaded.last_run().unwrap().result.peak_gain_dbi, Some(2.15));
+    }
+
+    // ── Version guard ────────────────────────────────────────────────────────
+
+    #[test]
+    fn unsupported_version_returns_error() {
+        let bad_toml = r#"
+version = 99
+name = "bad"
+deck_path = "deck.nec"
+[solver]
+mode = "hallen"
+pulse_rhs = "auto"
+"#;
+        let result = ProjectFile::from_toml(bad_toml);
+        assert!(
+            matches!(result, Err(ProjectError::UnsupportedVersion(99))),
+            "expected UnsupportedVersion(99), got {result:?}",
+        );
+    }
+
+    #[test]
+    fn missing_required_field_returns_deserialise_error() {
+        let bad_toml = r#"version = 1"#; // missing name, deck_path, solver
+        let result = ProjectFile::from_toml(bad_toml);
+        assert!(
+            matches!(result, Err(ProjectError::DeserialiseError(_))),
+            "expected DeserialiseError, got {result:?}",
+        );
+    }
+
+    // ── ProjectError Display ─────────────────────────────────────────────────
+
+    #[test]
+    fn project_error_unsupported_version_display() {
+        let msg = ProjectError::UnsupportedVersion(42).to_string();
+        assert!(msg.contains("42"), "display should mention the bad version");
+        assert!(
+            msg.contains(&PROJECT_FILE_VERSION.to_string()),
+            "display should mention the expected version"
+        );
+    }
+
+    // ── RunHistory API ───────────────────────────────────────────────────────
+
+    #[test]
+    fn run_history_starts_empty() {
+        let h = RunHistory::default();
+        assert!(h.is_empty());
+        assert_eq!(h.run_count(), 0);
+        assert!(h.last_run().is_none());
+        assert!(h.run_by_index(0).is_none());
+    }
+
+    #[test]
+    fn run_history_push_and_query() {
+        let mut h = RunHistory::default();
+        h.push(make_run_record("hallen", 74.24, 13.90));
+        h.push(make_run_record("continuity", 50.0, 0.0));
+
+        assert_eq!(h.run_count(), 2);
+        assert!(!h.is_empty());
+        assert_eq!(h.last_run().unwrap().solver.mode, "continuity");
+        assert_eq!(h.run_by_index(0).unwrap().solver.mode, "hallen");
+        assert_eq!(h.run_by_index(1).unwrap().solver.mode, "continuity");
+        assert!(h.run_by_index(2).is_none());
+    }
+
+    // ── ProjectFile run-history delegation ───────────────────────────────────
+
+    #[test]
+    fn project_file_run_count_delegates_to_history() {
+        let mut project = minimal_project();
+        assert_eq!(project.run_count(), 0);
+        assert!(project.last_run().is_none());
+        project
+            .history
+            .push(make_run_record("hallen", 74.24, 13.90));
+        assert_eq!(project.run_count(), 1);
+        assert!(project.last_run().is_some());
+        assert!(project.run_by_index(0).is_some());
+        assert!(project.run_by_index(1).is_none());
+    }
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -256,14 +256,14 @@ The following items were identified during a project-wide review on 2026-04-30 a
 
 ### Test coverage
 
-- [ ] **BL-IMPR-003 / Add unit tests to `nec_project` crate**: Crate currently has only `lib.rs` skeleton. Resolution criteria: at least one unit-test module exercising the public API surface; CI gate on `cargo test -p nec_project`. Precondition for FR-004 Markdown project-workflow work.
+- [x] **BL-IMPR-003 / Add unit tests to `nec_project` crate**: Crate currently has only `lib.rs` skeleton. Resolution criteria: at least one unit-test module exercising the public API surface; CI gate on `cargo test -p nec_project`. Precondition for FR-004 Markdown project-workflow work.
 - [ ] **BL-IMPR-004 / Add unit tests to `nec_report` crate**: Crate is exercised today only via CLI integration tests. Resolution criteria: unit tests for table-render corner cases (NaN, empty rows, very wide columns, pattern row filtering) directly against the public render API.
 - [ ] **BL-IMPR-005 / Property-based tests for excitation/loads**: Add `proptest`-driven sweeps over LD types 0–5 and EX types 1–5 to cover staged/portability paths and randomized card field values. Resolution criteria: at least one proptest in `nec_solver/src/excitation.rs` and `nec_solver/src/loads.rs` test modules with a stable seed configuration in CI.
 - [ ] **BL-IMPR-006 / GPU kernel edge-case tests**: Extend `crates/nec_accel/src/gpu_kernels` unit tests to cover 1-segment cases, very small/large frequencies, NaN-source handling, and pattern interpolation near the poles (θ=0, θ=π). Resolution criteria: dedicated edge-case tests added; existing happy-path tests untouched.
 
 ### Documentation
 
-- [ ] **BL-IMPR-007 / Single staged-card status table**: Document one canonical table (likely under `docs/cli-guide.md` or a new `docs/card-support-matrix.md`) of supported vs deferred behavior for EX types, PT, NT, LD types, TL types, and GN types, with links to the corresponding solver/parser entry points. Resolution criteria: table exists, is referenced from `docs/cli-guide.md` and `README.md`, and is covered by a frontmatter validation hook if practical.
+- [x] **BL-IMPR-007 / Single staged-card status table**: Document one canonical table (likely under `docs/cli-guide.md` or a new `docs/card-support-matrix.md`) of supported vs deferred behavior for EX types, PT, NT, LD types, TL types, and GN types, with links to the corresponding solver/parser entry points. Resolution criteria: table exists, is referenced from `docs/cli-guide.md` and `README.md`, and is covered by a frontmatter validation hook if practical.
 - [ ] **BL-IMPR-008 / Clarify GPU stub state in `nec_accel` README**: The `crates/nec_accel` GPU dispatch path is currently a stub; today only the roadmap notes this. Resolution criteria: a short README in `crates/nec_accel/` (or a doc comment in `lib.rs`) explicitly states which kernels are stubs vs implemented and links to the roadmap entry that tracks the real-kernel work.
 
 ### Performance & parallelism

--- a/docs/card-support-matrix.md
+++ b/docs/card-support-matrix.md
@@ -1,0 +1,109 @@
+---
+project: fnec-rust
+doc: docs/card-support-matrix.md
+status: living
+last_updated: 2026-05-05
+---
+
+# NEC Card Support Matrix
+
+This document is the canonical reference for supported, partial, and deferred NEC card behavior in fnec-rust.  It covers every card that appears in the corpus or is relevant to 4nec2 / NEC2 compatibility.
+
+Legend: **Full** — complete implementation; **Partial** — accepted and produces useful output, but some semantics are deferred (see Notes column); **Deferred** — parsed for portability but ignored at runtime with an explicit warning; **N/A** — not applicable or not in scope.
+
+## Geometry cards
+
+| Card | Support | Notes |
+|------|---------|-------|
+| CM / CE | Full | Comment cards; preserved in parse, ignored at runtime |
+| GW | Full | Wire-segment definition |
+| GE | Full | Geometry end; `GE I1=1` infers PEC ground when no GN card is present |
+| GM | Full | Geometry move: rotate and/or translate wire ranges in place; `tag_increment > 0` appends transformed copies |
+| GR | Full | Geometry repeat: successive z-axis rotation copies |
+| GN type −1 | Full | Null-ground explicit free-space (same as omitting GN) |
+| GN type 0 | Full | Simple finite ground (Sommerfeld / reflection-coefficient path) |
+| GN type 1 | Full | Perfect-conductor (PEC) image method |
+| GN type 2 | Partial | Low-height finite-conductivity near-ground path; scoped subset is regression-gated; other GN 2 geometries deferred |
+| GN other | Deferred | Unsupported type: treated as free-space with a warning |
+
+## Program-control cards
+
+| Card | Support | Notes |
+|------|---------|-------|
+| FR | Full | Linear frequency sweep; all FR steps solved and reported |
+| EN | Full | Terminates parse |
+
+## Excitation cards
+
+| Card | Support | Notes |
+|------|---------|-------|
+| EX type 0 | Full | Voltage-gap source; supported across all solver paths (Hallen, pulse, continuity, sinusoidal) |
+| EX type 1 | Partial | Implemented for `--solver pulse`; all other solver paths use staged portability (EX 0 behavior + warning) pending current-source semantics |
+| EX type 2 | Partial | Staged portability; treated like EX type 0 with a warning; incident-plane-wave semantics pending |
+| EX type 3 | Partial | `legacy` mode (default): treated like EX type 0 + non-default I4 warning; `--ex3-i4-mode divide-by-i4` enables experimental I4-divisor runtime semantics |
+| EX type 4 | Partial | Staged portability; treated like EX type 0 with a warning; segment-current semantics pending |
+| EX type 5 | Partial | Staged portability; treated like EX type 0 with a warning; electric-Hertz-dipole (qdsrc) semantics pending |
+
+## Load cards
+
+| Card | Support | Notes |
+|------|---------|-------|
+| LD type 0 | Full | Series RLC: `Z = R + j(ωL − 1/(ωC))` |
+| LD type 1 | Full | Parallel RLC: `Z = 1 / (1/R + 1/(jωL) + jωC)` |
+| LD type 2 | Full | Series RL: `Z = R + jωL` |
+| LD type 3 | Full | Series RC: `Z = R − j/(ωC)` |
+| LD type 4 | Full | Series impedance (frequency-independent): `Z = R + jX` |
+| LD type 5 | Full | Distributed wire conductivity: `Z = dl / (2π·a·σ)` |
+| LD other | Deferred | Unknown type: load ignored with a warning |
+
+### LD field mapping
+
+`LD  type  tag  seg_first  seg_last  F1  F2  F3`
+
+| Type | F1 | F2 | F3 |
+|------|----|----|-----|
+| 0 | R (Ω) | L (H) | C (F) |
+| 1 | R (Ω) | L (H) | C (F) |
+| 2 | R (Ω) | L (H) | — |
+| 3 | R (Ω) | — | C (F) |
+| 4 | R (Ω) | X (Ω) | — |
+| 5 | σ (S/m) | — | — |
+
+`tag=0` applies the load to all tags; `seg_first=0` applies to all segments of the tag; `seg_last=0` means same as `seg_first`.
+
+## Network cards
+
+| Card | Support | Notes |
+|------|---------|-------|
+| TL type 0 | Partial | Lossless, `NSEG=0/1`; stamps a 2-port admittance model into the Z matrix; `segment=0` maps to the tag center segment with a warning |
+| TL other | Deferred | Lossy / complex variants: card is ignored with a warning |
+| NT | Deferred | Parsed for staged portability; ignored at runtime with a warning |
+| PT | Deferred | Parsed for staged portability; ignored at runtime with a warning |
+
+### TL field mapping
+
+`TL  tag1  seg1  tag2  seg2  NSEG  type  F1  F2  F3`
+
+| Field | Meaning |
+|-------|---------|
+| tag1, seg1 | Port 1 endpoint |
+| tag2, seg2 | Port 2 endpoint |
+| NSEG | Number of TL sections (0 or 1 = single section supported) |
+| type | 0 = lossless (supported); non-zero = lossy/complex (deferred) |
+| F1 | Characteristic impedance Z₀ (Ω, default 50) |
+| F2 | Transmission-line length (m) |
+| F3 | Velocity factor (ratio, default 1.0) for lossless; angle (°) for lossy (deferred) |
+
+## Output / post-processing cards
+
+| Card | Support | Notes |
+|------|---------|-------|
+| RP | Full | Far-field radiation pattern; all RP grid points computed and included in the `RADIATION_PATTERN` report section |
+
+## Unknown / other cards
+
+Any unrecognised card mnemonic is skipped with a parser warning emitted to stderr.  The solve proceeds on the remaining deck.
+
+---
+
+*See also*: [CLI guide](cli-guide.md) · [Design](design.md) · [Roadmap](roadmap.md)

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/cli-guide.md
 status: living
-last_updated: 2026-05-01
+last_updated: 2026-05-05
 ---
 
 # CLI Guide — fnec (v0.2.0)
@@ -267,6 +267,10 @@ EN
 ```
 
 ## Supported NEC cards
+
+For the full card support matrix including field mappings and per-type details, see [docs/card-support-matrix.md](card-support-matrix.md).
+
+Quick reference:
 
 | Card | Support | Notes |
 |------|---------|-------|


### PR DESCRIPTION
## Summary

### BL-IMPR-003: `nec_project` unit tests

Added 11 unit tests directly in `crates/nec_project/src/lib.rs` covering the full public API:

- `SolverConfig::default()` values
- `ProjectFile` round-trip (minimal, with runs+history, with `peak_gain_dbi`)
- TOML omits empty `runs`/`history` fields (`skip_serializing_if`)
- Version guard: `UnsupportedVersion(n)` on wrong version, `DeserialiseError` on bad TOML
- `ProjectError` Display output includes version numbers
- `RunHistory`: starts empty, push/query (`run_count`, `last_run`, `run_by_index`, `is_empty`, out-of-range)
- `ProjectFile` delegation to `RunHistory`

**Result**: `cargo test -p nec_project` — 11 new unit tests + 13 existing integration tests + 1 doc-test all pass.

### BL-IMPR-007: Card support matrix

Created `docs/card-support-matrix.md` — canonical standalone reference covering:
- Geometry cards (GW, GE, GM, GR, GN types −1/0/1/2/other)
- Program-control cards (FR, EN)  
- Excitation cards (EX types 0–5 with exact support status per solver path)
- Load cards (LD types 0–5) with field mapping table
- Network cards (TL type 0/other, NT, PT) with TL field mapping table
- Output cards (RP)
- Unknown card catch-all

Cross-references added to `docs/cli-guide.md` (above the quick-reference table) and `README.md` (see-also line).

## Checklist
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --workspace` passes
- [x] Backlog items BL-IMPR-003 and BL-IMPR-007 marked done