### PR TITLE
docs: BL-IMPR-008 — clarify GPU stub state in nec_accel lib doc

### DIFF
--- a/crates/nec_accel/src/lib.rs
+++ b/crates/nec_accel/src/lib.rs
@@ -1,6 +1,40 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
+//! Optional GPU acceleration backends for fnec-rust.
+//!
+//! # Kernel status
+//!
+//! **All GPU kernels in this crate are currently stubs.**  Every kernel runs on
+//! the CPU using the same numerical algorithms as `nec_solver`.  No real GPU
+//! dispatch occurs.  The stub infrastructure exists so that the dispatch seam,
+//! timing instrumentation, and hybrid-scheduling logic can be developed and
+//! tested without waiting for a real GPU back-end.
+//!
+//! | Kernel / entry point | Module | Status |
+//! |---|---|---|
+//! | `HallenFrGpuKernel` (far-field, Hallén) | `gpu_kernels` | **Stub** — CPU emulation |
+//! | `HallenRhsGpuKernel` (RHS builder) | `gpu_kernels` | **Stub** — CPU emulation |
+//! | `PocklingtonMatrixGpuKernel` (Z-matrix fill) | `gpu_kernels` | **Stub** — CPU emulation |
+//! | `compute_hallen_fr_point_stub` | `gpu_kernels` | **Stub** — CPU emulation |
+//! | `compute_hallen_fr_batch_stub` | `gpu_kernels` | **Stub** — CPU emulation |
+//! | `fill_zmatrix_wgpu` | `wgpu_device` (feature `wgpu`) | **Stub** — wgpu scaffolding only |
+//!
+//! # Dispatch policy
+//!
+//! [`dispatch_frequency_point`] always returns [`DispatchDecision::FallbackToCpu`]
+//! unless the environment variable `FNEC_ACCEL_STUB_GPU=1` is set, which forces
+//! [`DispatchDecision::RunOnGpu`] for testing the hybrid scheduling path.  Even
+//! then, [`execute_frequency_point`] runs the CPU closure — no real GPU work
+//! is performed.
+//!
+//! # Roadmap
+//!
+//! Real kernel implementation is tracked under **GAP-007** in
+//! `docs/requirements.md` (GPU rollout from postprocessing to matrix fill and
+//! solve, FOSS-first per DEC-008).  Until GAP-007 is resolved this crate
+//! provides the dispatch seam only.
+
 pub mod gpu_kernels;
 
 #[cfg(feature = "wgpu")]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -264,7 +264,7 @@ The following items were identified during a project-wide review on 2026-04-30 a
 ### Documentation
 
 - [x] **BL-IMPR-007 / Single staged-card status table**: Document one canonical table (likely under `docs/cli-guide.md` or a new `docs/card-support-matrix.md`) of supported vs deferred behavior for EX types, PT, NT, LD types, TL types, and GN types, with links to the corresponding solver/parser entry points. Resolution criteria: table exists, is referenced from `docs/cli-guide.md` and `README.md`, and is covered by a frontmatter validation hook if practical.
-- [ ] **BL-IMPR-008 / Clarify GPU stub state in `nec_accel` README**: The `crates/nec_accel` GPU dispatch path is currently a stub; today only the roadmap notes this. Resolution criteria: a short README in `crates/nec_accel/` (or a doc comment in `lib.rs`) explicitly states which kernels are stubs vs implemented and links to the roadmap entry that tracks the real-kernel work.
+- [x] **BL-IMPR-008 / Clarify GPU stub state in `nec_accel` README**: The `crates/nec_accel` GPU dispatch path is currently a stub; today only the roadmap notes this. Resolution criteria: a short README in `crates/nec_accel/` (or a doc comment in `lib.rs`) explicitly states which kernels are stubs vs implemented and links to the roadmap entry that tracks the real-kernel work.
 
 ### Performance & parallelism
 


### PR DESCRIPTION
Add crate-level doc comment to crates/nec_accel/src/lib.rs documenting the current GPU stub state. Kernel status table, dispatch policy, and roadmap link to GAP-007/DEC-008. No functional change. BL-IMPR-008 marked done in backlog.