### PR TITLE
feat: FR-004A add markdown project import for nec_project

### DIFF
--- a/crates/nec_project/src/lib.rs
+++ b/crates/nec_project/src/lib.rs
@@ -116,6 +116,8 @@ pub enum ProjectError {
     DeserialiseError(toml::de::Error),
     /// The file declares an unsupported format version.
     UnsupportedVersion(u32),
+    /// Markdown import parsing failed.
+    MarkdownParseError(String),
 }
 
 impl std::fmt::Display for ProjectError {
@@ -128,6 +130,9 @@ impl std::fmt::Display for ProjectError {
                     f,
                     "unsupported project file version {v} (expected {PROJECT_FILE_VERSION})"
                 )
+            }
+            ProjectError::MarkdownParseError(msg) => {
+                write!(f, "project markdown parse error: {msg}")
             }
         }
     }
@@ -165,6 +170,110 @@ impl ProjectFile {
         Ok(project)
     }
 
+    /// Deserialise a project from a Markdown manifest.
+    ///
+    /// Accepted format:
+    /// - YAML frontmatter delimited by `---` with keys:
+    ///   - `format: fnec-project-markdown`
+    ///   - `version: 1`
+    /// - One fenced TOML block tagged as a project payload:
+    ///   - ````toml project````
+    ///
+    /// The fenced TOML payload must be a valid [`ProjectFile`] document.
+    /// Frontmatter `version` must match payload `version`.
+    pub fn from_markdown(s: &str) -> Result<Self, ProjectError> {
+        let lines: Vec<&str> = s.lines().collect();
+        if lines.len() < 3 || lines[0].trim() != "---" {
+            return Err(ProjectError::MarkdownParseError(
+                "missing YAML frontmatter opening delimiter".to_string(),
+            ));
+        }
+
+        let mut fm_end = None;
+        for (i, line) in lines.iter().enumerate().skip(1) {
+            if line.trim() == "---" {
+                fm_end = Some(i);
+                break;
+            }
+        }
+        let fm_end = fm_end.ok_or_else(|| {
+            ProjectError::MarkdownParseError(
+                "missing YAML frontmatter closing delimiter".to_string(),
+            )
+        })?;
+
+        let mut format_value: Option<String> = None;
+        let mut version_value: Option<u32> = None;
+        for line in lines.iter().take(fm_end).skip(1) {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            let (k, v) = trimmed.split_once(':').ok_or_else(|| {
+                ProjectError::MarkdownParseError(format!("invalid frontmatter line: {trimmed}"))
+            })?;
+            let key = k.trim();
+            let value = strip_yaml_scalar(v.trim());
+            match key {
+                "format" => format_value = Some(value.to_string()),
+                "version" => {
+                    let parsed = value.parse::<u32>().map_err(|_| {
+                        ProjectError::MarkdownParseError(
+                            "frontmatter version must be an integer".to_string(),
+                        )
+                    })?;
+                    version_value = Some(parsed);
+                }
+                _ => {}
+            }
+        }
+
+        if format_value.as_deref() != Some("fnec-project-markdown") {
+            return Err(ProjectError::MarkdownParseError(
+                "frontmatter format must be fnec-project-markdown".to_string(),
+            ));
+        }
+        let frontmatter_version = version_value.ok_or_else(|| {
+            ProjectError::MarkdownParseError("frontmatter version is required".to_string())
+        })?;
+
+        let mut in_project_toml = false;
+        let mut project_toml = String::new();
+        for line in lines.iter().skip(fm_end + 1) {
+            let trimmed = line.trim();
+            if !in_project_toml {
+                if let Some(rest) = trimmed.strip_prefix("```") {
+                    let info = rest.trim();
+                    if info.starts_with("toml") && info.contains("project") {
+                        in_project_toml = true;
+                    }
+                }
+                continue;
+            }
+
+            if trimmed == "```" {
+                break;
+            }
+            project_toml.push_str(line);
+            project_toml.push('\n');
+        }
+
+        if project_toml.trim().is_empty() {
+            return Err(ProjectError::MarkdownParseError(
+                "missing fenced TOML project block (```toml project)".to_string(),
+            ));
+        }
+
+        let project = ProjectFile::from_toml(&project_toml)?;
+        if project.version != frontmatter_version {
+            return Err(ProjectError::MarkdownParseError(format!(
+                "frontmatter version {} does not match project payload version {}",
+                frontmatter_version, project.version
+            )));
+        }
+        Ok(project)
+    }
+
     // --- run-history query API -------------------------------------------
 
     /// Number of completed runs recorded in the history.
@@ -182,6 +291,18 @@ impl ProjectFile {
     pub fn run_by_index(&self, index: usize) -> Option<&RunRecord> {
         self.history.run_by_index(index)
     }
+}
+
+fn strip_yaml_scalar(value: &str) -> &str {
+    if value.len() >= 2 {
+        let bytes = value.as_bytes();
+        if (bytes[0] == b'"' && bytes[value.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[value.len() - 1] == b'\'')
+        {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
 }
 
 // ---------------------------------------------------------------------------
@@ -400,6 +521,13 @@ pulse_rhs = "auto"
             msg.contains(&PROJECT_FILE_VERSION.to_string()),
             "display should mention the expected version"
         );
+    }
+
+    #[test]
+    fn markdown_parse_error_display_includes_reason() {
+        let msg = ProjectError::MarkdownParseError("bad schema".to_string()).to_string();
+        assert!(msg.contains("markdown parse error"));
+        assert!(msg.contains("bad schema"));
     }
 
     // ── RunHistory API ───────────────────────────────────────────────────────

--- a/crates/nec_project/tests/project_roundtrip.rs
+++ b/crates/nec_project/tests/project_roundtrip.rs
@@ -271,3 +271,94 @@ fn history_empty_omitted_from_toml() {
     let toml_str = project.to_toml().unwrap();
     assert!(!toml_str.contains("history"));
 }
+
+// --- markdown import contract tests ----------------------------------------
+
+#[test]
+fn markdown_import_minimal_project_succeeds() {
+    let markdown = r#"---
+format: fnec-project-markdown
+version: 1
+title: demo
+---
+
+# Demo project
+
+```toml project
+version = 1
+name = "md-import"
+deck_path = "corpus/dipole-freesp-51seg.nec"
+
+[solver]
+mode = "hallen"
+pulse_rhs = "auto"
+```
+"#;
+
+    let loaded = ProjectFile::from_markdown(markdown).unwrap();
+    assert_eq!(loaded.version, 1);
+    assert_eq!(loaded.name, "md-import");
+    assert_eq!(
+        loaded.deck_path,
+        PathBuf::from("corpus/dipole-freesp-51seg.nec")
+    );
+    assert_eq!(loaded.solver.mode, "hallen");
+    assert!(loaded.runs.is_empty());
+}
+
+#[test]
+fn markdown_import_requires_frontmatter() {
+    let markdown = r#"
+# Missing frontmatter
+
+```toml project
+version = 1
+name = "bad"
+deck_path = "corpus/dipole-freesp-51seg.nec"
+[solver]
+mode = "hallen"
+pulse_rhs = "auto"
+```
+"#;
+
+    let err = ProjectFile::from_markdown(markdown).unwrap_err();
+    assert!(matches!(err, ProjectError::MarkdownParseError(_)));
+}
+
+#[test]
+fn markdown_import_requires_project_fence() {
+    let markdown = r#"---
+format: fnec-project-markdown
+version: 1
+---
+
+```toml
+name = "not-a-project-fence"
+```
+"#;
+
+    let err = ProjectFile::from_markdown(markdown).unwrap_err();
+    assert!(matches!(err, ProjectError::MarkdownParseError(_)));
+}
+
+#[test]
+fn markdown_import_frontmatter_and_payload_version_must_match() {
+    let markdown = r#"---
+format: fnec-project-markdown
+version: 2
+---
+
+```toml project
+version = 1
+name = "mismatch"
+deck_path = "corpus/dipole-freesp-51seg.nec"
+
+[solver]
+mode = "hallen"
+pulse_rhs = "auto"
+```
+"#;
+
+    let err = ProjectFile::from_markdown(markdown).unwrap_err();
+    assert!(matches!(err, ProjectError::MarkdownParseError(_)));
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -117,8 +117,9 @@ last_updated: 2026-04-30
 	Resolution criteria: `nec_project` has a documented crate scope covering Markdown project structure, run metadata, and result-storage responsibilities, and roadmap/backlog work items explicitly track Markdown import/export delivery.
 	- 2026-05-30 resolution: scope is now explicitly documented in `docs/project-format.md` and crate-level docs in `crates/nec_project/src/lib.rs` (project structure boundary, run metadata, and result-storage ownership). Markdown delivery is now explicitly tracked by backlog items FR-004A/FR-004B below and roadmap gap `GAP-015`.
 
-- [ ] **FR-004A Markdown project import path (`nec_project`) / Owner: Project+Core APIs / Target: Phase 6+**
+- [x] **FR-004A Markdown project import path (`nec_project`) / Owner: Project+Core APIs / Target: Phase 6+**
 	Resolution criteria: implement Markdown project import (`.md` with frontmatter + fenced blocks) into `nec_project::ProjectFile`, add parser contract tests, and document accepted Markdown schema in `docs/project-format.md`.
+	- 2026-05-30 resolution: implemented `ProjectFile::from_markdown(...)` in `crates/nec_project/src/lib.rs` with frontmatter validation (`format: fnec-project-markdown`, `version`) plus fenced payload parsing (` ```toml project ` block). Added parser contract coverage in `crates/nec_project/tests/project_roundtrip.rs` (success path + required-frontmatter + required-project-fence + version mismatch). Documented accepted Markdown import schema and example in `docs/project-format.md`.
 
 - [ ] **FR-004B Markdown project export path (`nec_project`) / Owner: Project+Core APIs / Target: Phase 6+**
 	Resolution criteria: implement deterministic Markdown export from `nec_project::ProjectFile` (stable field ordering + formatting), add round-trip tests (`markdown -> ProjectFile -> markdown` stability contracts), and document CLI/API entry points.

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -40,6 +40,48 @@ Markdown project import/export delivery tracking:
 
 `.fnecproj`
 
+## Markdown import schema (`FR-004A`)
+
+`nec_project::ProjectFile::from_markdown(...)` accepts a Markdown manifest with
+frontmatter and a fenced TOML project payload.
+
+Required frontmatter keys:
+
+- `format: fnec-project-markdown`
+- `version: 1`
+
+Required fenced block:
+
+- ````toml project```` containing the same TOML schema as `.fnecproj`
+
+Import contract notes:
+
+- frontmatter `version` must match payload `version`
+- only the `toml project` fenced block is consumed as project payload
+- the payload is validated by the same version guard as `ProjectFile::from_toml`
+
+Example:
+
+````markdown
+---
+format: fnec-project-markdown
+version: 1
+title: half-wave dipole study
+---
+
+# Half-wave dipole project
+
+```toml project
+version = 1
+name = "dipole-study"
+deck_path = "corpus/dipole-freesp-51seg.nec"
+
+[solver]
+mode = "hallen"
+pulse_rhs = "auto"
+```
+````
+
 ## Top-level fields
 
 | Field | Type | Required | Description |


### PR DESCRIPTION
## Summary
- implement `ProjectFile::from_markdown(...)` in `crates/nec_project/src/lib.rs`
- add Markdown import parse errors (`ProjectError::MarkdownParseError`) and clear error messages
- validate frontmatter contract (`format: fnec-project-markdown`, `version`) and fenced payload contract (```toml project)
- add parser contract tests in `crates/nec_project/tests/project_roundtrip.rs` (success + required frontmatter + required project fence + version mismatch)
- document accepted Markdown import schema and example in `docs/project-format.md`
- mark backlog item FR-004A complete with resolution notes in `docs/backlog.md`

## Validation
- `cargo test -p nec_project`
- `./scripts/validate-doc-frontmatter.sh`
