### PR TITLE
perf: BL-IMPR-009 add cpu-single benchmark baseline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This configures `core.hooksPath` to use `.githooks/`.
 - Parser fuzz scaffold: `(cd fuzz && cargo fuzz run nec_parser_parse corpus/nec_parser_parse)`
 - Remote ARM64 check (Pi over SSH): `bash ./scripts/pi-remote-workspace-check.sh <user@host>`
 - Remote ARM64 benchmark CSV (Pi over SSH): `bash ./scripts/pi-remote-benchmark.sh <user@host>`
+- Remote benchmark with explicit single-thread baseline + parallel CPU sweep: `FNEC_BENCH_EXECS="cpu-single cpu" bash ./scripts/pi-remote-benchmark.sh <user@host>`
 - Benchmark CSV delta view: `bash ./scripts/pi-benchmark-compare.sh <base.csv> <candidate.csv>`
 - Benchmark CSV delta gate example: `bash ./scripts/pi-benchmark-compare.sh --max-delta-pct 15 --fail-on-mode-drift <base.csv> <candidate.csv>`
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -268,7 +268,8 @@ The following items were identified during a project-wide review on 2026-04-30 a
 
 ### Performance & parallelism
 
-- [ ] **BL-IMPR-009 / CPU single-thread benchmark baseline in CI**: Add a `RAYON_NUM_THREADS=1` benchmark scenario to the existing benchmark harness so parallel scaling can be measured against a stable single-thread baseline. Resolution criteria: single-thread baseline CSV captured by the existing benchmark scripts and gated by an existing comparison workflow; no regressions in current benchmark coverage.
+- [x] **BL-IMPR-009 / CPU single-thread benchmark baseline in CI**: Add a `RAYON_NUM_THREADS=1` benchmark scenario to the existing benchmark harness so parallel scaling can be measured against a stable single-thread baseline. Resolution criteria: single-thread baseline CSV captured by the existing benchmark scripts and gated by an existing comparison workflow; no regressions in current benchmark coverage.
+	- 2026-05-30 resolution: `scripts/pi-remote-benchmark.sh` now supports explicit benchmark scenarios including `cpu-single` (mapped to `RAYON_NUM_THREADS=1` with `--exec cpu`) and defaults to `cpu-single cpu` so baseline and parallel CPU rows are captured in the same CSV run. `scripts/pi-benchmark-compare.sh --gpu-vs-cpu-max-pct` now prefers `cpu-single` when both `cpu-single` and legacy `cpu` rows are present, preserving compatibility with existing CSV compare gating workflows.
 
 ### Feature gaps
 

--- a/scripts/pi-benchmark-compare.sh
+++ b/scripts/pi-benchmark-compare.sh
@@ -12,8 +12,10 @@ print per deck+solver deltas for timing and residual diagnostics.
 In the two-file form, base.csv is compared to candidate.csv.
 
 In the single-file form (--gpu-vs-cpu-max-pct), GPU rows are compared to CPU
-rows within candidate.csv for the same (deck, solver) combination.  Fails if
-any GPU average exceeds the CPU average by more than the given percentage.
+rows within candidate.csv for the same (deck, solver) combination. If both
+`cpu-single` and legacy `cpu` rows exist, `cpu-single` is used as the CPU
+baseline. Fails if any GPU average exceeds the CPU average by more than the
+given percentage.
 This is the G5 gate (PH5-CHK-005): GPU ≥ 0.8× CPU (limit: 25%).
 
 Columns in output (two-file mode):
@@ -128,19 +130,27 @@ if [[ -n "${gpu_vs_cpu_max_pct}" ]]; then
     {
         ex = (NF >= 13 && $13 != "") ? $13 : "cpu"
         k = $3 "|" $4
-        if (ex == "cpu") { cpu_c[k]++; cpu_t[k] += $7 }
+        if (ex == "cpu-single") { cpu_single_c[k]++; cpu_single_t[k] += $7 }
+        else if (ex == "cpu") { cpu_legacy_c[k]++; cpu_legacy_t[k] += $7 }
         else if (ex == "gpu") { gpu_c[k]++; gpu_t[k] += $7 }
     }
     END {
         fail = 0
-        for (k in cpu_c) {
-            if (!(k in gpu_c)) continue
-            if (cpu_c[k] == 0 || gpu_c[k] == 0) continue
-            cpu_avg = cpu_t[k] / cpu_c[k]
+        for (k in gpu_c) {
+            if (gpu_c[k] == 0) continue
+            if (k in cpu_single_c && cpu_single_c[k] > 0) {
+                cpu_avg = cpu_single_t[k] / cpu_single_c[k]
+                cpu_runs = cpu_single_c[k]
+            } else if (k in cpu_legacy_c && cpu_legacy_c[k] > 0) {
+                cpu_avg = cpu_legacy_t[k] / cpu_legacy_c[k]
+                cpu_runs = cpu_legacy_c[k]
+            } else {
+                continue
+            }
             gpu_avg = gpu_t[k] / gpu_c[k]
             r = (cpu_avg > 0) ? gpu_avg / cpu_avg : 0
             split(k, p, "|")
-            printf "%s,%s,%d,%d,%.3f,%.3f,%.4f\n", p[1], p[2], cpu_c[k], gpu_c[k], cpu_avg, gpu_avg, r
+            printf "%s,%s,%d,%d,%.3f,%.3f,%.4f\n", p[1], p[2], cpu_runs, gpu_c[k], cpu_avg, gpu_avg, r
             if (max_pct != "" && cpu_avg > 0) {
                 delta_pct = (gpu_avg - cpu_avg) / cpu_avg * 100.0
                 if (delta_pct > (max_pct + 0.0)) {

--- a/scripts/pi-remote-benchmark.sh
+++ b/scripts/pi-remote-benchmark.sh
@@ -24,8 +24,11 @@ Environment overrides:
                        default: "corpus/dipole-freesp-51seg.nec corpus/dipole-ground-51seg.nec corpus/yagi-5elm-51seg.nec"
   FNEC_BENCH_SOLVERS   Space-separated solver names
                        default: "hallen pulse sinusoidal"
-  FNEC_BENCH_EXECS     Space-separated execution modes (cpu|hybrid|gpu)
-                       default: "cpu"
+  FNEC_BENCH_EXECS     Space-separated benchmark scenarios:
+                       cpu-single | cpu | hybrid | gpu
+                       default: "cpu-single cpu"
+                       cpu-single forces RAYON_NUM_THREADS=1 for a stable
+                       single-thread baseline while still using --exec cpu.
   FNEC_BENCH_RUNS      Number of repeated runs per deck+solver (default: 3)
   FNEC_BENCH_OUT       Output CSV path (default: tmp/pi-benchmark-<UTC timestamp>.csv)
 EOF
@@ -47,7 +50,7 @@ local_dir="${FNEC_LOCAL_DIR:-$PWD}"
 bootstrap_rust="${FNEC_BOOTSTRAP_RUST:-1}"
 bench_decks="${FNEC_BENCH_DECKS:-corpus/dipole-freesp-51seg.nec corpus/dipole-ground-51seg.nec corpus/yagi-5elm-51seg.nec}"
 bench_solvers="${FNEC_BENCH_SOLVERS:-hallen pulse sinusoidal}"
-bench_execs="${FNEC_BENCH_EXECS:-cpu}"
+bench_execs="${FNEC_BENCH_EXECS:-cpu-single cpu}"
 bench_runs="${FNEC_BENCH_RUNS:-3}"
 out_csv="${FNEC_BENCH_OUT:-tmp/pi-benchmark-$(date -u +%Y%m%dT%H%M%SZ).csv}"
 out_dir="$(dirname "${out_csv}")"
@@ -115,14 +118,48 @@ cargo build -q -p nec-cli
 
 for deck in ${BENCH_DECKS}; do
   for solver in ${BENCH_SOLVERS}; do
-    for exec_mode in ${BENCH_EXECS}; do
+    for bench_exec in ${BENCH_EXECS}; do
+      case "${bench_exec}" in
+        cpu-single)
+          exec_arg="cpu"
+          bench_rayon="1"
+          bench_stub_gpu="0"
+          ;;
+        cpu)
+          exec_arg="cpu"
+          bench_rayon=""
+          bench_stub_gpu="0"
+          ;;
+        hybrid)
+          exec_arg="hybrid"
+          bench_rayon=""
+          bench_stub_gpu="0"
+          ;;
+        gpu)
+          exec_arg="gpu"
+          bench_rayon=""
+          bench_stub_gpu="1"
+          ;;
+        *)
+          echo "error: unsupported benchmark exec scenario: ${bench_exec}" >&2
+          exit 2
+          ;;
+      esac
+
       run=1
       while [[ "${run}" -le "${BENCH_RUNS}" ]]; do
         ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         start_ns="$(date +%s%N)"
         status="ok"
 
-        if ! target/debug/fnec --solver "${solver}" --exec "${exec_mode}" "${deck}" >/tmp/fnec_out.txt 2>/tmp/fnec_err.txt; then
+        if [[ -n "${bench_rayon}" ]]; then
+          export RAYON_NUM_THREADS="${bench_rayon}"
+        else
+          unset RAYON_NUM_THREADS || true
+        fi
+        export FNEC_ACCEL_STUB_GPU="${bench_stub_gpu}"
+
+        if ! target/debug/fnec --solver "${solver}" --exec "${exec_arg}" "${deck}" >/tmp/fnec_out.txt 2>/tmp/fnec_err.txt; then
           status="fail"
         fi
 
@@ -140,7 +177,7 @@ for deck in ${BENCH_DECKS}; do
 
         printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
           "${ts}" "${deck}" "${solver}" "${run}" "${status}" "${elapsed_ms}" \
-          "${mode}" "${pulse_rhs}" "${freq_mhz}" "${abs_res}" "${rel_res}" "${exec_mode}" "${diag_spread}" "${sin_rel_res}"
+          "${mode}" "${pulse_rhs}" "${freq_mhz}" "${abs_res}" "${rel_res}" "${bench_exec}" "${diag_spread}" "${sin_rel_res}"
 
         run="$((run + 1))"
       done


### PR DESCRIPTION
## Summary
- add explicit cpu-single benchmark scenario to scripts/pi-remote-benchmark.sh (mapped to RAYON_NUM_THREADS=1 with --exec cpu)
- default remote benchmark scenario sweep now captures both cpu-single and cpu rows in one run for stable single-thread vs parallel CPU comparison
- update scripts/pi-benchmark-compare.sh GPU-vs-CPU gate to prefer cpu-single rows when present, while remaining backward compatible with legacy cpu rows
- update benchmark workflow guidance in README and mark BL-IMPR-009 resolved in backlog

## Validation
- bash -n scripts/pi-remote-benchmark.sh
- bash -n scripts/pi-benchmark-compare.sh
- scripts/pi-benchmark-compare.sh --help
- scripts/pi-remote-benchmark.sh --help
- bash scripts/test-benchmark-gate.sh
- functional smoke check with synthetic CSV confirming cpu-single baseline preference