### PR TITLE
diag: BL-IMPR-012 extend buried-wire guardrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ fnec-rust is a Rust-native antenna modeling workspace targeting near-100% practi
   - Validated: 51-segment λ/2 dipole at 14.2 MHz → **74.24 + j13.90 Ω** (matches Python reference)
 	- GN 1 (perfect ground at z=0) is supported via image method; `dipole-ground-51seg` regression is **81.91 + j16.42 Ω**
 	- GN 0 (simple finite-ground reflection coefficient path) is supported; `dipole-gn0-fresnel-51seg` is regression-gated
-	- GN 2 low above-ground finite-conductivity cases are supported on the current scoped path; `dipole-gn2-deferred` and `dipole-gn2-near-ground-51seg` are regression-gated
-	- Buried active-ground wire classes (`z < 0`) remain deferred and fail fast with an actionable error instead of silently falling back
+	- GN 2 low above-ground finite-conductivity cases are supported on the current scoped path; the supported subset is strictly above-ground (`z > 0`); `dipole-gn2-deferred` and `dipole-gn2-near-ground-51seg` are regression-gated
+	- Buried or interface-touching active-ground wire classes (`z <= 0`) remain deferred and fail fast with an actionable error instead of silently falling back
 	- GN types outside the current scoped subset still remain deferred
 	- GE ground-reflection flag: `1` = PEC image (handled); `-1` = below-ground (warns); other values warn with valid range hint
 	- **Multi-wire junctioned / non-collinear Hallen** (unique to fnec-rust): per-wire local cos(k·s) homogeneous vectors, KCL junction continuity rows, and correct passive-wire (zero) RHS — no other NEC2-compatible tool handles junctioned wire topologies via the Hallen integral equation; validated against NEC2 on `dipole-loaded` top-hat geometry (Z ≈ 12.4−j918 Ω, NEC2 ref 13.5−j896 Ω); external cross-check recommended for novel geometries

--- a/apps/nec-cli/src/geometry_validation.rs
+++ b/apps/nec-cli/src/geometry_validation.rs
@@ -97,10 +97,18 @@ pub(super) fn buried_wire_geometry_error(
     }
 
     for seg in segs {
-        if seg.start[2] < -BURIED_Z_EPS || seg.end[2] < -BURIED_Z_EPS {
+        let min_z = seg.start[2].min(seg.end[2]);
+        if min_z <= BURIED_Z_EPS {
+            let detail = match ground {
+                GroundModel::SimpleFiniteGround { eps_r, sigma } => {
+                    format!("finite ground eps_r={:.3}, sigma={:.6}", eps_r, sigma)
+                }
+                GroundModel::PerfectConductor => "PEC ground".to_string(),
+                _ => "active ground".to_string(),
+            };
             return Some(format!(
-                "unsupported buried-wire geometry for active ground model on tag {} seg {} (z < 0). Use free-space or move geometry to z >= 0; buried/near-ground classes are deferred",
-                seg.tag, seg.tag_index
+                "unsupported buried-wire geometry for active ground model on tag {} seg {} (min z = {:.6e} m, {}). Use free-space or move geometry strictly above the ground interface (z > 0); buried/ground-contact classes are deferred",
+                seg.tag, seg.tag_index, min_z, detail,
             ));
         }
     }

--- a/apps/nec-cli/tests/ground_diagnostics.rs
+++ b/apps/nec-cli/tests/ground_diagnostics.rs
@@ -397,6 +397,52 @@ fn buried_wire_with_active_ground_fails_fast_with_actionable_error() {
 }
 
 #[test]
+fn interface_touching_wire_with_active_ground_fails_fast_with_material_context() {
+    // The scoped finite-ground path only supports strictly above-ground wires.
+    // Touching the z=0 interface must fail fast with active-medium context.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    let deck_path = std::env::temp_dir().join(format!("fnec-gn2-interface-{now}.nec"));
+
+    let deck =
+        "GW 1 51 0 0 0.0 0 0 10.564 0.001\nGE\nGN 2 0 0 0 13.0 0.005\nEX 0 1 26 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+    fs::write(&deck_path, deck).expect("failed to write temporary interface-touching deck");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg("--solver")
+        .arg("hallen")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run fnec for interface-touch guardrail test: {e}"));
+
+    let _ = fs::remove_file(&deck_path);
+
+    assert!(
+        !output.status.success(),
+        "interface-touching deck with active ground should fail, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error: unsupported buried-wire geometry for active ground model"),
+        "expected buried-wire guardrail error, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("eps_r=13.000") && stderr.contains("sigma=0.005000"),
+        "expected finite-ground material context in diagnostic, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("z > 0"),
+        "expected strict above-ground guidance in diagnostic, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn near_ground_wire_with_active_ground_runs_without_deferred_warning() {
     // Near-ground wire with GN2 is a supported active-ground path.
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");

--- a/docs/nec4-support.md
+++ b/docs/nec4-support.md
@@ -144,7 +144,7 @@ This flat table lists every NEC-2/NEC-4 mnemonic known to fnec-rust with its exa
 |:-----|:-------|:------|
 | Free space (no ground) | FULL | Baseline. No coupling to ground plane. |
 | Perfect conductor (infinite, ideal) | PARTIAL | Implemented via image method. Phase 1. Sommerfeld corrections (Phase 2) for accuracy near ground. |
-| Finite conductivity (simple scoped model) | PARTIAL | GN types 0 and 2 map to the scoped `SimpleFiniteGround` path using Fresnel-reflection approximation with parsed EPSE/SIG. Above-ground wire classes are in-scope and corpus-gated. Full Sommerfeld/Norton ground-wave integrals deferred to Phase 2+. |
+| Finite conductivity (simple scoped model) | PARTIAL | GN types 0 and 2 map to the scoped `SimpleFiniteGround` path using Fresnel-reflection approximation with parsed EPSE/SIG. Strictly above-ground wire classes (`z > 0`) are in-scope and corpus-gated; buried or interface-touching wires are deferred. Full Sommerfeld/Norton ground-wave integrals deferred to Phase 2+. |
 | Layered earth | DEFERRED | Multi-layer soil models. Phase 3. |
 | Seawater effects | DEFERRED | Conductive media. Phase 3. |
 
@@ -159,7 +159,7 @@ Planned PAR-002 scope:
 
 Current scoped coverage:
 
-- `GN 2` low above-ground wire cases are in-scope and regression-gated via `corpus/dipole-gn2-near-ground-51seg.nec`.
+- `GN 2` low above-ground wire cases are in-scope and regression-gated via `corpus/dipole-gn2-near-ground-51seg.nec`; interface-touching or buried active-ground wires remain fail-fast deferred classes.
 - Buried `z < 0` active-ground wire classes remain out of scope for now and fail fast with actionable diagnostics (`corpus/dipole-gn2-buried-unsupported.nec`).
 3. Add tolerance-gated external-reference comparisons for those fixtures in `corpus/reference-results.json` and `apps/nec-cli/tests/corpus_validation.rs`.
 4. Keep existing GN type 1 PEC behavior unchanged and regression-protected while finite-ground support expands.


### PR DESCRIPTION
## Summary
- extend active-ground buried-wire detection to reject interface-touching wires as well as below-ground wires
- include finite-ground material parameters in the actionable diagnostic for GN0/GN2 paths
- add a GN2 regression covering the z=0 interface-touch case and update ground-scope docs

## Validation
- cargo fmt --all
- cargo test -p nec-cli --test ground_diagnostics
- cargo test -p nec-cli