### PR TITLE
perf: add persistent benchmark history capture and trend summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ This configures `core.hooksPath` to use `.githooks/`.
 - Remote ARM64 check (Pi over SSH): `bash ./scripts/pi-remote-workspace-check.sh <user@host>`
 - Remote ARM64 benchmark CSV (Pi over SSH): `bash ./scripts/pi-remote-benchmark.sh <user@host>`
 - Remote benchmark with explicit single-thread baseline + parallel CPU sweep: `FNEC_BENCH_EXECS="cpu-single cpu" bash ./scripts/pi-remote-benchmark.sh <user@host>`
+- Remote benchmark with persistent history append: `FNEC_BENCH_HISTORY="benchmarks/pi-benchmark-history.csv" bash ./scripts/pi-remote-benchmark.sh <user@host>`
 - Benchmark CSV delta view: `bash ./scripts/pi-benchmark-compare.sh <base.csv> <candidate.csv>`
 - Benchmark CSV delta gate example: `bash ./scripts/pi-benchmark-compare.sh --max-delta-pct 15 --fail-on-mode-drift <base.csv> <candidate.csv>`
+- Append benchmark CSV to persistent history: `bash ./scripts/pi-benchmark-history.sh append <candidate.csv> benchmarks/pi-benchmark-history.csv`
+- Benchmark history trend summary: `bash ./scripts/pi-benchmark-history.sh trend benchmarks/pi-benchmark-history.csv`
 
 GitHub Actions includes `benchmark-compare.yml`, which runs on PRs and compares `benchmarks/pi-base.csv` vs `benchmarks/pi-candidate.csv` when both files exist. If either file is missing, the job reports a clean skip.
 When it runs, it also writes a benchmark delta preview to the Actions job summary.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -109,8 +109,9 @@ last_updated: 2026-04-30
 	- 2026-04-30 context: investigation item closed; this item captures the Phase 2 delivery requirement. See `docs/solver-findings.md` §"Current --allow-noncollinear-hallen status" for the rationale and three-way decision space.
 	- 2026-05 completed: Segmented hybrid (option 3) implemented. Per-wire local cos(k·s) vectors replace global s-axis; passive wires get rhs=0; junction endpoints detected via `detect_wire_junctions()` and enforced as KCL continuity rows in the augmented Hallen system. `dipole-loaded` corpus gate now passes (Z ≈ 12.39 − j918 Ω; external NEC2 ref 13.46 − j896 Ω). `--allow-noncollinear-hallen` flag silently accepted (no-op). All CI tests pass.
 
-- [ ] **Benchmark history trend capture / Owner: Performance / Target: Phase 5 prep**
+- [x] **Benchmark history trend capture / Owner: Performance / Target: Phase 5 prep**
 	Resolution criteria: repeated benchmark runs can be appended to a persistent history format and summarized by a tracked script without relying on ad hoc files in `tmp/`.
+	- 2026-05-30 resolution: added `scripts/pi-benchmark-history.sh` with `append` and `trend` commands, using tracked history schema `benchmarks/pi-benchmark-history.csv` (`ingested_at_utc`, `git_sha`, `source_csv`, plus benchmark row fields). `scripts/pi-remote-benchmark.sh` now supports optional `FNEC_BENCH_HISTORY` to auto-append each run CSV to history, and trend summaries are emitted by `scripts/pi-benchmark-history.sh trend <history.csv>`.
 
 - [ ] **FR-004 project format scope (`nec_project`) / Owner: Project+Core APIs / Target: Phase 3**
 	Resolution criteria: `nec_project` has a documented crate scope covering Markdown project structure, run metadata, and result-storage responsibilities, and roadmap/backlog work items explicitly track Markdown import/export delivery.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -90,6 +90,34 @@ Note: GPU paths are currently stub/fallback based, so this is execution-path cov
 - Timing includes full CLI invocation path, not just kernel-only execution.
 - `hybrid` and `gpu` can include fallback paths; mode counts are included to guard against drift.
 
+## Persistent History
+
+To retain benchmark snapshots over time in a tracked, non-`tmp/` location, use:
+
+```bash
+bash ./scripts/pi-benchmark-history.sh append <candidate.csv> benchmarks/pi-benchmark-history.csv
+```
+
+Or append automatically after each remote benchmark run:
+
+```bash
+FNEC_BENCH_HISTORY="benchmarks/pi-benchmark-history.csv" \
+  bash ./scripts/pi-remote-benchmark.sh <user@host>
+```
+
+History schema (`benchmarks/pi-benchmark-history.csv`):
+
+- `ingested_at_utc`
+- `git_sha`
+- `source_csv`
+- all original benchmark CSV fields from `scripts/pi-remote-benchmark.sh`
+
+Summarize long-term trend by deck/solver/exec mode:
+
+```bash
+bash ./scripts/pi-benchmark-history.sh trend benchmarks/pi-benchmark-history.csv
+```
+
 ## Baseline Results (Three Targets)
 
 ### Solver Average Runtime (ms)

--- a/scripts/pi-benchmark-history.sh
+++ b/scripts/pi-benchmark-history.sh
@@ -54,17 +54,17 @@ case "${cmd}" in
     fi
 
     in_header="$(head -n 1 "${in_csv}")"
-    current_header='timestamp_utc,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,freq_mhz,abs_res,rel_res,exec_mode,diag_spread,sin_rel_res'
+    current_csv_header='timestamp_utc,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,freq_mhz,abs_res,rel_res,exec_mode,diag_spread,sin_rel_res'
     legacy_header='timestamp_unix_ms,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,exec,freq_mhz,abs_res,rel_res,diag_spread,sin_rel_res'
     format=""
-    if [[ "${in_header}" == "${current_header}" ]]; then
+    if [[ "${in_header}" == "${current_csv_header}" ]]; then
       format="current"
     elif [[ "${in_header}" == "${legacy_header}" ]]; then
       format="legacy"
     else
       echo "error: unsupported benchmark CSV header in ${in_csv}" >&2
       echo "expected one of:" >&2
-      echo "  ${current_header}" >&2
+      echo "  ${current_csv_header}" >&2
       echo "  ${legacy_header}" >&2
       exit 1
     fi
@@ -75,11 +75,11 @@ case "${cmd}" in
     if [[ ! -f "${history_csv}" ]]; then
       printf '%s\n' "${history_header}" > "${history_csv}"
     else
-      current_header="$(head -n 1 "${history_csv}")"
-      if [[ "${current_header}" != "${history_header}" ]]; then
+      existing_history_header="$(head -n 1 "${history_csv}")"
+      if [[ "${existing_history_header}" != "${history_header}" ]]; then
         echo "error: history CSV header mismatch in ${history_csv}" >&2
         echo "expected: ${history_header}" >&2
-        echo "actual:   ${current_header}" >&2
+        echo "actual:   ${existing_history_header}" >&2
         exit 1
       fi
     fi
@@ -97,13 +97,21 @@ case "${cmd}" in
       ' "${in_csv}" >> "${history_csv}"
     else
       # legacy local format: exec column appears before freq/abs/rel and
-      # timestamp is in unix-ms form; normalize into canonical field order.
+      # timestamp is in unix-ms form; normalize both field order and timestamp.
       awk -F, -v ts="${ingested_at}" -v sha="${git_sha}" -v src="${source_name}" '
+        function iso_from_unix_ms(ms, sec, cmd, out) {
+          sec = int(ms / 1000)
+          cmd = "date -u -d @" sec " +%Y-%m-%dT%H:%M:%SZ"
+          cmd | getline out
+          close(cmd)
+          return out
+        }
         NR == 1 { next }
         NF > 1 {
+          iso_ts = iso_from_unix_ms($1 + 0)
           printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
             ts, sha, src,
-            $1, $2, $3, $4, $5, $6, $7,
+            iso_ts, $2, $3, $4, $5, $6, $7,
             $8, $9, $11, $12, $13, $10, $14, $15
         }
       ' "${in_csv}" >> "${history_csv}"

--- a/scripts/pi-benchmark-history.sh
+++ b/scripts/pi-benchmark-history.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pi-benchmark-history.sh append <benchmark.csv> [history.csv]
+  scripts/pi-benchmark-history.sh trend <history.csv>
+
+Commands:
+  append  Append one benchmark CSV into a persistent history CSV.
+          If history.csv is omitted, defaults to benchmarks/pi-benchmark-history.csv.
+
+  trend   Summarize trend per (deck, solver, exec_mode) from history CSV snapshots.
+          Output columns:
+            deck, solver, exec_mode, snapshots,
+            first_avg_ms, latest_avg_ms, delta_pct,
+            latest_timestamp_utc, latest_git_sha, latest_source_csv
+
+History CSV schema:
+  ingested_at_utc,git_sha,source_csv,<original benchmark CSV columns...>
+
+Notes:
+  - Only rows with status=ok are used by trend.
+  - The benchmark CSV must be produced by scripts/pi-remote-benchmark.sh.
+  - Supports both current header (`timestamp_utc,...,exec_mode,...`) and
+    legacy local header (`timestamp_unix_ms,...,exec,...`).
+EOF
+}
+
+default_history="benchmarks/pi-benchmark-history.csv"
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+cmd="$1"
+shift
+
+case "${cmd}" in
+  append)
+    if [[ $# -lt 1 || $# -gt 2 ]]; then
+      usage >&2
+      exit 1
+    fi
+
+    in_csv="$1"
+    history_csv="${2:-${default_history}}"
+
+    if [[ ! -f "${in_csv}" ]]; then
+      echo "error: benchmark CSV not found: ${in_csv}" >&2
+      exit 1
+    fi
+
+    in_header="$(head -n 1 "${in_csv}")"
+    current_header='timestamp_utc,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,freq_mhz,abs_res,rel_res,exec_mode,diag_spread,sin_rel_res'
+    legacy_header='timestamp_unix_ms,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,exec,freq_mhz,abs_res,rel_res,diag_spread,sin_rel_res'
+    format=""
+    if [[ "${in_header}" == "${current_header}" ]]; then
+      format="current"
+    elif [[ "${in_header}" == "${legacy_header}" ]]; then
+      format="legacy"
+    else
+      echo "error: unsupported benchmark CSV header in ${in_csv}" >&2
+      echo "expected one of:" >&2
+      echo "  ${current_header}" >&2
+      echo "  ${legacy_header}" >&2
+      exit 1
+    fi
+
+    mkdir -p "$(dirname "${history_csv}")"
+
+    history_header='ingested_at_utc,git_sha,source_csv,timestamp_utc,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,freq_mhz,abs_res,rel_res,exec_mode,diag_spread,sin_rel_res'
+    if [[ ! -f "${history_csv}" ]]; then
+      printf '%s\n' "${history_header}" > "${history_csv}"
+    else
+      current_header="$(head -n 1 "${history_csv}")"
+      if [[ "${current_header}" != "${history_header}" ]]; then
+        echo "error: history CSV header mismatch in ${history_csv}" >&2
+        echo "expected: ${history_header}" >&2
+        echo "actual:   ${current_header}" >&2
+        exit 1
+      fi
+    fi
+
+    ingested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    git_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    source_name="${in_csv}"
+
+    if [[ "${format}" == "current" ]]; then
+      awk -F, -v ts="${ingested_at}" -v sha="${git_sha}" -v src="${source_name}" '
+        NR == 1 { next }
+        NF > 1 {
+          printf "%s,%s,%s,%s\n", ts, sha, src, $0
+        }
+      ' "${in_csv}" >> "${history_csv}"
+    else
+      # legacy local format: exec column appears before freq/abs/rel and
+      # timestamp is in unix-ms form; normalize into canonical field order.
+      awk -F, -v ts="${ingested_at}" -v sha="${git_sha}" -v src="${source_name}" '
+        NR == 1 { next }
+        NF > 1 {
+          printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+            ts, sha, src,
+            $1, $2, $3, $4, $5, $6, $7,
+            $8, $9, $11, $12, $13, $10, $14, $15
+        }
+      ' "${in_csv}" >> "${history_csv}"
+    fi
+
+    echo "Appended benchmark rows from ${in_csv} to ${history_csv}"
+    ;;
+
+  trend)
+    if [[ $# -ne 1 ]]; then
+      usage >&2
+      exit 1
+    fi
+
+    history_csv="$1"
+    if [[ ! -f "${history_csv}" ]]; then
+      echo "error: history CSV not found: ${history_csv}" >&2
+      exit 1
+    fi
+
+    if ! head -n 1 "${history_csv}" | grep -q '^ingested_at_utc,git_sha,source_csv,timestamp_utc,target,deck,solver,run,status,elapsed_ms,diag_mode,pulse_rhs,freq_mhz,abs_res,rel_res,exec_mode,diag_spread,sin_rel_res$'; then
+      echo "error: unsupported history CSV header in ${history_csv}" >&2
+      exit 1
+    fi
+
+    tmp_agg="$(mktemp)"
+    trap 'rm -f "${tmp_agg}"' EXIT
+
+    # Aggregate one snapshot row per (source_csv, git_sha, deck, solver, exec_mode).
+    awk -F, '
+      NR == 1 { next }
+      $9 != "ok" { next }
+      {
+        snapshot = $3 "|" $2 "|" $6 "|" $7 "|" $16
+        count[snapshot] += 1
+        sum[snapshot] += $10
+        if (!(snapshot in min) || $10 < min[snapshot]) {
+          min[snapshot] = $10
+        }
+        if (!(snapshot in max) || $10 > max[snapshot]) {
+          max[snapshot] = $10
+        }
+        if (!(snapshot in latest_ts) || $4 > latest_ts[snapshot]) {
+          latest_ts[snapshot] = $4
+        }
+      }
+      END {
+        for (k in count) {
+          split(k, p, "|")
+          avg = sum[k] / count[k]
+          printf "%s\t%s\t%s\t%s\t%s\t%.6f\t%s\t%s\n", p[1], p[2], p[3], p[4], p[5], avg, latest_ts[k], k
+        }
+      }
+    ' "${history_csv}" | sort -t $'\t' -k3,3 -k4,4 -k5,5 -k7,7 > "${tmp_agg}"
+
+    {
+      echo "deck,solver,exec_mode,snapshots,first_avg_ms,latest_avg_ms,delta_pct,latest_timestamp_utc,latest_git_sha,latest_source_csv"
+      awk -F'\t' '
+        {
+          src = $1
+          sha = $2
+          deck = $3
+          solver = $4
+          exec_mode = $5
+          avg = $6 + 0.0
+          ts = $7
+          combo = deck "|" solver "|" exec_mode
+
+          if (!(combo in seen)) {
+            seen[combo] = 1
+            snaps[combo] = 1
+            first[combo] = avg
+            latest[combo] = avg
+            latest_ts[combo] = ts
+            latest_sha[combo] = sha
+            latest_src[combo] = src
+            next
+          }
+
+          snaps[combo] += 1
+          latest[combo] = avg
+          latest_ts[combo] = ts
+          latest_sha[combo] = sha
+          latest_src[combo] = src
+        }
+        END {
+          for (combo in seen) {
+            split(combo, p, "|")
+            delta = "n/a"
+            if (first[combo] != 0) {
+              delta = sprintf("%+.2f%%", ((latest[combo] - first[combo]) / first[combo]) * 100.0)
+            }
+            printf "%s,%s,%s,%d,%.3f,%.3f,%s,%s,%s,%s\n", p[1], p[2], p[3], snaps[combo], first[combo], latest[combo], delta, latest_ts[combo], latest_sha[combo], latest_src[combo]
+          }
+        }
+      ' "${tmp_agg}" | sort
+    }
+    ;;
+
+  *)
+    echo "error: unknown command: ${cmd}" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/pi-remote-benchmark.sh
+++ b/scripts/pi-remote-benchmark.sh
@@ -31,6 +31,8 @@ Environment overrides:
                        single-thread baseline while still using --exec cpu.
   FNEC_BENCH_RUNS      Number of repeated runs per deck+solver (default: 3)
   FNEC_BENCH_OUT       Output CSV path (default: tmp/pi-benchmark-<UTC timestamp>.csv)
+  FNEC_BENCH_HISTORY   Optional history CSV path. When set, appends FNEC_BENCH_OUT
+                       into this persistent history via scripts/pi-benchmark-history.sh.
 EOF
 }
 
@@ -53,6 +55,7 @@ bench_solvers="${FNEC_BENCH_SOLVERS:-hallen pulse sinusoidal}"
 bench_execs="${FNEC_BENCH_EXECS:-cpu-single cpu}"
 bench_runs="${FNEC_BENCH_RUNS:-3}"
 out_csv="${FNEC_BENCH_OUT:-tmp/pi-benchmark-$(date -u +%Y%m%dT%H%M%SZ).csv}"
+history_csv="${FNEC_BENCH_HISTORY:-}"
 out_dir="$(dirname "${out_csv}")"
 
 if [[ -z "${ssh_target}" ]]; then
@@ -221,3 +224,13 @@ awk -F, '
 ' "${out_csv}"
 
 echo "CSV written: ${out_csv}"
+
+if [[ -n "${history_csv}" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  history_script="${script_dir}/pi-benchmark-history.sh"
+  if [[ ! -x "${history_script}" ]]; then
+    echo "warning: history append requested but helper is not executable: ${history_script}" >&2
+  else
+    "${history_script}" append "${out_csv}" "${history_csv}"
+  fi
+fi


### PR DESCRIPTION
## Summary\n- add scripts/pi-benchmark-history.sh with append and trend subcommands\n- support both current and legacy benchmark CSV headers during history ingestion\n- add optional FNEC_BENCH_HISTORY auto-append hook in scripts/pi-remote-benchmark.sh\n- mark backlog item "Benchmark history trend capture" complete and document usage in README/docs/benchmarks\n\n## Validation\n- bash -n scripts/pi-benchmark-history.sh scripts/pi-remote-benchmark.sh\n- bash scripts/pi-benchmark-history.sh --help\n- bash scripts/pi-remote-benchmark.sh --help | rg -n "FNEC_BENCH_HISTORY|FNEC_BENCH_EXECS|Usage"\n- bash scripts/pi-benchmark-history.sh append tmp/local-baseline-20260427T111026Z.csv <tmp-history>\n- bash scripts/pi-benchmark-history.sh append tmp/t480-baseline-20260427T101204Z.csv <tmp-history>\n- bash scripts/pi-benchmark-history.sh trend <tmp-history>\n- full pre-commit hook suite (cargo test --workspace + docs checks + cargo audit) passed during commit\n