### PR TITLE
docs: resolve FR-004 scope and track markdown project I/O

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -113,8 +113,15 @@ last_updated: 2026-04-30
 	Resolution criteria: repeated benchmark runs can be appended to a persistent history format and summarized by a tracked script without relying on ad hoc files in `tmp/`.
 	- 2026-05-30 resolution: added `scripts/pi-benchmark-history.sh` with `append` and `trend` commands, using tracked history schema `benchmarks/pi-benchmark-history.csv` (`ingested_at_utc`, `git_sha`, `source_csv`, plus benchmark row fields). `scripts/pi-remote-benchmark.sh` now supports optional `FNEC_BENCH_HISTORY` to auto-append each run CSV to history, and trend summaries are emitted by `scripts/pi-benchmark-history.sh trend <history.csv>`.
 
-- [ ] **FR-004 project format scope (`nec_project`) / Owner: Project+Core APIs / Target: Phase 3**
+- [x] **FR-004 project format scope (`nec_project`) / Owner: Project+Core APIs / Target: Phase 3**
 	Resolution criteria: `nec_project` has a documented crate scope covering Markdown project structure, run metadata, and result-storage responsibilities, and roadmap/backlog work items explicitly track Markdown import/export delivery.
+	- 2026-05-30 resolution: scope is now explicitly documented in `docs/project-format.md` and crate-level docs in `crates/nec_project/src/lib.rs` (project structure boundary, run metadata, and result-storage ownership). Markdown delivery is now explicitly tracked by backlog items FR-004A/FR-004B below and roadmap gap `GAP-015`.
+
+- [ ] **FR-004A Markdown project import path (`nec_project`) / Owner: Project+Core APIs / Target: Phase 6+**
+	Resolution criteria: implement Markdown project import (`.md` with frontmatter + fenced blocks) into `nec_project::ProjectFile`, add parser contract tests, and document accepted Markdown schema in `docs/project-format.md`.
+
+- [ ] **FR-004B Markdown project export path (`nec_project`) / Owner: Project+Core APIs / Target: Phase 6+**
+	Resolution criteria: implement deterministic Markdown export from `nec_project::ProjectFile` (stable field ordering + formatting), add round-trip tests (`markdown -> ProjectFile -> markdown` stability contracts), and document CLI/API entry points.
 
 ## Parity-driven backlog items
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -15,6 +15,27 @@ Project files are the primary mechanism for storing per-project solver
 configuration and named run variants.  The CLI will load a project file when
 invoked with a `.fnecproj` path instead of a `.nec` deck path.
 
+## `nec_project` scope boundary (FR-004)
+
+The `nec_project` crate owns project-container semantics, not solver math.
+
+In scope:
+
+- project structure schema (currently TOML `.fnecproj`, with Markdown import/export tracked for future delivery)
+- run metadata (`timestamp`, solver snapshot, and compact result summaries)
+- result-storage conventions for repeatable project workflows (`history` ordering and query API)
+
+Out of scope:
+
+- NEC card parsing/geometry semantics (owned by `nec_parser`/`nec_model`)
+- impedance/pattern/current math kernels (owned by `nec_solver`/`nec_accel`)
+- renderer/report formatting contracts (owned by `nec_report`)
+
+Markdown project import/export delivery tracking:
+
+- Backlog: `FR-004A` (Markdown import) and `FR-004B` (Markdown export) in `docs/backlog.md`
+- Roadmap gap tracking: `GAP-015` in `docs/roadmap.md`
+
 ## File extension
 
 `.fnecproj`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -299,6 +299,7 @@ Execution order recommendation: PH6-CHK-001 → PH6-CHK-002 → PH6-CHK-003 → 
 | GAP-012 | AutoEZ-class automation acceptance | **HIGH** | Phase 3 end | Automation | Acceptance checklist covers variable sweeps, resonance targeting, convergence studies, and matching-network helpers with at least one documented end-to-end workflow per class. |
 | GAP-013 | NEC-5-informed validation matrix | **HIGH** | Phase 2 end | Validation | Validation-manual-informed case matrix is maintained with owner, corpus mapping, and tolerance-gated status for each in-scope class. |
 | GAP-014 | External optimizer-loop compatibility | **MEDIUM** | Phase 3 end | Automation+CLI | Deterministic objective-evaluation CLI/API contract is documented and at least one xnec2c-optimize-style loop is reproduced end-to-end with stable machine-readable outputs. |
+| GAP-015 | Markdown project import/export delivery track | **MEDIUM** | Phase 6+ | Project+Core APIs | `nec_project` supports deterministic Markdown project import and export (in addition to TOML), with documented schema, round-trip stability tests, and explicit CLI/API entry points. |
 
 ## Competitive parity work items
 


### PR DESCRIPTION
## Summary
- mark FR-004 (project format scope) as resolved in backlog with explicit resolution note
- document `nec_project` scope boundary (project structure, run metadata, result-storage ownership) in `docs/project-format.md`
- add explicit roadmap tracking for Markdown project import/export delivery via `GAP-015`
- add follow-up backlog items `FR-004A` (Markdown import) and `FR-004B` (Markdown export)

## Why
FR-004 required two things: a documented `nec_project` scope and explicit tracking of Markdown project import/export delivery. This PR closes the scope-definition item while creating concrete roadmap/backlog tracking for the Markdown I/O delivery work.

## Validation
- `./scripts/validate-doc-frontmatter.sh`
- reviewed doc-only diff for `docs/backlog.md`, `docs/project-format.md`, `docs/roadmap.md`
