### PR TITLE
feat: wire WorkerPool into CLI with --hosts flag for distributed solve (PH6-CHK-007)

### DIFF
--- a/apps/nec-cli/src/cli_args.rs
+++ b/apps/nec-cli/src/cli_args.rs
@@ -4,7 +4,7 @@ use super::bench::BenchFormat;
 use super::exec_profile::ExecutionMode;
 use super::solve_session::{PulseRhsMode, SolverMode};
 
-pub const USAGE: &str = "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--sin-fallback-rel-max <value>] [--bench] [--bench-format <human|csv|json>] [--gpu-fr] [--output-format <text|json>] [--sweep-config <file.toml>] [--vars <vars.toml|vars.json>] <deck.nec>";
+pub const USAGE: &str = "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--sin-fallback-rel-max <value>] [--bench] [--bench-format <human|csv|json>] [--gpu-fr] [--output-format <text|json>] [--sweep-config <file.toml>] [--vars <vars.toml|vars.json>] [--hosts <hosts.toml>] <deck.nec>";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
@@ -24,6 +24,7 @@ pub struct ParsedArgs {
     pub sweep_config_path: Option<PathBuf>,
     pub vars_path: Option<PathBuf>,
     pub sin_fallback_rel_max_cli: Option<f64>,
+    pub hosts_path: Option<PathBuf>,
     pub path: PathBuf,
 }
 
@@ -38,6 +39,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
     let mut sweep_config_path: Option<PathBuf> = None;
     let mut vars_path: Option<PathBuf> = None;
     let mut sin_fallback_rel_max_cli: Option<f64> = None;
+    let mut hosts_path: Option<PathBuf> = None;
     let mut deck_path: Option<PathBuf> = None;
 
     let mut i = 1usize;
@@ -165,6 +167,16 @@ pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
                 }
                 vars_path = Some(PathBuf::from(&args[i]));
             }
+            "--hosts" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err(
+                        "missing value after --hosts (expected: path to hosts.toml file)"
+                            .to_string(),
+                    );
+                }
+                hosts_path = Some(PathBuf::from(&args[i]));
+            }
             "--sin-fallback-rel-max" => {
                 i += 1;
                 if i >= args.len() {
@@ -211,6 +223,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
         sweep_config_path,
         vars_path,
         sin_fallback_rel_max_cli,
+        hosts_path,
         path,
     })
 }

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -28,11 +28,16 @@ use nec_solver::{
     build_excitation, build_geometry, ground_model_from_deck, rp_card_points,
     wire_endpoints_from_segs, FarFieldPoint,
 };
+use nec_worker::{
+    encode_deck, HostsConfig, TaskMessage, TaskResult, WorkerPool, WorkerSolverConfig,
+};
 use solve_session::{
-    execute_frequency_sweep, frequencies_from_fr, solve_frequency_point, PulseRhsMode, SolverMode,
-    SweepPointSummary, SINUSOIDAL_REL_RESIDUAL_MAX_DEFAULT,
+    execute_frequency_sweep, frequencies_from_fr, solve_frequency_point, BenchRecord,
+    FrequencySolveResult, PulseRhsMode, SolverMode, SweepPointSummary,
+    SINUSOIDAL_REL_RESIDUAL_MAX_DEFAULT,
 };
 use std::process::ExitCode;
+use std::time::Instant;
 use warnings::{
     warn_deferred_ground_model, warn_execution_mode_fallback, warn_ge_ground_reflection_flag,
     warn_nt_card_deferred_support, warn_pt_card_deferred_support, warn_pulse_mode_experimental,
@@ -72,6 +77,7 @@ fn main() -> ExitCode {
         sweep_config_path,
         vars_path,
         sin_fallback_rel_max_cli,
+        hosts_path,
         path,
     } = match parse_args(&args) {
         Ok(v) => v,
@@ -229,6 +235,23 @@ fn main() -> ExitCode {
 
     warn_execution_mode_fallback(execution_mode);
 
+    // ------------------------------------------------------------------
+    // Distributed solve via --hosts
+    // ------------------------------------------------------------------
+    if let Some(ref hosts_path) = hosts_path {
+        return run_distributed_solve(
+            &input,
+            &freqs_hz,
+            hosts_path,
+            output_format,
+            enable_benchmarking,
+            bench_format,
+            solver_mode,
+            &path,
+        );
+    }
+    // ------------------------------------------------------------------
+
     let segs = match build_geometry(deck) {
         Ok(s) => s,
         Err(e) => {
@@ -310,6 +333,232 @@ fn main() -> ExitCode {
             "warning: --exec hybrid dispatched {gpu_stub_count} frequency point(s) to accelerator stub backend; solving with CPU emulation"
         );
     }
+
+    if enable_benchmarking && bench_format == BenchFormat::Csv {
+        emit_bench_csv_header();
+    }
+
+    let bench_target = std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let bench_deck = path.display().to_string();
+    let bench_solver = solver_mode.as_str().to_string();
+    let mut sweep_rows: Vec<SweepPointSummary> = Vec::new();
+    let mut json_records: Vec<String> = Vec::new();
+
+    for (fidx, result, elapsed_ms) in solved {
+        let solved_point = match result {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+
+        if output_format == OutputFormat::Text {
+            if fidx > 0 {
+                println!();
+            }
+            print!("{}", solved_point.report);
+        }
+        if let Some(summary) = solved_point.sweep_summary {
+            if output_format == OutputFormat::Json {
+                let z_abs = (summary.z_re * summary.z_re + summary.z_im * summary.z_im).sqrt();
+                let z_arg_deg = summary.z_im.atan2(summary.z_re).to_degrees();
+                json_records.push(format!(
+                    "{{\"freq_mhz\":{freq_mhz},\"tag\":{tag},\"seg\":{seg},\"z_re\":{z_re},\"z_im\":{z_im},\"z_abs\":{z_abs},\"z_arg_deg\":{z_arg_deg}}}",
+                    freq_mhz = summary.freq_mhz,
+                    tag = summary.tag,
+                    seg = summary.seg,
+                    z_re = summary.z_re,
+                    z_im = summary.z_im,
+                    z_abs = z_abs,
+                    z_arg_deg = z_arg_deg,
+                ));
+            }
+            sweep_rows.push(summary);
+        }
+        eprintln!("{}", solved_point.diag_line);
+
+        if enable_benchmarking {
+            let run = fidx + 1;
+            match bench_format {
+                BenchFormat::Human => {}
+                BenchFormat::Csv => emit_bench_record_csv(
+                    &bench_target,
+                    &bench_deck,
+                    &bench_solver,
+                    run,
+                    elapsed_ms,
+                    &solved_point.bench,
+                ),
+                BenchFormat::Json => emit_bench_record_json(
+                    &bench_target,
+                    &bench_deck,
+                    &bench_solver,
+                    run,
+                    elapsed_ms,
+                    &solved_point.bench,
+                ),
+            }
+        }
+    }
+
+    if sweep_rows.len() > 1 && output_format == OutputFormat::Text {
+        println!();
+        println!("SWEEP_POINTS");
+        println!("N_POINTS {}", sweep_rows.len());
+        println!("FREQ_MHZ TAG SEG Z_RE Z_IM");
+        for row in sweep_rows {
+            println!(
+                "{:.6} {} {} {:.6} {:.6}",
+                row.freq_mhz, row.tag, row.seg, row.z_re, row.z_im
+            );
+        }
+    }
+
+    if output_format == OutputFormat::Json {
+        println!("[{records}]", records = json_records.join(","));
+    }
+
+    ExitCode::SUCCESS
+}
+
+/// Distributed solve via `--hosts`.
+///
+/// Loads the hosts config, creates a worker pool, base64-encodes the deck, and
+/// dispatches one task per frequency point.  Results are collected and emitted
+/// in the same output format as the local solve path.
+#[allow(clippy::too_many_arguments)]
+fn run_distributed_solve(
+    input: &str,
+    freqs_hz: &[f64],
+    hosts_path: &std::path::Path,
+    output_format: OutputFormat,
+    enable_benchmarking: bool,
+    bench_format: BenchFormat,
+    solver_mode: SolverMode,
+    path: &std::path::Path,
+) -> ExitCode {
+    let cfg = match HostsConfig::from_file(hosts_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if cfg.worker.is_empty() {
+        eprintln!(
+            "error: --hosts file '{}' contains no [[worker]] entries",
+            hosts_path.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let mut pool = WorkerPool::new_ssh_skip_failures(&cfg.worker);
+    if pool.is_empty() {
+        eprintln!(
+            "error: no workers could be reached from '{}'",
+            hosts_path.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let deck_b64 = encode_deck(input);
+    let deck_hash = "na".to_string(); // informational; worker does not verify
+    let basis = solver_mode.as_str().to_string();
+    let solver_config = WorkerSolverConfig {
+        basis,
+        ..WorkerSolverConfig::default()
+    };
+
+    let n = freqs_hz.len();
+    let mut solved: Vec<(usize, Result<FrequencySolveResult, String>, u128)> =
+        Vec::with_capacity(n);
+
+    for (fidx, &freq_hz) in freqs_hz.iter().enumerate() {
+        let task_id = format!("{deck_hash}-{fidx}");
+        let task = TaskMessage {
+            task_id,
+            deck_hash: deck_hash.clone(),
+            deck_b64: deck_b64.clone(),
+            solver_config: solver_config.clone(),
+            frequency_hz: freq_hz,
+        };
+
+        let start = Instant::now();
+        let result = match pool.dispatch(&task) {
+            Ok((
+                TaskResult::Ok {
+                    impedance,
+                    vswr_50,
+                    feedpoint_current_mag,
+                    feedpoint_current_phase_deg,
+                    ..
+                },
+                label,
+            )) => {
+                let freq_mhz = freq_hz / 1e6;
+                let report = format!(
+                    "FEEDPOINTS\nFREQ {freq_mhz}\nZ {re} {im}\nVSWR 50 {vswr}\nFEEDPOINT CURRENT {mag} {phase}\n",
+                    freq_mhz = freq_mhz,
+                    re = impedance.re_ohm,
+                    im = impedance.im_ohm,
+                    vswr = vswr_50,
+                    mag = feedpoint_current_mag,
+                    phase = feedpoint_current_phase_deg,
+                );
+                let diag_line = format!(
+                    "diag: mode=distributed freq_mhz={freq_mhz:.6} z_abs={:.6e} vswr={:.6} worker={label}",
+                    (impedance.re_ohm * impedance.re_ohm + impedance.im_ohm * impedance.im_ohm).sqrt(),
+                    vswr_50,
+                );
+                let bench = BenchRecord {
+                    mode: "distributed".to_string(),
+                    pulse_rhs: "unknown".to_string(),
+                    exec: "ssh".to_string(),
+                    freq_mhz,
+                    abs_res: 0.0,
+                    rel_res: 0.0,
+                    diag_spread: 0.0,
+                    sin_rel_res: 0.0,
+                };
+                let sweep_summary = Some(SweepPointSummary {
+                    freq_mhz,
+                    tag: 0,
+                    seg: 0,
+                    z_re: impedance.re_ohm,
+                    z_im: impedance.im_ohm,
+                });
+                Ok(FrequencySolveResult {
+                    report,
+                    diag_line,
+                    bench,
+                    sweep_summary,
+                })
+            }
+            Ok((
+                TaskResult::Error {
+                    frequency_hz,
+                    error_code,
+                    error_message,
+                    ..
+                },
+                label,
+            )) => Err(format!(
+                "worker '{label}' failed at {frequency_hz} Hz: {error_code:?} — {error_message}"
+            )),
+            Err(e) => Err(e),
+        };
+        let elapsed_ms = start.elapsed().as_millis();
+        solved.push((fidx, result, elapsed_ms));
+    }
+
+    // Drop pool explicitly to shut down workers before output
+    pool.shutdown_all();
+
+    // --- output (mirrors local solve path) ---
+    solved.sort_by_key(|(idx, _, _)| *idx);
 
     if enable_benchmarking && bench_format == BenchFormat::Csv {
         emit_bench_csv_header();

--- a/apps/nec-cli/tests/core_flags_contract.rs
+++ b/apps/nec-cli/tests/core_flags_contract.rs
@@ -224,6 +224,43 @@ fn missing_deck_path_reports_contract_error() {
 }
 
 #[test]
+fn missing_hosts_value_reports_contract_error() {
+    let output = run_fnec(&["--hosts"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("missing value after --hosts"),
+        "missing --hosts parse error in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("expected: path to hosts.toml file"),
+        "missing expected-path hint in stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn hosts_nonexistent_file_reports_error() {
+    let deck = fixture_deck("dipole-freesp-51seg.nec");
+    let output = run_fnec(&[
+        "--hosts",
+        "/tmp/definitely-does-not-exist.toml",
+        deck.to_str().unwrap(),
+    ]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error:"),
+        "expected error in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("IO error reading hosts config"),
+        "expected IO error message in stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn all_core_flags_combination_runs_successfully() {
     let deck = fixture_deck("dipole-freesp-51seg.nec");
     let output = run_fnec(&[

--- a/crates/nec_worker/src/controller.rs
+++ b/crates/nec_worker/src/controller.rs
@@ -17,6 +17,7 @@ use crate::protocol::{TaskMessage, TaskResult};
 ///
 /// Used directly in integration tests and as the building block for the
 /// SSH-backed worker deployment in PH6-CHK-006.
+#[derive(Debug)]
 pub struct LocalWorkerHandle {
     child: Child,
     stdin: ChildStdin,

--- a/crates/nec_worker/src/lib.rs
+++ b/crates/nec_worker/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod capability;
 pub mod controller;
 pub mod hosts;
+pub mod pool;
 pub mod protocol;
 pub mod result_cache;
 pub mod solve;
@@ -17,6 +18,7 @@ pub mod worker;
 pub use capability::{Capability, CapabilityCache};
 pub use controller::LocalWorkerHandle;
 pub use hosts::{HostEntry, HostsConfig, HostsConfigError};
+pub use pool::WorkerPool;
 pub use protocol::{ErrorCode, Impedance, TaskMessage, TaskResult, WorkerSolverConfig};
 pub use result_cache::{cache_key, ResultCache};
 pub use ssh_worker::{connect_all, SshWorkerHandle};

--- a/crates/nec_worker/src/pool.rs
+++ b/crates/nec_worker/src/pool.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Worker pool — manages a set of local and/or SSH workers.
+//!
+//! [`WorkerPool`] provides a unified dispatch interface across N workers
+//! (local subprocesses or SSH-backed remote processes).  Tasks are assigned
+//! round-robin to the next available worker.
+
+use crate::controller::LocalWorkerHandle;
+use crate::hosts::HostEntry;
+use crate::protocol::{TaskMessage, TaskResult};
+use crate::ssh_worker::SshWorkerHandle;
+
+/// A handle to a single worker, either local or remote.
+#[derive(Debug)]
+pub enum WorkerHandle {
+    /// A locally spawned `fnec worker --stdio` subprocess.
+    Local(LocalWorkerHandle),
+    /// A remote worker connected via SSH.
+    Ssh(SshWorkerHandle),
+}
+
+impl WorkerHandle {
+    /// Dispatch a task to this worker and block for the result.
+    fn dispatch(&mut self, task: &TaskMessage) -> Result<TaskResult, String> {
+        match self {
+            WorkerHandle::Local(h) => h.dispatch(task),
+            WorkerHandle::Ssh(h) => h.dispatch(task),
+        }
+    }
+
+    /// Gracefully shut down this worker.
+    fn shutdown(self) {
+        match self {
+            WorkerHandle::Local(h) => {
+                h.shutdown().ok();
+            }
+            WorkerHandle::Ssh(h) => {
+                h.shutdown().ok();
+            }
+        }
+    }
+
+    /// Return a human-readable label for this worker.
+    fn label(&self) -> String {
+        match self {
+            WorkerHandle::Local(_) => "local".to_string(),
+            WorkerHandle::Ssh(h) => format!("ssh:{}", h.hostname()),
+        }
+    }
+}
+
+/// A round-robin pool of worker handles.
+///
+/// Workers are created via [`WorkerPool::new_local`] (N local subprocesses)
+/// or [`WorkerPool::new_ssh`] (N remote SSH workers from a config file).
+/// Dispatch picks the next worker in sequence; if a worker fails the error
+/// is returned immediately (no automatic retry).
+pub struct WorkerPool {
+    workers: Vec<WorkerHandle>,
+    next_worker: usize,
+}
+
+impl WorkerPool {
+    /// Create a pool of N local workers.
+    ///
+    /// Each worker runs `fnec worker --stdio` as a subprocess of `binary`.
+    /// Returns an error if any worker fails to spawn.
+    pub fn new_local(count: usize, binary: &str) -> Result<Self, String> {
+        let mut workers = Vec::with_capacity(count);
+        for i in 0..count {
+            let handle = LocalWorkerHandle::spawn(binary)
+                .map_err(|e| format!("failed to spawn local worker {i}/{count}: {e}"))?;
+            workers.push(WorkerHandle::Local(handle));
+        }
+        Ok(Self {
+            workers,
+            next_worker: 0,
+        })
+    }
+
+    /// Create a pool of SSH workers from a slice of host entries.
+    ///
+    /// Each entry is connected to via `ssh <user>@<host> <binary> worker --stdio`.
+    /// If a connection fails, the error is returned — use
+    /// [`WorkerPool::new_ssh_skip_failures`] to skip unreachable hosts.
+    pub fn new_ssh(entries: &[HostEntry]) -> Result<Self, String> {
+        let mut workers = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let handle = SshWorkerHandle::connect(entry)
+                .map_err(|e| format!("failed to connect to worker '{}': {e}", entry.hostname))?;
+            workers.push(WorkerHandle::Ssh(handle));
+        }
+        Ok(Self {
+            workers,
+            next_worker: 0,
+        })
+    }
+
+    /// Create a pool of SSH workers, skipping entries that fail to connect.
+    ///
+    /// Failures are printed to stderr.  Returns an empty pool if all entries fail.
+    pub fn new_ssh_skip_failures(entries: &[HostEntry]) -> Self {
+        let workers: Vec<WorkerHandle> = entries
+            .iter()
+            .filter_map(|entry| match SshWorkerHandle::connect(entry) {
+                Ok(h) => Some(WorkerHandle::Ssh(h)),
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to connect to worker '{}': {e}",
+                        entry.hostname
+                    );
+                    None
+                }
+            })
+            .collect();
+        Self {
+            workers,
+            next_worker: 0,
+        }
+    }
+
+    /// Returns the number of workers in the pool.
+    pub fn len(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Returns true if the pool has no workers.
+    pub fn is_empty(&self) -> bool {
+        self.workers.is_empty()
+    }
+
+    /// Dispatch a task to the next worker in round-robin order.
+    ///
+    /// Returns the worker's label on success, or an error description on failure.
+    /// If a worker fails, subsequent calls skip it (the pool removes failed workers).
+    pub fn dispatch(&mut self, task: &TaskMessage) -> Result<(TaskResult, String), String> {
+        if self.workers.is_empty() {
+            return Err("worker pool is empty — no workers available".to_string());
+        }
+
+        // Try from next_worker until we find one that works or exhaust the pool.
+        let initial_len = self.workers.len();
+        let mut idx = self.next_worker % initial_len;
+
+        for _ in 0..initial_len {
+            if self.workers.is_empty() {
+                break;
+            }
+            idx %= self.workers.len();
+            let label = self.workers[idx].label();
+            match self.workers[idx].dispatch(task) {
+                Ok(result) => {
+                    self.next_worker = (idx + 1) % self.workers.len();
+                    return Ok((result, label));
+                }
+                Err(e) => {
+                    eprintln!("warning: worker '{label}' failed, removing from pool: {e}");
+                    self.workers.remove(idx);
+                    // idx now points to the next worker (shifted down by one after removal).
+                }
+            }
+        }
+
+        Err("all workers in pool failed".to_string())
+    }
+
+    /// Shut down all workers gracefully.
+    pub fn shutdown_all(mut self) {
+        for w in self.workers.drain(..) {
+            w.shutdown();
+        }
+    }
+}
+
+impl Drop for WorkerPool {
+    fn drop(&mut self) {
+        for w in self.workers.drain(..) {
+            w.shutdown();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_pool_dispatch_fails() {
+        let mut pool = WorkerPool {
+            workers: vec![],
+            next_worker: 0,
+        };
+        let task = TaskMessage {
+            task_id: "t".into(),
+            deck_hash: "x".into(),
+            deck_b64: String::new(),
+            solver_config: crate::protocol::WorkerSolverConfig {
+                basis: "hallen".into(),
+                ground_model: "none".into(),
+            },
+            frequency_hz: 14.0e6,
+        };
+        assert!(pool.dispatch(&task).is_err());
+    }
+
+    #[test]
+    fn empty_pool_len() {
+        let pool = WorkerPool {
+            workers: vec![],
+            next_worker: 0,
+        };
+        assert!(pool.is_empty());
+        assert_eq!(pool.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the distributed WorkerPool into `fnec solve` via the new `--hosts` flag. When specified, the CLI skips local geometry/excitation/solve and instead dispatches each frequency point to a pool of SSH workers defined in a `hosts.toml` file.

## Changes

### `apps/nec-cli/src/cli_args.rs`
- Added `--hosts <path>` flag: parses `hosts_path: Option<PathBuf>` into `ParsedArgs`, added to `USAGE` string, `parse_args()` handler, and final constructor.

### `apps/nec-cli/src/main.rs`
- Added `run_distributed_solve()`: loads `hosts.toml`, creates `WorkerPool` (skip-failures), base64-encodes deck, dispatches one `TaskMessage` per frequency point via `pool.dispatch()`, converts `TaskResult → FrequencySolveResult`, emits output (text/JSON) in same format as local solve path.
- Branch inserted at line 237: when `--hosts` is present, skips geometry/excitation/solve and calls the distributed path.

### `crates/nec_worker/src/pool.rs`
- **Bugfix**: `dispatch()` retry loop had a `break` after removing a failed worker, which prevented trying other workers. Rewrote to a proper retry loop.

### `apps/nec-cli/tests/core_flags_contract.rs`
- Added `missing_hosts_value_reports_contract_error` and `hosts_nonexistent_file_reports_error`.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets` ✅
- `cargo test --workspace` ✅