### PR TITLE
test: fill nec_worker unit test gap across controller/pool/ssh_worker (GAP-001)

### DIFF
--- a/crates/nec_worker/src/controller.rs
+++ b/crates/nec_worker/src/controller.rs
@@ -81,3 +81,27 @@ impl Drop for LocalWorkerHandle {
         let _ = self.child.wait();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_nonexistent_binary_returns_error() {
+        let result = LocalWorkerHandle::spawn("/nonexistent/fnec-binary");
+        assert!(result.is_err(), "expected Err, got Ok");
+    }
+
+    #[test]
+    fn spawn_empty_binary_path_returns_error() {
+        let result = LocalWorkerHandle::spawn("");
+        assert!(result.is_err(), "expected Err, got Ok");
+    }
+
+    #[test]
+    fn shutdown_message_is_valid_json() {
+        let msg = r#"{"cmd":"shutdown"}"#;
+        let val: serde_json::Value = serde_json::from_str(msg).unwrap();
+        assert_eq!(val.get("cmd").and_then(|v| v.as_str()), Some("shutdown"));
+    }
+}

--- a/crates/nec_worker/src/pool.rs
+++ b/crates/nec_worker/src/pool.rs
@@ -214,4 +214,23 @@ mod tests {
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
     }
+
+    #[test]
+    fn new_local_nonexistent_binary_returns_error() {
+        let result = WorkerPool::new_local(1, "/nonexistent/fnec-binary");
+        assert!(result.is_err(), "expected Err, got Ok");
+    }
+
+    #[test]
+    fn new_local_zero_workers_returns_empty() {
+        let pool = WorkerPool::new_local(0, "fnec").unwrap();
+        assert!(pool.is_empty());
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn new_local_multiple_with_nonexistent_binary_returns_error() {
+        let result = WorkerPool::new_local(3, "/nonexistent/fnec-binary");
+        assert!(result.is_err(), "expected Err, got Ok");
+    }
 }

--- a/crates/nec_worker/src/ssh_worker.rs
+++ b/crates/nec_worker/src/ssh_worker.rs
@@ -203,4 +203,19 @@ mod tests {
         assert!(handles.is_empty());
         assert!(cache.is_empty());
     }
+
+    #[test]
+    fn connect_all_skips_unreachable_host_gracefully() {
+        // connect_all should not panic when given an unresolvable host;
+        // it prints a warning to stderr and continues.
+        let toml = r#"
+[[worker]]
+hostname = "invalid-host-that-will-never-resolve.example"
+"#;
+        let cfg = crate::HostsConfig::from_str(toml).unwrap();
+        // Note: this may take up to ConnectTimeout (5s) per entry.
+        let (handles, cache) = connect_all(&cfg);
+        assert!(handles.is_empty());
+        assert!(cache.is_empty());
+    }
 }


### PR DESCRIPTION
Addresses GAP-001 from review-260620: adds missing unit tests for `nec_worker` modules.

**Changes:**
- `controller.rs` (+3 tests): spawn error paths (nonexistent binary, empty path), shutdown JSON format
- `pool.rs` (+3 tests): init edge cases (nonexistent binary, zero workers, multiple failures)
- `ssh_worker.rs` (+1 test): graceful handling of unresolvable hosts in `connect_all`

**Coverage changes:**
| Module | Before | After |
|--------|--------|-------|
| controller.rs | 0 | 3 |
| pool.rs | 2 | 5 |
| ssh_worker.rs | 1 | 2 |
| **Total** | **59** | **66** |

Every module in `nec_worker` now has at least 2 unit tests. All 66 tests pass.