### PR TITLE
test: batch PAR-011 drop-in cwd side-effect contracts

### DIFF
--- a/apps/nec-cli/tests/exec_modes.rs
+++ b/apps/nec-cli/tests/exec_modes.rs
@@ -544,3 +544,177 @@ fn dropin_alias_missing_deck_does_not_create_files_in_working_directory() {
         "drop-in alias missing-deck run must not create files in working directory; got: {after_entries:?}"
     );
 }
+
+#[test]
+fn fournec2_alias_run_does_not_create_files_in_working_directory() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("4nec2-kernel");
+    let sandbox = create_sandbox_dir("dropin-cwd-4nec2-sandbox");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+    let _sandbox_cleanup = TempPathCleanup::dir(sandbox.clone());
+
+    let before_entries: Vec<PathBuf> = fs::read_dir(&sandbox)
+        .expect("failed to read 4nec2 sandbox before run")
+        .map(|entry| {
+            entry
+                .expect("failed to read 4nec2 sandbox entry before run")
+                .path()
+        })
+        .collect();
+    assert!(
+        before_entries.is_empty(),
+        "expected empty 4nec2 sandbox before run, got: {before_entries:?}"
+    );
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .env_remove("FNEC_ACCEL_STUB_GPU")
+        .arg(&deck_path)
+        .current_dir(&sandbox)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to run 4nec2 alias '{}' for file-side-effect contract test: {e}",
+                alias.display()
+            )
+        });
+
+    assert!(
+        output.status.success(),
+        "4nec2 alias run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let after_entries: Vec<PathBuf> = fs::read_dir(&sandbox)
+        .expect("failed to read 4nec2 sandbox after run")
+        .map(|entry| {
+            entry
+                .expect("failed to read 4nec2 sandbox entry after run")
+                .path()
+        })
+        .collect();
+
+    assert!(
+        after_entries.is_empty(),
+        "4nec2 alias run must not create files in working directory; got: {after_entries:?}"
+    );
+}
+
+#[test]
+fn dropin_alias_explicit_exec_cpu_run_does_not_create_files_in_working_directory() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("nec2dxs3k0");
+    let sandbox = create_sandbox_dir("dropin-cwd-explicit-cpu-sandbox");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+    let _sandbox_cleanup = TempPathCleanup::dir(sandbox.clone());
+
+    let before_entries: Vec<PathBuf> = fs::read_dir(&sandbox)
+        .expect("failed to read explicit-exec sandbox before run")
+        .map(|entry| {
+            entry
+                .expect("failed to read explicit-exec sandbox entry before run")
+                .path()
+        })
+        .collect();
+    assert!(
+        before_entries.is_empty(),
+        "expected empty explicit-exec sandbox before run, got: {before_entries:?}"
+    );
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("cpu")
+        .env_remove("FNEC_ACCEL_STUB_GPU")
+        .arg(&deck_path)
+        .current_dir(&sandbox)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to run drop-in alias '{}' with explicit exec for side-effect contract test: {e}",
+                alias.display()
+            )
+        });
+
+    assert!(
+        output.status.success(),
+        "drop-in alias explicit-exec run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let after_entries: Vec<PathBuf> = fs::read_dir(&sandbox)
+        .expect("failed to read explicit-exec sandbox after run")
+        .map(|entry| {
+            entry
+                .expect("failed to read explicit-exec sandbox entry after run")
+                .path()
+        })
+        .collect();
+
+    assert!(
+        after_entries.is_empty(),
+        "drop-in alias explicit-exec run must not create files in working directory; got: {after_entries:?}"
+    );
+}
+
+#[test]
+fn dropin_alias_explicit_exec_cpu_missing_deck_does_not_create_files_in_working_directory() {
+    let alias = create_dropin_alias("nec2dxs3k0");
+    let sandbox = create_sandbox_dir("dropin-cwd-explicit-cpu-missing-sandbox");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+    let _sandbox_cleanup = TempPathCleanup::dir(sandbox.clone());
+
+    let bogus_path = test_tmp_dir().join("fnec-dropin-explicit-missing-cwd.nec");
+    let _ = fs::remove_file(&bogus_path);
+
+    let before_entries: Vec<PathBuf> = fs::read_dir(&sandbox)
+        .expect("failed to read explicit-exec missing-deck sandbox before run")
+        .map(|entry| {
+            entry
+                .expect("failed to read explicit-exec missing-deck sandbox entry before run")
+                .path()
+        })
+        .collect();
+    assert!(
+        before_entries.is_empty(),
+        "expected empty explicit-exec missing-deck sandbox before run, got: {before_entries:?}"
+    );
+
+    let output = Command::new(&alias)
+        .arg("--exec")
+        .arg("cpu")
+        .arg(&bogus_path)
+        .current_dir(&sandbox)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to run drop-in alias '{}' with explicit exec for missing-deck side-effect contract test: {e}",
+                alias.display()
+            )
+        });
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "missing deck under explicit-exec drop-in alias must exit with code 1; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let after_entries: Vec<PathBuf> = fs::read_dir(&sandbox)
+        .expect("failed to read explicit-exec missing-deck sandbox after run")
+        .map(|entry| {
+            entry
+                .expect("failed to read explicit-exec missing-deck sandbox entry after run")
+                .path()
+        })
+        .collect();
+
+    assert!(
+        after_entries.is_empty(),
+        "drop-in alias explicit-exec missing-deck run must not create files in working directory; got: {after_entries:?}"
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -259,6 +259,7 @@ last_updated: 2026-05-30
 	- 2026-05-30 progress: added drop-in alias runtime-contract coverage in `apps/nec-cli/tests/exec_modes.rs` to lock stdout-report/stderr-warning separation and missing-deck exit-code behavior under `nec2dxs*` aliases; moved the touched CLI tests to repo-local `.tmp/nec-cli-tests` artifacts instead of OS temp paths.
 	- 2026-05-30 progress: added drop-in alias file-side-effect contract coverage in `apps/nec-cli/tests/exec_modes.rs` (`dropin_alias_run_does_not_create_files_in_working_directory`) to lock that current filename-steered scaffold runs do not create working-directory artifacts.
 	- 2026-05-30 progress: extended drop-in alias file-side-effect coverage with error-path validation in `apps/nec-cli/tests/exec_modes.rs` (`dropin_alias_missing_deck_does_not_create_files_in_working_directory`) to lock that missing-deck failures also avoid creating working-directory artifacts.
+	- 2026-05-30 progress: bundled additional drop-in side-effect runtime contracts in `apps/nec-cli/tests/exec_modes.rs` to reduce test-PR fragmentation, covering `4nec2` alias success-path cwd invariants plus explicit `--exec=cpu` success and missing-deck cwd invariants.
 	- 2026-04-26 scope decision: compatibility harness skeleton work is postponed for now (option 3 deferred).
 	- Discovery checklist (capture before implementation starts):
 		- Binary-name matrix: confirm exact accepted executable names/casing and segment-limit mapping (`nec2dxs500.exe`, `nec2dxs1K5.exe`, `nec2dxs3k0.exe`, `nec2dxs5k0.exe`, `nec2dxs8k0.exe`, `nec2dxs11k.exe`).


### PR DESCRIPTION
## Summary
- bundle multiple PAR-011 drop-in cwd side-effect contract tests into one test PR
- add no-artifact cwd assertions for:
  - `4nec2` alias success path
  - explicit `--exec=cpu` success path
  - explicit `--exec=cpu` missing-deck error path
- update backlog with one grouped progress entry

## Why
To reduce test-related PR fragmentation while continuing PAR-011 runtime contract hardening, this batch groups closely related drop-in side-effect invariants in one focused change.

## Validation
- `cargo test -p nec-cli --test exec_modes`
- `./scripts/validate-doc-frontmatter.sh`
