### PR TITLE
test: batch PAR-011 drop-in scriptability contracts

### DIFF
--- a/apps/nec-cli/tests/scriptability_contract.rs
+++ b/apps/nec-cli/tests/scriptability_contract.rs
@@ -3,6 +3,9 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 fn test_tmp_dir() -> PathBuf {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
@@ -19,6 +22,56 @@ fn write_temp_deck(prefix: &str, body: &str) -> PathBuf {
     let path = test_tmp_dir().join(format!("fnec-{prefix}-{now}.nec"));
     fs::write(&path, body).expect("failed to write temporary deck");
     path
+}
+
+fn make_dropin_alias_path(alias_name: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH")
+        .as_nanos();
+    test_tmp_dir().join(format!("fnec-dropin-alias-{alias_name}-{now}"))
+}
+
+fn create_dropin_alias(alias_name: &str) -> PathBuf {
+    let source = PathBuf::from(env!("CARGO_BIN_EXE_fnec"));
+    let alias = make_dropin_alias_path(alias_name);
+
+    #[cfg(unix)]
+    {
+        if symlink(&source, &alias).is_ok() {
+            return alias;
+        }
+    }
+
+    if fs::hard_link(&source, &alias).is_ok() {
+        return alias;
+    }
+
+    fs::copy(&source, &alias).unwrap_or_else(|e| {
+        panic!(
+            "failed to create drop-in alias by copy from '{}' to '{}': {e}",
+            source.display(),
+            alias.display()
+        )
+    });
+
+    alias
+}
+
+struct TempPathCleanup {
+    path: PathBuf,
+}
+
+impl TempPathCleanup {
+    fn file(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for TempPathCleanup {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
 }
 
 #[test]
@@ -298,5 +351,222 @@ fn no_arg_invocation_exits_with_code_2_and_usage_on_stderr() {
     assert!(
         !stdout.contains("FNEC FEEDPOINT REPORT"),
         "stdout must have no report output on no-arg invocation, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn dropin_alias_bench_json_stays_on_stderr_not_stdout() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("nec2dxs500");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--bench-format")
+        .arg("json")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run drop-in alias for bench json stream test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "drop-in alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("bench_json:{"),
+        "expected benchmark json record in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("bench_json:{"),
+        "stdout must stay report-only for parsers, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("drop-in compatibility profile detected by binary name"),
+        "expected drop-in warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("drop-in compatibility profile detected by binary name"),
+        "drop-in warning must not appear on stdout, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn fournec2_alias_bench_json_stays_on_stderr_not_stdout() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("4nec2-kernel");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--bench-format")
+        .arg("json")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run 4nec2 alias for bench json stream test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "4nec2 alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("bench_json:{"),
+        "expected benchmark json record in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("bench_json:{"),
+        "stdout must stay report-only for parsers, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("drop-in compatibility profile detected by binary name"),
+        "expected drop-in warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("drop-in compatibility profile detected by binary name"),
+        "drop-in warning must not appear on stdout, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn dropin_alias_explicit_exec_cpu_bench_json_stays_on_stderr_not_stdout() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("nec2dxs3k0");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--exec")
+        .arg("cpu")
+        .arg("--bench-format")
+        .arg("json")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!("Failed to run explicit-exec drop-in alias for bench json stream test: {e}")
+        });
+
+    assert!(
+        output.status.success(),
+        "explicit-exec drop-in alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("bench_json:{"),
+        "expected benchmark json record in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("bench_json:{"),
+        "stdout must stay report-only for parsers, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("preserving explicit --exec=cpu"),
+        "expected explicit-exec preservation warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("preserving explicit --exec=cpu"),
+        "explicit-exec warning must not appear on stdout, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn dropin_alias_bench_csv_stays_on_stderr_not_stdout() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let deck_path = workspace_root.join("corpus/dipole-freesp-51seg.nec");
+    let alias = create_dropin_alias("nec2dxs500");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+
+    let output = Command::new(&alias)
+        .arg("--solver")
+        .arg("hallen")
+        .arg("--bench-format")
+        .arg("csv")
+        .arg(&deck_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run drop-in alias for bench csv stream test: {e}"));
+
+    assert!(
+        output.status.success(),
+        "drop-in alias failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("bench_csv:"),
+        "expected benchmark csv record in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("bench_csv:"),
+        "stdout must stay report-only for parsers, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("drop-in compatibility profile detected by binary name"),
+        "expected drop-in warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("drop-in compatibility profile detected by binary name"),
+        "drop-in warning must not appear on stdout, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn fournec2_alias_missing_deck_keeps_exit_code_and_error_on_stderr() {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let alias = create_dropin_alias("4nec2-kernel");
+    let _alias_cleanup = TempPathCleanup::file(alias.clone());
+    let bogus_path = test_tmp_dir().join("fnec-4nec2-missing-stream.nec");
+    let _ = fs::remove_file(&bogus_path);
+
+    let output = Command::new(&alias)
+        .arg(&bogus_path)
+        .current_dir(&workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run 4nec2 alias for missing-deck stream test: {e}"));
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1 for missing deck under 4nec2 alias"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("drop-in compatibility profile detected by binary name"),
+        "expected drop-in warning in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("cannot read"),
+        "expected file-read error in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("FNEC FEEDPOINT REPORT"),
+        "stdout must have no report output on missing-deck error, got:\n{stdout}"
     );
 }

--- a/apps/nec-cli/tests/scriptability_contract.rs
+++ b/apps/nec-cli/tests/scriptability_contract.rs
@@ -569,4 +569,12 @@ fn fournec2_alias_missing_deck_keeps_exit_code_and_error_on_stderr() {
         !stdout.contains("FNEC FEEDPOINT REPORT"),
         "stdout must have no report output on missing-deck error, got:\n{stdout}"
     );
+    assert!(
+        !stdout.contains("drop-in compatibility profile detected by binary name"),
+        "drop-in warning must not appear on stdout, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("cannot read"),
+        "missing-deck read error must not appear on stdout, got:\n{stdout}"
+    );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -261,6 +261,7 @@ last_updated: 2026-05-30
 	- 2026-05-30 progress: extended drop-in alias file-side-effect coverage with error-path validation in `apps/nec-cli/tests/exec_modes.rs` (`dropin_alias_missing_deck_does_not_create_files_in_working_directory`) to lock that missing-deck failures also avoid creating working-directory artifacts.
 	- 2026-05-30 progress: bundled additional drop-in side-effect runtime contracts in `apps/nec-cli/tests/exec_modes.rs` to reduce test-PR fragmentation, covering `4nec2` alias success-path cwd invariants plus explicit `--exec=cpu` success and missing-deck cwd invariants.
 	- 2026-05-30 progress: bundled additional stream/diagnostic runtime contracts in `apps/nec-cli/tests/exec_modes.rs` to reduce test-PR fragmentation, covering `4nec2` alias stdout/stderr separation plus explicit `--exec=cpu` success and missing-deck stderr/exit-code invariants under drop-in aliases.
+	- 2026-05-30 progress: bundled a larger drop-in scriptability test batch in `apps/nec-cli/tests/scriptability_contract.rs` to further reduce test-PR fragmentation, covering `nec2dxs*` and `4nec2` alias benchmark JSON/CSV stream routing plus `4nec2` missing-deck stderr/exit-code invariants.
 	- 2026-04-26 scope decision: compatibility harness skeleton work is postponed for now (option 3 deferred).
 	- Discovery checklist (capture before implementation starts):
 		- Binary-name matrix: confirm exact accepted executable names/casing and segment-limit mapping (`nec2dxs500.exe`, `nec2dxs1K5.exe`, `nec2dxs3k0.exe`, `nec2dxs5k0.exe`, `nec2dxs8k0.exe`, `nec2dxs11k.exe`).


### PR DESCRIPTION
## Summary
- bundle a larger PAR-011 drop-in scriptability test batch into one PR
- add drop-in alias benchmark stream-routing contracts:
  - `nec2dxs*` alias JSON on stderr only
  - `4nec2` alias JSON on stderr only
  - explicit `--exec=cpu` alias JSON on stderr only
  - `nec2dxs*` alias CSV on stderr only
- add `4nec2` missing-deck scriptability contract (exit code + stderr-only error/warning)
- record one grouped backlog progress entry

## Why
To further reduce test-related PR fragmentation, this groups several closely related scriptability contracts in one slice rather than splitting into multiple micro-PRs.

## Validation
- `cargo test -p nec-cli --test scriptability_contract`
- `./scripts/validate-doc-frontmatter.sh`
