### PR TITLE
docs: close PAR-007 AutoEZ procurement gate

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -228,8 +228,9 @@ last_updated: 2026-04-30
 - [ ] **PAR-006 / necpp-style embeddability and diagnostics / Owner: Core APIs / Target: Phase 3 / Issue: #19**
 	Resolution criteria: stable automation API surface documented; binding strategy decision recorded; geometry diagnostics catch at least the known invalid/fragile model classes with actionable errors.
 
-- [ ] **PAR-007 / AutoEZ procurement gate / Owner: Product / Target: Phase 3 start / Issue: #20**
+- [x] **PAR-007 / AutoEZ procurement gate / Owner: Product / Target: Phase 3 start / Issue: #20**
 	Resolution criteria: go/no-go decision recorded with evidence from open-tool and documentation benchmarking; if go, purchase and benchmark plan logged; if no-go, defer rationale and next review date logged.
+	- 2026-05-30 resolution: **no-go for now** recorded in `docs/roadmap.md` section "Commercial benchmark acquisition policy" with rationale (public/open-tool benchmarking remains sufficient) and explicit next review date `2026-09-30`.
 
 - [x] **PAR-008 / NEC-5 validation-manual coverage matrix / Owner: Solver+Validation / Target: Phase 2 / Issue: #21**
 	Resolution: Completed 2026-04-26 for coverage-matrix scope. NEC-5 Validation Manual scenario classes are mapped to current fnec-rust in-scope equivalents; mapped in-scope classes have reproducible corpus tests with explicit tolerance gating; known out-of-scope classes are documented with rationale and phase deferral. Matrix source: `docs/corpus-validation-strategy.md` section "NEC-5 validation coverage matrix (PAR-008)".

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -324,6 +324,7 @@ Execution order recommendation: PH6-CHK-001 → PH6-CHK-002 → PH6-CHK-003 → 
 - Revisit AutoEZ acquisition when Phase 3 work begins on automation parity: variable sweeps, resonance targeting, convergence studies, matching-network helpers, and repeated-analysis orchestration.
 - Purchase becomes justified when hands-on validation is needed for UX details that public documentation cannot settle reliably, especially around multi-step study workflows and format-translation behavior.
 - Until then, treat AutoEZ as a design benchmark and workflow target, not as a required reference engine for numerical validation.
+- Next review date: **2026-09-30** (or earlier if a Phase 3 parity gate requires hands-on AutoEZ workflow validation).
 
 ## Gap-driven milestone blockers (Phase gates)
 


### PR DESCRIPTION
## Summary
- close `PAR-007` in backlog as no-go for current AutoEZ procurement cycle
- add the missing explicit next review date in `docs/roadmap.md` commercial benchmark acquisition policy

## Why
`PAR-007` resolution criteria required two things for a no-go path:
1. documented defer rationale
2. logged next review date

The rationale already existed, but the explicit review date was missing. This PR fills that gap and reconciles backlog status accordingly.

## Validation
- `./scripts/validate-doc-frontmatter.sh`
