### PR TITLE
docs: project traceability layer + matrix (docs/project/)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,24 @@
+# cargo-audit configuration for fnec-rust.
+# Run: cargo audit   (also invoked by the pre-push hook, .githooks/pre-push)
+# Policy record and rationale: docs/dependency-policy.md § Exception process.
+#
+# This ignore list must stay in sync with the [advisories].ignore block in
+# deny.toml (cargo-deny) — both gate the same advisories from different tools.
+
+[advisories]
+ignore = [
+    # quick-xml DoS advisories — SCOPED, BUILD-TIME-ONLY EXCEPTION (2026-07-02).
+    # quick-xml v0.39.x is a compile-time-only dependency of `wayland-scanner`
+    # (a proc-macro parsing the trusted, in-crate Wayland protocol XML), reached
+    # via wayland-scanner → smithay-client-toolkit → winit → iced → nec-gui. It
+    # never processes attacker-controlled input at runtime, so neither DoS
+    # advisory is reachable from any fnec-rust runtime path.
+    #
+    # Root fix (quick-xml >= 0.41.0) is blocked upstream: the newest published
+    # wayland-scanner (0.31.10) still requires `quick-xml ^0.39`.
+    #
+    # REVISIT TRIGGER: remove both once a wayland-scanner release depends on
+    # quick-xml >= 0.41.0, then `cargo update -p quick-xml`.
+    "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate attribute names
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation (NsReader)
+]

--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,29 @@ version = "*"
 [advisories]
 version = 2
 # Treat all unignored security advisories as errors.
-ignore = []
+# See docs/dependency-policy.md § Exception process for the review record.
+ignore = [
+    # quick-xml DoS advisories — SCOPED, BUILD-TIME-ONLY EXCEPTION.
+    # quick-xml v0.39.x enters the graph solely as a compile-time dependency of
+    # `wayland-scanner` (a proc-macro that parses the trusted, in-crate Wayland
+    # protocol XML shipped with wayland-rs). It is pulled in via
+    # wayland-scanner → smithay-client-toolkit → winit → iced → nec-gui, and only
+    # runs on the developer/build machine over vendored, non-attacker-controlled
+    # input. Neither advisory is reachable from any runtime path in fnec-rust:
+    # the solver, CLI, workers, and GUI never feed untrusted data to quick-xml.
+    #
+    # Root fix (quick-xml >= 0.41.0) is BLOCKED UPSTREAM: the newest published
+    # wayland-scanner (0.31.10) still requires `quick-xml ^0.39`; no released
+    # Wayland-stack version accepts >= 0.41 yet, so a dependency bump cannot reach
+    # a fixed lockfile today.
+    #
+    # Review date: 2026-07-02 (DC0SK, user-approved).
+    # REVISIT TRIGGER: remove BOTH entries once a wayland-scanner release depends
+    # on quick-xml >= 0.41.0 (then `cargo update -p quick-xml`). Tracked as a
+    # Phase 8 dependency-hygiene follow-up.
+    "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate attribute names
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation (NsReader)
+]
 
 # ── Bans ──────────────────────────────────────────────────────────────────────
 [bans]

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/README.md
 status: living
-last_updated: 2026-04-22
+last_updated: 2026-07-02
 ---
 
 # Documentation Overview
@@ -21,6 +21,7 @@ This directory captures project decisions and operating guidance for `fnec-rust`
 
 ## Document index
 
+- `docs/project/` — **traceability layer**: end-to-end requirement → design → implementation → tests → results matrix ([docs/project/README.md](project/README.md), [traceability-matrix.md](project/traceability-matrix.md))
 - `docs/requirements.md` — functional and non-functional requirements
 - `docs/steering.md` — governance and decision ownership
 - `docs/roadmap.md` — phased execution plan

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/dependency-policy.md
 status: living
-last_updated: 2026-05-02
+last_updated: 2026-07-02
 ---
 
 # Dependency Policy
@@ -97,6 +97,23 @@ Exceptions are re-reviewed whenever the affected crate's version is bumped.
 | Crate | Version | Allowed license(s) | Rationale | Review date |
 |:------|:--------|:-------------------|:----------|:------------|
 | `self_cell` | `*` | `Apache-2.0 OR GPL-2.0-only` | Multi-license; we select Apache-2.0. Transitive dep of iced/winit. | 2026-05-02 |
+
+### Security advisory exceptions
+
+Security advisories (RUSTSEC) are gated by two tools that must stay in sync:
+`cargo audit` (pre-push hook `.githooks/pre-push`, ignore list in
+`.cargo/audit.toml`) and `cargo deny` (`deny.toml` `[advisories].ignore`). A
+vulnerability advisory may be ignored **only** with a documented, dated rationale
+and a concrete revisit trigger, added to **both** files.
+
+| Advisory | Crate | Category | Rationale | Revisit trigger | Review date |
+|:---------|:------|:---------|:----------|:----------------|:------------|
+| RUSTSEC-2026-0194 | `quick-xml` | DoS (quadratic on duplicate attrs) | Build-time-only dep of `wayland-scanner` (proc-macro parsing trusted in-crate Wayland protocol XML via winit/iced/nec-gui). Not reachable from any runtime path. | Remove once wayland-scanner depends on `quick-xml >= 0.41.0`, then `cargo update -p quick-xml`. | 2026-07-02 |
+| RUSTSEC-2026-0195 | `quick-xml` | DoS (unbounded NsReader allocation) | Same build-time-only `wayland-scanner` path; no untrusted runtime input. | Same as RUSTSEC-2026-0194. | 2026-07-02 |
+
+Root fix is blocked upstream: the newest published `wayland-scanner` (0.31.10)
+still requires `quick-xml ^0.39`, so no dependency bump reaches a fixed lockfile
+today. Tracked as a Phase 8 dependency-hygiene follow-up.
 
 ---
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,94 @@
+---
+project: fnec-rust
+doc: docs/project/README.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Project traceability layer
+
+This directory is the **consolidated traceability layer** for fnec-rust. It ties
+the whole delivery chain together in one place:
+
+```
+requirements / changes
+        │
+        ▼
+architecture / design decisions
+        │
+        ▼
+implementation (crates, apps, modules)
+        │
+        ▼
+tests (unit, integration, corpus, GPU parity)
+        │
+        ▼
+test results (recorded runs, gates)
+        │
+        ▲
+helper & validation tooling ──────────┘
+   (scripts, harnesses, external reference engines)
+```
+
+The individual layers already exist across the repo (requirements in
+`docs/requirements.md`, per-checklist design docs like
+`docs/ph7-chk-003-gpu-resident-solve.md`, tests under `*/tests/`, scripts under
+`scripts/`). This layer does **not** replace them — it **links** them so any
+requirement can be traced forward to the code and tests that satisfy it, and any
+test can be traced back to the requirement it defends.
+
+## Document map
+
+| Layer | Document | What it holds |
+|:------|:---------|:--------------|
+| ★ Matrix | [traceability-matrix.md](traceability-matrix.md) | The end-to-end matrix: requirement → design → implementation → tests → result. Start here. |
+| Requirements / changes | [requirements-register.md](requirements-register.md) | Every requirement, decision, gap, and blocker ID with its source and coverage state. |
+| Architecture / design | [architecture-design-index.md](architecture-design-index.md) | Index of foundational architecture docs and per-checklist design/decision records. |
+| Implementation | [implementation-map.md](implementation-map.md) | Every crate/app/module with its responsibility and the requirements it serves. |
+| Tests | [test-catalog.md](test-catalog.md) | Every test file with its count, what it validates, and the checklist it gates. |
+| Test results | [test-results.md](test-results.md) | Recorded test-run results and the standing CI gates. |
+| Tooling | [tooling-catalog.md](tooling-catalog.md) | Helper/validation scripts, benchmark harnesses, corpus, and external reference engines. |
+
+## Source of truth vs. this layer
+
+- **`docs/roadmap.md`** remains the authoritative source for *checklist status*
+  (which `PHx-CHK-*` items are done and their embedded evidence). The matrix here
+  mirrors that status and adds the cross-layer links.
+- **`docs/requirements.md`, `docs/nec4-support.md`, `docs/card-support-matrix.md`,
+  `docs/corpus-validation-strategy.md`** remain authoritative for their domains.
+  The register and matrix here aggregate and point into them.
+
+If this layer and a source-of-truth doc ever disagree, the source-of-truth doc
+wins and this layer is the bug — fix it in the same change.
+
+## Maintenance rule (keep it current before each push)
+
+The matrix is only useful if it is honest. **Before every `git push`**, run the
+pre-push traceability check:
+
+1. **Requirements** — did this change add/alter a requirement, decision, gap, or
+   blocker? Update [requirements-register.md](requirements-register.md).
+2. **Design** — did it add or supersede a design/decision doc? Update
+   [architecture-design-index.md](architecture-design-index.md).
+3. **Implementation** — did it add a module or change a module's responsibility?
+   Update [implementation-map.md](implementation-map.md).
+4. **Tests** — did it add/rename/remove a test file or change a test count area?
+   Update [test-catalog.md](test-catalog.md).
+5. **Results** — run `cargo test --workspace` (and, if GPU code changed,
+   `cargo test -p nec_accel --features wgpu`) and record the new aggregate in
+   [test-results.md](test-results.md) with the commit, date, and toolchain.
+6. **Tooling** — did it add a script/harness/reference dependency? Update
+   [tooling-catalog.md](tooling-catalog.md).
+7. **Matrix** — add/adjust the row(s) in
+   [traceability-matrix.md](traceability-matrix.md) so the changed checklist item
+   links all five layers, and bump every touched doc's `last_updated`.
+
+A change that closes or advances a `PHx-CHK-*` item is not "done" for this project
+until its matrix row links requirement → design → implementation → tests → result.
+
+## Frontmatter contract
+
+Every file here follows the repo frontmatter contract (enforced for `docs/*.md`
+by `scripts/validate-docs-frontmatter.sh`; `docs/project/*.md` follow it for
+consistency): exactly four keys in order — `project: fnec-rust`, `doc: <path>`,
+`status: living`, `last_updated: YYYY-MM-DD`.

--- a/docs/project/architecture-design-index.md
+++ b/docs/project/architecture-design-index.md
@@ -1,0 +1,76 @@
+---
+project: fnec-rust
+doc: docs/project/architecture-design-index.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Architecture & design index
+
+The **design layer** of the traceability chain: the documents that record *how*
+and *why* the implementation is shaped the way it is. Every non-trivial checklist
+item that made an architectural choice has a design/decision record; this index
+maps decision → document.
+
+## Foundational architecture
+
+| Document | Scope |
+|:---------|:------|
+| `docs/architecture.md` | System architecture: crate boundaries, data flow, frontend/solver separation. |
+| `docs/design.md` | Design principles and cross-cutting decisions. |
+| `docs/applied-math.md` | The MoM/Hallén numerical formulation, quadrature, singularity handling. |
+| `docs/nec-requirements.md` | NEC deck/reference-data requirements for tolerance verification. |
+| `docs/project-blueprint.md` | High-level product blueprint. |
+| `docs/steering.md` | Steering/process guidance. |
+
+## Domain decision records
+
+| Document | Decision recorded | Requirement IDs |
+|:---------|:------------------|:----------------|
+| `docs/nec4-support.md` | NEC-4 feature boundary: supported/deferred card set; card status index | GAP-002, BLK-002, COMP-003 |
+| `docs/card-support-matrix.md` | Per-card support state (Full/Partial/Deferred) | COMP-003, CP-003 |
+| `docs/corpus-validation-strategy.md` | Corpus + tolerance strategy; NEC-5-informed matrix (`PH2N5-*`, `PH6N5-*`) | PRT-010, GAP-013 |
+| `docs/gpu-arch.md` | GPU architecture: wgpu choice, target matrix, G1–G7 gate sequence | GAP-007, DEC-003 |
+| `docs/multi-vendor-gpu.md` | Backend matrix; AMD Vulkan validation; ROCm/SYCL deferral | DEC-008, CP-009 |
+| `docs/distributed-execution-design.md` | Transport, authN/authZ, worker contract, result-cache design | PRT-011, CP-011 |
+| `docs/worker-deployment.md` | SSH worker deployment, hosts config, capability cache | PRT-011 |
+| `docs/nec5-frontier.md` | NEC-5 accuracy frontier decision (wire-only continuation) | PRT-009, CP-009 |
+| `docs/plugin-api-design.md` | Extension surface + safety model; EP-1..4 | GAP-004, BLK-004, DEC-006 |
+| `docs/dependency-policy.md` | SPDX allowlist/deny-list, GPLv2 rules, exception process | GAP-008, BLK-005, DEC-007 |
+| `docs/json-output-schema.md` | Locked JSON output schema v1 | FR-008, PH4-CHK-003 |
+| `docs/project-format.md` | TOML/Markdown project file format | FR-004, GAP-010/015 |
+| `docs/phase5-entry-criteria.md` | Measurable Phase 5 (GPU) entry gate | PH4-CHK-007 |
+| `docs/rooftop-basis-plan.md` | Basis-function strategy notes | Solver accuracy |
+| `docs/solver-findings.md` | Solver numerical findings log | NFR-004 |
+| `docs/utd-feasibility-assessment.md` | UTD feasibility assessment | PRT-009 (frontier) |
+
+## Per-checklist decision records (Phase 7–8)
+
+These are the fine-grained "requirement → decision → implementation → result"
+records for the most recent work. Each is self-contained and is the design node
+in its matrix row.
+
+| Document | Checklist | Decision |
+|:---------|:----------|:---------|
+| `docs/ph7-chk-001-gpu-stub-retirement.md` | PH7-CHK-001 | Retire the GPU CPU-emulation scaffold; no path reports CPU time as GPU time. |
+| `docs/ph7-chk-002-gpu-microbenchmark.md` | PH7-CHK-002 | In-process microbench isolating dispatch from device-init. |
+| `docs/ph7-chk-003-gpu-resident-solve.md` | PH7-CHK-003 | GPU-resident f32 solve; Björck refinement; 2 Ω tolerance bar (amended). |
+| `docs/ph7-chk-004-distributed-gpu-execution.md` | PH7-CHK-004 | `--exec gpu` through the SSH worker pool; serde-default protocol fields. |
+| `docs/ph7-chk-005-real-gpu-benchmark.md` | PH7-CHK-005 | Real AMD-GPU crossover evidence; not the CI software rasterizer. |
+| `docs/ph8-chk-002-plane-wave-excitation.md` | PH8-CHK-002 | **NEC2 EX-type alignment** + plane-wave RHS in the forcing term; staged delivery. |
+
+## Notable architectural decisions (verified)
+
+- **wgpu as the single GPU API** (DEC-003, GAP-007): one WGSL codebase covers
+  Vulkan/Metal/DX12/OpenCL; native ROCm/SYCL deferred with a dated rationale
+  because the AMD Renoir APU target is outside ROCm's support matrix
+  (`docs/multi-vendor-gpu.md`, PH7-CHK-006).
+- **f64 CPU solve is the accuracy reference; GPU is f32** (PH7-CHK-003): the
+  GPU-resident solve validates to 2 Ω, not the 0.05 Ω corpus gate, because wgpu is
+  f32-only and the Hallén solve is normal-equations least-squares.
+- **Wire-only NEC-5 continuation** (PRT-009, `docs/nec5-frontier.md`): surfaces
+  are explicitly out of scope; Phase 8 finishes wire-card semantics instead.
+- **NEC2 EX-type alignment** (PH8-CHK-002, user-approved 2026-06-27): fnec's
+  EX-type numbering is realigned to NEC2 (type 1 = plane wave, current source →
+  type 4) so real 4nec2 plane-wave decks are not misread. This is the current
+  in-flight decision.

--- a/docs/project/implementation-map.md
+++ b/docs/project/implementation-map.md
@@ -1,0 +1,109 @@
+---
+project: fnec-rust
+doc: docs/project/implementation-map.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Implementation map
+
+The **implementation layer**: every crate and app with its role, its key modules,
+and the requirements/checklists it serves. This is the bridge from design docs to
+the test catalog.
+
+Workspace layout: 7 library crates (`crates/`), 2 binaries (`apps/`), 1 Python
+binding (`bindings/fnec_py/`).
+
+## nec_parser — deck front end
+Text → typed AST. Parses NEC cards into `NecDeck`; provides `$VAR` templating.
+Serves **FR-003, COMP-001, PH3-CHK-007**.
+
+- `src/lib.rs` — parses `CM/CE/GW/GE/GM/GR/GN/EX/FR/RP/LD/TL/NT/PT/EN` into `NecDeck`; `ParseError`; unknown cards non-fatal.
+- `src/template.rs` — `$VARNAME` substitution (`$$` escapes `$`); `TemplateError` on undefined vars.
+
+## nec_model — shared data model
+Typed card structs, deck container, and plugin-extension traits. No solving logic.
+Serves **FR-001, FR-006, FR-009 (validators), DEC-006, EP-1/EP-4**.
+
+- `src/card.rs` — per-card structs (`GwCard`, `ExCard`, `FrCard`, `LdCard`, `TlCard`, `NtCard`, `PtCard`, `GnCard`, …) + `Card` enum. **PH8-CHK-002 will extend `ExCard` with the plane-wave polarization field.**
+- `src/deck.rs` — `NecDeck` container (cards in source order).
+- `src/lib.rs` — `DeckPostProcessor` (EP-1) + `DeckValidator` (EP-4) traits, `ValidationDiagnostic`, `run_validators`.
+
+## nec_solver — MoM numerical core
+Deck → geometry → impedance/excitation systems → currents → derived quantities.
+Serves **FR-001, DEC-010/011, PRT-001/002/008, NFR-004, PH8-CHK-001..006**.
+
+- `src/lib.rs` — facade re-exporting geometry/matrix/excitation/basis/linear/loads/tl/farfield.
+- `src/geometry.rs` — `GW` → `Segment` lists; `GroundModel` extraction; junction detection.
+- `src/matrix.rs` — Hallén A-matrix (+ Pocklington/Z variants, ground); Gauss-Legendre quadrature + self-term singularity subtraction; `ZMatrix`.
+- `src/excitation.rs` — complex RHS from `EX` cards; `build_hallen_rhs` (delta-gap); pulse-RHS scaling; `ExcitationError`. **PH8-CHK-002 adds the plane-wave forcing RHS here.**
+- `src/basis.rs` — `ContinuityTransform`, `SinusoidalTransform` basis mappings.
+- `src/linear.rs` — dense complex LU (partial pivoting); pulse/Hallén/continuity/sinusoidal solve entries; `SolveError`.
+- `src/loads.rs` — `LD` → per-segment complex loads (RLC/RL/RC/Z/conductivity); `LoadWarning`.
+- `src/tl.rs` — `TL` → sparse Z stamps (`TlStamp`, lossless 2-port cot/csc); `TlWarning`. **PH8-CHK-004/005 extend (NT stamp, lossy TL).**
+- `src/farfield.rs` — RP patterns, directivity (dBi), radiated-power integration, RP point generation, bilinear gain interpolation.
+
+## nec_accel — optional GPU acceleration
+CPU reference kernel + real wgpu compute shaders + per-frequency dispatch seam.
+Serves **DEC-003/008, NFR-003, PRT-011, Gates G3–G7, PH7-CHK-001..006**. wgpu is
+feature-gated (`--features wgpu`).
+
+- `src/lib.rs` — crate overview + `dispatch_frequency_point` scheduling seam (returns CPU fallback when GPU not wired); documents kernel status.
+- `src/gpu_kernels.rs` — CPU-reference Hallén far-field kernel (`compute_hallen_fr_point_cpu`/`_batch_cpu`), GPU-ready layouts (`GpuSegment`, `GpuFarFieldPoint`), `KernelTiming`. The parity baseline for shaders (PH7-CHK-001 renamed `*_stub` → `*_cpu`).
+- `src/wgpu_device.rs` — real wgpu dispatch: adapter enumeration, no-op gate, WGSL shaders for RP far-field, Z-matrix fill, and GPU-resident Hallén solve; `microbench_zmatrix_dispatch` (PH7-CHK-002); `solve_hallen_gpu_resident` (PH7-CHK-003).
+- `src/shaders/*.wgsl` — `zmatrix_fill.wgsl`, RP far-field, `hallen_normal_solve.wgsl` (GPU-resident solve: Jacobi equilibration + complex LU + Björck refinement).
+
+## nec_report — presentation only
+Formats solved results into the versioned text report. Serves **FR-005,
+PH2-CHK-004, EP-2/EP-3**.
+
+- `src/lib.rs` — `ReportInput` + row types (`CurrentRow`, `FeedpointRow`, `SourceRow`, pattern rows); `render_text_report` (`FORMAT_VERSION 1`); `ReportSection` (EP-3), `ResultFilter` (EP-2). No solving.
+
+## nec_project — project/workflow model
+Serde project/run configuration; TOML + Markdown round-trip. Serves **FR-004,
+GAP-010/015, PH3-CHK-004/005**.
+
+- `src/lib.rs` — `ProjectFile`, `SolverConfig`, `NamedRun`, `RunHistory`/`RunRecord`/`ResultSummary`; `from/to_toml`, `from/to_markdown`; version-guard `ProjectError`.
+
+## nec_worker — distributed execution
+Controller/worker protocol, local + SSH handles, worker pool, capability model,
+result cache. Serves **PRT-011, CP-011, PH6-CHK-005/006/007, PH7-CHK-004**.
+
+- `src/lib.rs` — facade + `encode_deck` base64 helper.
+- `src/protocol.rs` — NDJSON wire types (`TaskMessage`, `TaskResult`, `Impedance`, `WorkerSolverConfig` incl. `exec`, `ErrorCode`); serde-default for wire back-compat.
+- `src/capability.rs` — `Capability` (CPU threads, GPU/wgpu backend), `assignment_weight`, `CapabilityCache`.
+- `src/hosts.rs` — `HostsConfig`/`HostEntry` from `hosts.toml`; `HostsConfigError`.
+- `src/controller.rs` — `LocalWorkerHandle`: local `fnec worker --stdio` subprocess.
+- `src/ssh_worker.rs` — `SshWorkerHandle`: remote worker over `ssh`; `connect_all`.
+- `src/pool.rs` — `WorkerPool`/`WorkerHandle` (Local/Ssh); round-robin dispatch.
+- `src/solve.rs` — in-worker Hallén solve (`solve_deck_at_frequency`/`_with_exec`); GPU-resident dispatch for supported class (PH7-CHK-004).
+- `src/worker.rs` — `run_worker_stdio` event loop (stdin tasks → stdout results).
+- `src/result_cache.rs` — SHA-256 `cache_key(deck, config, freq)`; FIFO `ResultCache`.
+
+## apps/nec-cli (`fnec`) — CLI frontend & orchestrator
+Args → validate → solve (single/sweep/hybrid GPU/distributed) → report/bench.
+Serves **FR-002, FR-007/008, NFR-005, PRT-003, all `--exec`/sweep/vars flags**.
+
+- `src/main.rs` — entry wiring parse → validate → solve → report; mode select; sweep dispatch (local or `WorkerPool`).
+- `src/cli_args.rs` — arg parsing (`parse_args`, `ParsedArgs`, `USAGE`, `OutputFormat`).
+- `src/solve_session.rs` — solve orchestration: `SolverMode`/`PulseRhsMode`, per-point solve, sweep, residual metrics, feedpoint/source/load rows, hybrid-lane planning. **PH8-CHK-002 touches the EX-type routing here.**
+- `src/exec_profile.rs` — `Cpu/Hybrid/Gpu` selection; 4nec2 drop-in recognition; GPU probe.
+- `src/geometry_validation.rs` — intersection / buried-wire / risky-source checks.
+- `src/resonance_search.rs` — bisection resonance targeting (PH3-CHK-008).
+- `src/sweep_config.rs` — `--sweep-config` TOML (linear/point list).
+- `src/vars_config.rs` — `--vars` JSON/TOML map loader.
+- `src/bench.rs` — benchmark record emission (human/CSV/JSON).
+- `src/warnings.rs` — non-fatal user warnings (deferred ground, NT/PT deferral, pulse-experimental, GPU fallback). **PH8-CHK-002 replaces the EX plane-wave warning with real semantics.**
+
+## apps/nec-gui (`nec-gui`) — iced desktop frontend
+Testable state machine over `nec_solver`: solve, sweep, pattern, currents.
+Serves **FR-002, PRT-004, PH3-CHK-009/010/011**.
+
+- `src/main.rs` — iced app (`FnecGui`) wrapping `AppState`; async solve/sweep/pattern/currents tasks.
+- `src/lib.rs` — library facade (`app_state`, `solve`) for binary + headless tests.
+- `src/app_state.rs` — iced-free state machine: tabs, per-pipeline phases, `Message`, `AppState::apply`.
+- `src/solve.rs` — thin `nec_solver` wrappers (solve/sweep/pattern/currents).
+
+## bindings/fnec_py — Python binding
+`pyo3` cdylib exposing `solve_deck_str`/`sweep_deck_str`. Serves **FR-008,
+COMP-012, PH4-CHK-004**.

--- a/docs/project/requirements-register.md
+++ b/docs/project/requirements-register.md
@@ -1,0 +1,138 @@
+---
+project: fnec-rust
+doc: docs/project/requirements-register.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Requirements register
+
+Consolidated index of every requirement, scope decision, parity gap, competitive
+item, gap, and blocker ID used across the project, with its source document and
+current coverage state. This is the **left edge** of the traceability chain — the
+["what must be true"] that the rest of the chain satisfies.
+
+Detail lives in the source docs; this register exists so no ID is orphaned and so
+the [traceability-matrix.md](traceability-matrix.md) can point at a single
+canonical list.
+
+## Scope decisions (`DEC-*`) — source: `docs/requirements.md`
+
+| ID | Decision | Coverage |
+|:---|:---------|:---------|
+| DEC-001 | Support NEC-2 and NEC-4 incrementally | Phases 1–2, ongoing Phase 8 |
+| DEC-002 | Ground scope starts simple, complexity added later | Phase 2 (GN0/GN1/GN2), Phase 8 (PH8-CHK-006) |
+| DEC-003 | GPU via wgpu for the full Hallén path, optional with CPU fallback | Phases 5–7 |
+| DEC-004 | Text output first; JSON/CSV later | Phase 1 text, Phase 4 JSON (PH4-CHK-003) |
+| DEC-005 | Modern task-oriented GUI, not a 4nec2 clone | Phase 3 (PH3-CHK-009..012) |
+| DEC-006 | Plugin/scripting in scope | Phase 4 (EP-1..4) |
+| DEC-007 | License risk tracked via SBOM + dependency review | Phase 4 (PH4-CHK-001), `deny.toml`, SBOM gate |
+| DEC-008 | GPU prioritizes FOSS frameworks; AMD preferred | Phases 5–7 (wgpu Vulkan on AMD; ROCm/SYCL deferral) |
+| DEC-009 | Explicit parity targets vs NEC-2/4, 4nec2, EZNEC, AutoEZ, xnec2c, necpp | Roadmap parity tables; ongoing |
+| DEC-010 | Hallén supports non-collinear/junctioned multi-wire (hybrid formulation) | Phase 1 close (v0.3.0) |
+| DEC-011 | Sinusoidal mode must be safety-bounded with Hallén fallback | Phase 6 (PH6-CHK-003) |
+
+## Functional requirements (`FR-*`) — source: `docs/requirements.md`
+
+| ID | Requirement | Coverage |
+|:---|:------------|:---------|
+| FR-001 | Core solver as reusable Rust crates | `nec_parser/model/solver/report/project/accel/worker` |
+| FR-002 | CLI and GUI frontends | `apps/nec-cli`, `apps/nec-gui` |
+| FR-003 | Parse and execute real 4nec2 NEC decks | Phases 1–2; Phase 8 closes remaining cards |
+| FR-004 | Markdown project import/export | GAP-015 (done: `nec_project` `from/to_markdown`) |
+| FR-005 | 4nec2-like text reports | Phase 1 report contract v1 (PH2-CHK-004) |
+| FR-006 | Plugin/scripting extension mechanism | Phase 3–4 (EP-1..4) |
+| FR-007 | Deterministic batch/sweep workflows | Phase 3 (PH3-CHK-006/007/008) |
+| FR-008 | Stable automation-oriented core APIs | Phase 4 (PH4-CHK-003/004/006) |
+| FR-009 | Early geometry diagnostics | Phase 2 (PH2-CHK-006) |
+| FR-010 | Resonance/convergence/matching helpers | Phase 3 (PH3-CHK-008) |
+
+## Non-functional requirements (`NFR-*`) — source: `docs/requirements.md`
+
+| ID | Requirement | Coverage |
+|:---|:------------|:---------|
+| NFR-001 | Linux-first (Wayland), then macOS, then Windows | CI/dev on Linux; portability via `wgpu`/`iced` |
+| NFR-001a | Raspberry Pi 4/5 as in-scope acceleration reference | `scripts/pi-*`, benchmark matrix |
+| NFR-002 | CPU execution multithreaded and deterministic | rayon paths; `RAYON_NUM_THREADS` benchmark mode |
+| NFR-003 | GPU optional with reliable CPU fallback | Phase 5–7; `dispatch_frequency_point` fallback |
+| NFR-004 | Numerical compatibility measured with per-metric tolerance | Corpus + `reference-results.json` gates |
+| NFR-005 | Script-friendly stable stdin/stdout/stderr | Phase 2 scriptability contract (PH2-CHK-008) |
+| NFR-006 | Usability competitive with incumbents | Phase 3 usability benchmark (PH3-CHK-012) |
+
+## Compatibility requirements (`COMP-*`) — source: `docs/requirements.md`
+
+| ID | Requirement | Coverage |
+|:---|:------------|:---------|
+| COMP-001 | Tolerant parsing of real 4nec2 decks | `nec_parser`; corpus deck sanity |
+| COMP-002 | Output comparable to reference within tolerance matrix | Corpus validation gate |
+| COMP-003 | NEC-4 scope versioned and explicit | `docs/nec4-support.md`, `docs/card-support-matrix.md` |
+| COMP-004..007 | xnec2c secondary dialect, auto-detection, override, isolation | Parser dialect design (staged) |
+| COMP-008 | Accuracy never regresses below tolerance without contract change | CI corpus gate |
+| COMP-009 | Track 4nec2/EZNEC mainstream parity | Roadmap parity tables |
+| COMP-010 | Track xnec2c/yeti01-nec2/necpp | Roadmap parity tables |
+| COMP-011 | CLI sufficient to replace classic batch NEC tools | Phase 2 (PH2-CHK-008), GAP-011 |
+| COMP-012 | Embeddable automation surface (necpp-style) | Phase 4 bindings (PH4-CHK-004) |
+
+## Parity gaps (`PRT-*`) — source: `docs/roadmap.md` / `docs/requirements.md`
+
+| ID | Gap | Target phase | State |
+|:---|:----|:-------------|:------|
+| PRT-001 | Ground modeling short of NEC-4/EZNEC | Phase 2 | Partial; Phase 8 (PH8-CHK-006) extends |
+| PRT-002 | Loads/TL/network/source families lag | Phase 2–3 | Partial; Phase 8 (PH8-CHK-001..005) closes |
+| PRT-003 | Sweep/gain/pattern/report weaker than 4nec2 | Phase 1–2 | Done |
+| PRT-004 | GUI/workflow maturity behind | Phase 3 | Done |
+| PRT-005 | No optimization/parameter-sweep workflow | Phase 3–4 | Done |
+| PRT-006 | No AutoEZ-class automation | Phase 3–4 | Done |
+| PRT-007 | Weak geometry validation/embeddability | Phase 2–4 | Done |
+| PRT-008 | Accuracy program too narrow | Phase 1–3 | Done (broadened corpus) |
+| PRT-009 | No NEC-5 surfaces plan | Phase 4–5 | Decided: wire-only (`nec5-frontier.md`) |
+| PRT-010 | No NEC-5-informed validation matrix | Phase 2–3 | Done (PH2-CHK-007) |
+| PRT-011 | No distributed authenticated execution | Phase 5 | Done (Phase 6–7) |
+
+## Competitive parity work items (`CP-*`) — source: `docs/roadmap.md`
+
+`CP-001`..`CP-012`: full descriptions and comparators in the roadmap
+"Competitive parity work items" table. Cross-referenced by checklist rows in the
+[traceability-matrix.md](traceability-matrix.md). Notable active item: **CP-003**
+(missing source/TL/network cards break deck portability) is the driving item for
+Phase 8.
+
+## Gaps (`GAP-*`) and blockers (`BLK-*`) — source: `docs/roadmap.md`, `docs/requirements.md`
+
+| ID | Title | State |
+|:---|:------|:------|
+| GAP-002 | NEC-4 feature boundary | Resolved (`docs/nec4-support.md`) |
+| GAP-003 | MVP ground model set | Resolved (Phase 2) |
+| GAP-004 | Plugin/scripting interface | Resolved (BLK-004) |
+| GAP-005 | 4nec2-like text report | Resolved 2026-04-23 |
+| GAP-006 | GUI information architecture | Resolved (Phase 3) |
+| GAP-007 | GPU rollout criteria | Resolved 2026-05-03 (`docs/gpu-arch.md`) |
+| GAP-008 | Dependency/license policy | Resolved (BLK-005) |
+| GAP-009 | Workflow parity acceptance criteria | Resolved (PH3-CHK-012) |
+| GAP-010 | Automation/embedding strategy | Resolved (Phase 4) |
+| GAP-011 | Classic batch-CLI parity definition | Resolved (Phase 2) |
+| GAP-012 | AutoEZ-class automation acceptance | Resolved (Phase 3) |
+| GAP-013 | NEC-5-informed validation matrix | Resolved (PH2-CHK-007) |
+| GAP-014 | External optimizer-loop compatibility | Resolved (Phase 3) |
+| GAP-015 | Markdown project import/export | Resolved (`nec_project`) |
+| BLK-001 | Tolerance matrix defined | Resolved 2026-04-22 |
+| BLK-002 | NEC-4 feature boundary documented | Resolved |
+| BLK-003 | 4nec2 report contract locked | Resolved 2026-04-23 |
+| BLK-004 | Plugin API + first two extension points | Resolved 2026-04-30 |
+| BLK-005 | GPLv2 dependency policy | Resolved 2026-05-02 |
+
+## Checklist ID families (delivery units)
+
+The requirement IDs above are satisfied through **checklist items**, the natural
+traceability unit (each already carries requirement IDs + validation artifacts in
+the roadmap):
+
+- `PH1-CHK-*` … `PH8-CHK-*` — per-phase implementation checklists (`docs/roadmap.md`).
+- `G1`..`G7` — GPU milestone gates (Phase 5, `docs/gpu-arch.md`).
+- `PH2N5-*`, `PH6N5-*` — NEC-5-informed validation matrix rows
+  (`docs/corpus-validation-strategy.md`).
+- `EP-1`..`EP-4` — plugin extension points (`docs/plugin-api-design.md`).
+
+Phase 8 (`PH8-CHK-001..006`) is the only phase with open items;
+**PH8-CHK-002** (incident plane-wave excitation) is in progress — see its
+design record `docs/ph8-chk-002-plane-wave-excitation.md`.

--- a/docs/project/test-catalog.md
+++ b/docs/project/test-catalog.md
@@ -1,0 +1,83 @@
+---
+project: fnec-rust
+doc: docs/project/test-catalog.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Test catalog
+
+The **tests layer**: every test file, its function count, what it validates, and
+the checklist/requirement it gates. Counts are `#[test]`/`#[tokio::test]` function
+counts (measured, not estimated). Aggregate pass/fail is recorded separately in
+[test-results.md](test-results.md).
+
+## Integration / contract tests
+
+| Test file | # | Validates | Gates |
+|:----------|:--|:----------|:------|
+| `apps/nec-cli/tests/core_flags_contract.rs` | 15 | `--solver`/`--pulse-rhs`/`--exec` flag contract + usage errors | NFR-005, PH2-CHK-008 |
+| `apps/nec-cli/tests/corpus_deck_sanity.rs` | 1 | Every corpus `.nec` deck has a `GE` card | Corpus hygiene |
+| `apps/nec-cli/tests/corpus_validation.rs` | 8 | Golden corpus matches references; checklist coverage (PAR002/003/005, loaded, pattern) | NFR-004, COMP-002/008, PH2-CHK-005/007 |
+| `apps/nec-cli/tests/deck_validator.rs` | 4 | Deck validator warns on missing `EX`; silent on well-formed decks | FR-009, EP-4 |
+| `apps/nec-cli/tests/ex_cards.rs` | 9 | `EX` types 0/1/3 feedpoint parity; unsupported types rejected | CP-003, PH8-CHK-001/002 (baseline) |
+| `apps/nec-cli/tests/exec_modes.rs` | 24 | `--exec` selection, drop-in alias resolution, sandbox paths | DEC-003, CP-012 |
+| `apps/nec-cli/tests/geometry_diagnostics.rs` | 3 | Fail-fast on crossing wires / tiny source; valid junctions accepted | FR-009, PH2-CHK-006 |
+| `apps/nec-cli/tests/gpu_benchmark_gate.rs` | 1 | Gate G5: GPU exec ≤1.5× CPU on large RP grid (best-of-N) | PH5-CHK-005, PH7-CHK-002 |
+| `apps/nec-cli/tests/gpu_resident_solve_cli.rs` | 1 | `--exec gpu` feedpoint Z within 2 Ω of CPU on corpus | PH7-CHK-003 |
+| `apps/nec-cli/tests/gpu_rp_exec.rs` | 2 | Gate G4: `--exec gpu` RP far-field matches CPU | PH5-CHK-004 |
+| `apps/nec-cli/tests/ground_diagnostics.rs` | 10 | `GN`/`GE` handling: PEC inference, GN0/GN2 active, GN3 deferred | PRT-001, PH2-CHK-001/002 |
+| `apps/nec-cli/tests/hallen_fr_cpu_reference.rs` | 6 | Hallén FR CPU reference kernel (wgpu RP parity baseline) | PH5-CHK-003, PH7-CHK-001 |
+| `apps/nec-cli/tests/json_output_contract.rs` | 5 | JSON output valid/stable, required fields, sweep records | FR-008, PH4-CHK-003 |
+| `apps/nec-cli/tests/ld_loads.rs` | 5 | `LD` types 1/2/4 change impedance; unsupported warn+continue | PRT-002, PH2-CHK-003 |
+| `apps/nec-cli/tests/loaded_case_tracking.rs` | 2 | Loaded non-collinear topology solves; `--allow-noncollinear` no-op | DEC-010 |
+| `apps/nec-cli/tests/parser_warnings.rs` | 22 | Warnings for unknown cards, `TL` types/segments; runs still succeed | COMP-001, PRT-002 |
+| `apps/nec-cli/tests/report_contract.rs` | 5 | Report v1 headers/rows; RP/sweep/load tables; section ordering | FR-005, PH2-CHK-004 |
+| `apps/nec-cli/tests/resonance_contract.rs` | 3 | `--resonance` convergence, unbounded fail, missing-flag usage | FR-010, PH3-CHK-008 |
+| `apps/nec-cli/tests/result_cache_contract.rs` | 5 | Distributed result cache hit/miss/invalidation + sweep reuse | PH6-CHK-007 |
+| `apps/nec-cli/tests/scriptability_contract.rs` | 25 | Scripting/drop-in alias contract; temp-file & path handling | NFR-005, GAP-011, PH2-CHK-008 |
+| `apps/nec-cli/tests/sinusoidal_a2_regression.rs` | 2 | Sinusoidal solver tracks Hallén on dipole + sweep | DEC-011, PH6-CHK-003 |
+| `apps/nec-cli/tests/sweep_contract.rs` | 5 | Sweep point/list/linear produce correct frequency blocks | FR-007, PH3-CHK-006 |
+| `apps/nec-cli/tests/template_contract.rs` | 5 | TOML/JSON var substitution; undefined-token error | PH3-CHK-007 |
+| `apps/nec-cli/tests/tl_cards.rs` | 3 | `TL` card changes feedpoint Z across nseg | PRT-002, PH2-CHK-003 |
+| `apps/nec-cli/tests/topology_fallback.rs` | 13 | Non-single-chain fallback across solver/pulse/exec/sinusoidal/loaded | DEC-010/011 |
+| `apps/nec-cli/tests/worker_gpu_exec.rs` | 1 | Distributed GPU dispatch through worker pool (mixed gpu/cpu) | PH7-CHK-004 |
+| `apps/nec-cli/tests/worker_integration.rs` | 7 | Hosts config, capability cache, subprocess round-trip | PH6-CHK-006/007 |
+| `apps/nec-gui/tests/gui_smoke.rs` | 47 | Headless GUI state machine + solve pipeline | PRT-004, PH3-CHK-009/010/011 |
+| `crates/nec_accel/tests/gpu_hallen_solve.rs` | 1 | Gate G7: GPU Z-fill + CPU Hallén solve end-to-end | PH5-CHK-007 |
+| `crates/nec_accel/tests/gpu_microbench.rs` | 1 | Microbench separates per-dispatch time from device init | PH7-CHK-002 |
+| `crates/nec_accel/tests/gpu_resident_solve.rs` | 1 | Fully GPU-resident Hallén fill+solve parity | PH7-CHK-003 |
+| `crates/nec_accel/tests/gpu_zmatrix_parity.rs` | 1 | Gate G6: GPU Z-fill element-wise parity vs CPU | PH5-CHK-006 |
+| `crates/nec_project/tests/project_roundtrip.rs` | 20 | `ProjectFile` TOML/Markdown round-trip + errors | FR-004, PH3-CHK-004/005, GAP-015 |
+| `crates/nec_solver/tests/pulse_rhs_scaling.rs` | 1 | Pulse RHS inverse-wavelength scaling | PRT-002 |
+| `crates/nec_worker/tests/gpu_exec.rs` | 2 | Worker-level GPU execution vs CPU parity | PH7-CHK-004 |
+
+Integration subtotal: **266** test functions (nec-cli 192, nec-gui 47,
+nec_accel 4, nec_project 20, nec_solver 1, nec_worker 2).
+
+## Unit tests (in `src/`)
+
+| Crate | # `#[test]` | Concentration |
+|:------|:------------|:--------------|
+| `nec_solver` | 100 | loads 18, geometry 20, excitation 15, linear 14, matrix 12, farfield 9, basis 6, tl 6 |
+| `nec_worker` | 66 | worker 17, result_cache 13, solve 7, capability 7, protocol 6, hosts 6, pool 5, controller 3, ssh_worker 2 |
+| `nec_report` | 25 | lib 25 |
+| `nec_accel` | 25 | gpu_kernels 20, lib 5 |
+| `nec_parser` | 21 | lib 14, template 7 |
+| `nec_project` | 12 | lib 12 |
+| `apps/nec-cli` | 10 | main 10 |
+| `nec_model` | 7 | lib 7 |
+
+Unit subtotal: **266** `#[test]` functions.
+
+## Totals
+
+- **`#[test]` functions**: ~532 (266 integration + 266 unit).
+- **`cargo test --workspace` aggregate** (includes doctests): **539 passing** across
+  53 test binaries — the authoritative pass count in [test-results.md](test-results.md).
+- **wgpu-gated GPU tests** (`cargo test -p nec_accel --features wgpu`): **29 passing**
+  across 6 binaries (real device dispatch, not the software rasterizer).
+
+The small gap between the `#[test]` grep count (532) and the `cargo test` aggregate
+(539) is doctests and feature-gated variants, which `cargo test` runs but the grep
+does not count.

--- a/docs/project/test-results.md
+++ b/docs/project/test-results.md
@@ -1,0 +1,95 @@
+---
+project: fnec-rust
+doc: docs/project/test-results.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Test results
+
+The **results layer**: recorded outcomes of the test/gate runs that back the
+traceability claims. Each entry pins the commit, toolchain, command, and result so
+a claim of "passing" is auditable, not asserted.
+
+Update this file before each push whenever code or tests changed (see the pre-push
+rule in [README.md](README.md)).
+
+## Latest recorded run
+
+| Field | Value |
+|:------|:------|
+| Date | 2026-07-02 |
+| Commit | `4bf66e4` (main) |
+| Version | fnec-rust 0.7.0 |
+| Toolchain | rustc 1.94.1 (e408947bf 2026-03-25) |
+| Host | Linux 6.18 x86_64 (AMD Renoir gfx90c APU, RADV Vulkan) |
+
+### `cargo test --workspace` (default features)
+
+```
+539 passed; 0 failed; 0 ignored — across 53 test binaries
+exit code 0
+```
+
+Authoritative workspace pass count. Covers all crates and both apps with the CPU
+solver path and the GPU dispatch seam in CPU-fallback mode (wgpu feature off).
+
+### `cargo test -p nec_accel --features wgpu` (real GPU dispatch)
+
+```
+29 passed; 0 failed; 0 ignored — across 6 test binaries
+exit code 0
+```
+
+Exercises the real wgpu device path (adapter enumeration, WGSL Z-fill, RP
+far-field, and the GPU-resident Hallén solve) on the AMD RADV RENOIR Vulkan
+backend — not the CI software rasterizer. This is the evidence behind the Phase 7
+GPU-residency claims (PH7-CHK-003/004) and gates G6/G7.
+
+### `cargo clippy --workspace`
+
+```
+exit code 0 — clean (no warnings)
+```
+
+## Standing CI gates (contract-level, always-on)
+
+| Gate | Script / test | Enforces |
+|:-----|:--------------|:---------|
+| Corpus tolerance | `apps/nec-cli/tests/corpus_validation.rs` + `corpus/reference-results.json` | NFR-004, COMP-002/008 — impedance/gain/pattern/current within tolerance |
+| Report contract | `report_contract.rs`, `scriptability_contract.rs` | FR-005, NFR-005 — stable machine-parseable output |
+| Doc frontmatter | `scripts/validate-docs-frontmatter.sh` | Every `docs/*.md` has the 4-key frontmatter block |
+| Version-bump docs | `scripts/check-version-bump-docs.sh` | A `Cargo.toml` version bump requires changelog + releasenotes + SBOM changes |
+| Dependency licenses | `deny.toml` (`cargo deny check licenses`) | GAP-008/BLK-005 SPDX allowlist |
+| Benchmark regression | `.benchmark-gates.toml` + `.github/workflows/benchmark-dashboard.yml` | PH6-CHK-001 regression-delta thresholds |
+
+## Milestone gate evidence (historical, from roadmap)
+
+Point-in-time numerical evidence recorded at delivery; re-verified by the standing
+tests above on every run.
+
+| Gate | Evidence |
+|:-----|:---------|
+| G6 (GPU Z-fill parity) | max rel err 2.12×10⁻⁶ vs CPU (limit 1×10⁻⁴), 51-seg dipole @ 14 MHz |
+| G7 (GPU fill + CPU solve) | ΔR=0 Ω, ΔX=0 Ω vs all-CPU reference |
+| PH7-CHK-003 (GPU-resident solve) | ΔR=0.012 Ω, ΔX=0.002 Ω vs f64 CPU; 3 corpus decks ≤0.01 Ω |
+| PH7-CHK-002 (microbench) | 61 ms device-init vs 268 µs dispatch (~227× isolation); 10/10 non-flaky |
+| PH7-CHK-005 (real GPU crossover) | Z-fill: GPU beats CPU <32 seg, up to ~240× at 1536 seg; RP 1.5–1.8× faster |
+| Reference dipole (Phase 0 baseline) | 51-seg λ/2 dipole → 74.24 + j13.90 Ω (matches Python reference) |
+
+## How to reproduce
+
+```sh
+# Full workspace (CPU path):
+cargo test --workspace
+
+# Real GPU path (needs a wgpu-capable adapter):
+cargo test -p nec_accel --features wgpu
+
+# Lint:
+cargo clippy --workspace
+
+# Doc frontmatter + version-bump gates:
+scripts/validate-docs-frontmatter.sh
+scripts/check-version-bump-docs.sh
+```

--- a/docs/project/tooling-catalog.md
+++ b/docs/project/tooling-catalog.md
@@ -1,0 +1,85 @@
+---
+project: fnec-rust
+doc: docs/project/tooling-catalog.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Helper & validation tooling catalog
+
+The **tooling layer**: the scripts, harnesses, corpus, and external reference
+engines that produce and defend the test evidence. These sit alongside the test
+layer — they generate references, gate contracts, and benchmark performance.
+
+## Release / contract gates (`scripts/`)
+
+| Tool | Purpose | Gates |
+|:-----|:--------|:------|
+| `validate-docs-frontmatter.sh` | Validate the 4-key frontmatter block on every `docs/*.md` | Doc contract |
+| `validate-doc-frontmatter.sh` | Thin alias delegating to the plural script | Doc contract |
+| `check-version-bump-docs.sh` | A `Cargo.toml` version bump must ship changelog + releasenotes + SBOM changes | Release contract |
+| `stamp-doc-last-updated.sh` | Stamp `last_updated` on changed docs for PR automation | Doc contract |
+
+## Benchmark harnesses (`scripts/`)
+
+| Tool | Purpose |
+|:-----|:--------|
+| `run-benchmark-matrix.sh` | Run the three-mode matrix (CPU single-thread / CPU multi-thread / GPU) |
+| `benchmark-compare-json.sh` | Compare two benchmark JSON artifacts and compute regression deltas |
+| `test-benchmark-gate.sh` | Exercise the benchmark regression gate locally |
+| `pi-benchmark-compare.sh` | Raspberry Pi CPU/GPU comparison (NFR-001a reference hardware) |
+| `pi-benchmark-history.sh` | Track Pi benchmark history across runs |
+| `pi-benchmark-summary.sh` | Summarize Pi benchmark results |
+| `pi-remote-benchmark.sh` | Drive a benchmark on a remote Pi over SSH |
+| `pi-remote-workspace-check.sh` | Verify the remote Pi workspace before a remote run |
+
+## Reference-data helpers (`scripts/`)
+
+| Tool | Purpose |
+|:-----|:--------|
+| `import-reference-impedance.py` | Import external (NEC2/4nec2) reference impedances into `corpus/reference-results.json` |
+| `fix_patterns.py` | Batch-fix/normalize corpus RP pattern-sample data |
+
+## In-repo example harnesses
+
+| Harness | Purpose | Backs |
+|:--------|:--------|:------|
+| `apps/nec-cli/examples/gpu_crossover.rs` | Measure the real discrete-GPU vs CPU crossover; emits `benchmarks/real-gpu-crossover.json` | PH7-CHK-005 |
+
+## Corpus & reference data (`corpus/`)
+
+The corpus is the numerical ground truth (NFR-004, COMP-002/008). ~40 `.nec`
+decks plus:
+
+| Artifact | Role |
+|:---------|:-----|
+| `corpus/reference-results.json` | Golden reference values + per-metric tolerances; consumed by `corpus_validation.rs` |
+| `corpus/reference-import-template.json` | Template for importing new external references |
+| `corpus/README.md` | Corpus conventions and provenance |
+| `corpus/dipole-*.nec`, `yagi-*.nec`, `tl-*.nec`, `multi-source-*.nec` | Deck fixtures spanning free-space/ground/loaded/RP/TL/multi-source/GM-GR classes |
+
+Benchmark artifacts live under `benchmarks/` (`ci-baseline.json`,
+`real-gpu-crossover.json`).
+
+## External validation engines
+
+Cross-tool validation references (not vendored; invoked from the host):
+
+| Tool | Role | Notes |
+|:-----|:-----|:------|
+| `nec2c` (`/usr/bin/nec2c`) | NEC-2 reference engine for external parity | Has an input-path-length limit — use short paths like `/tmp/nec/`. For source-free scattering decks (plane wave) an `XQ` execute card is required to print the induced `CURRENTS AND LOCATION` table. |
+| Python MoM reference (`hallen_reference.py`) | Independent Hallén cross-check | Phase 0 baseline validation |
+| xnec2c / 4nec2 | Mainstream comparators | Design/behaviour references (roadmap parity tables) |
+
+### PH8-CHK-002 external reference (in-flight)
+
+`docs/dev/ph8-planewave-ref-theta30.nec` — a checked-in `nec2c` harness deck
+(`EX 1 1 1 0 30 0 0` + `XQ 0`) that makes `nec2c` solve and print the induced
+currents for a θ=30° incident plane wave. This is the external parity reference for
+the PH8-CHK-002 plane-wave RHS work.
+
+## Software-bill-of-materials
+
+`SBOM.spdx.json` (regenerated via `cargo sbom > SBOM.spdx.json`) — required to
+change on any version bump by `check-version-bump-docs.sh`; backs DEC-007 license
+tracking.

--- a/docs/project/traceability-matrix.md
+++ b/docs/project/traceability-matrix.md
@@ -1,0 +1,189 @@
+---
+project: fnec-rust
+doc: docs/project/traceability-matrix.md
+status: living
+last_updated: 2026-07-02
+---
+
+# Traceability matrix
+
+The end-to-end matrix tying **requirement → design → implementation → tests →
+result** for every delivery unit. Two views:
+
+- **View A — requirement coverage**: each top-level requirement family → the
+  phase/checklist(s) that satisfy it → state.
+- **View B — checklist delivery matrix**: each `PHx-CHK-*` item → its full
+  five-layer chain.
+
+Column legend for View B: **Req** = requirement/gap IDs; **Design** = the design
+doc node; **Impl** = primary implementation modules; **Tests** = the gating test
+artifact(s); **Result** = recorded outcome. Detail behind each column lives in the
+sibling layer docs ([requirements](requirements-register.md) ·
+[design](architecture-design-index.md) · [implementation](implementation-map.md) ·
+[tests](test-catalog.md) · [results](test-results.md) ·
+[tooling](tooling-catalog.md)).
+
+Status legend: ✅ done · 🔨 in progress · 📋 planned.
+
+---
+
+## View A — requirement coverage
+
+| Requirement | Satisfied by | State |
+|:------------|:-------------|:------|
+| FR-001 reusable Rust crates | 7 crates + 2 apps | ✅ |
+| FR-002 CLI + GUI | `apps/nec-cli`, `apps/nec-gui` | ✅ |
+| FR-003 execute real NEC decks | Phases 1–2; Phase 8 residual cards | 🔨 (Phase 8) |
+| FR-004 Markdown project I/O | `nec_project` (GAP-015) | ✅ |
+| FR-005 4nec2-like text reports | PH2-CHK-004 report contract v1 | ✅ |
+| FR-006 plugin/scripting | EP-1..4 (Phase 3–4) | ✅ |
+| FR-007 batch/sweep workflows | PH3-CHK-006/007/008 | ✅ |
+| FR-008 stable automation APIs | PH4-CHK-003/004/006 | ✅ |
+| FR-009 geometry diagnostics | PH2-CHK-006 | ✅ |
+| FR-010 resonance/matching helpers | PH3-CHK-008 | ✅ |
+| NFR-002 multithreaded/deterministic CPU | rayon solve paths | ✅ |
+| NFR-003 optional GPU + CPU fallback | Phases 5–7 | ✅ |
+| NFR-004 per-metric tolerance | corpus + `reference-results.json` | ✅ |
+| NFR-005 script-friendly streams | PH2-CHK-008 | ✅ |
+| NFR-006 competitive usability | PH3-CHK-012 | ✅ |
+| COMP-001 tolerant parsing | `nec_parser` | ✅ |
+| COMP-002/008 tolerance-gated accuracy | corpus gate | ✅ |
+| COMP-003 versioned NEC-4 scope | `nec4-support.md`, `card-support-matrix.md` | ✅ (living) |
+| PRT-001 ground modeling | Phase 2; PH8-CHK-006 extends | 🔨 (Phase 8) |
+| PRT-002 loads/TL/network/source | Phase 2; PH8-CHK-001..005 | 🔨 (Phase 8) |
+| PRT-003 sweep/gain/pattern/report | Phase 1–2 | ✅ |
+| PRT-004 GUI/workflow | Phase 3 | ✅ |
+| PRT-005/006 optimization/automation | Phase 3–4 | ✅ |
+| PRT-007 geometry/embeddability | Phase 2–4 | ✅ |
+| PRT-008 accuracy breadth | Phase 1–3 corpus | ✅ |
+| PRT-009 NEC-5 surfaces | wire-only decision (`nec5-frontier.md`) | ✅ (decided) |
+| PRT-010 NEC-5 validation matrix | PH2-CHK-007 | ✅ |
+| PRT-011 distributed execution | Phases 6–7 | ✅ |
+| CP-003 deck-portability cards | **Phase 8 (in flight)** | 🔨 |
+| GAP-002..015, BLK-001..005 | see [register](requirements-register.md) | ✅ all resolved |
+
+---
+
+## View B — checklist delivery matrix
+
+### Phase 1 — NEC foundation (complete, v0.3.0)
+
+Delivered as roadmap key-deliverables rather than numbered CHK rows. Chain:
+**Req** FR-003/005, PRT-003/008, DEC-010 → **Design** `applied-math.md`,
+`architecture.md` → **Impl** `nec_parser`, `nec_solver` (geometry/matrix/linear),
+`nec_report` → **Tests** `corpus_validation.rs`, `report_contract.rs`,
+`topology_fallback.rs` → **Result** reference dipole 74.24+j13.90 Ω; corpus green.
+✅
+
+### Phase 2 — compatibility expansion (complete, v0.5.0)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH2-CHK-001 | PRT-001, CP-002 | `nec4-support.md` | `nec_solver/geometry.rs` (GroundModel) | `ground_diagnostics.rs`, `corpus_validation.rs` | GN2 solves; 6 ground fixtures gated | ✅ |
+| PH2-CHK-002 | PRT-001/008 | `nec4-support.md` | `nec-cli/geometry_validation.rs` | `ground_diagnostics.rs` | buried-wire fail-fast; near-ground gated | ✅ |
+| PH2-CHK-003 | PRT-002, CP-003 | `card-support-matrix.md` | `nec_solver/loads.rs`, `tl.rs` | `ld_loads.rs`, `tl_cards.rs`, `parser_warnings.rs` | LD 0–5, TL lossless, NT portability | ✅ |
+| PH2-CHK-004 | PRT-003, CP-001 | `design.md` | `nec_report/lib.rs` | `report_contract.rs`, `scriptability_contract.rs` | 6 stable sections, ordered | ✅ |
+| PH2-CHK-005 | PRT-008, CP-001 | `corpus-validation-strategy.md` | `nec_solver/farfield.rs` | `corpus_validation.rs` | RP/gain/current gates added | ✅ |
+| PH2-CHK-006 | PRT-007, CP-007 | `design.md` | `nec-cli/geometry_validation.rs` | `geometry_diagnostics.rs` | intersection/source/junction gates | ✅ |
+| PH2-CHK-007 | PRT-010 | `corpus-validation-strategy.md` | corpus matrix rows | `corpus_validation.rs` | `PH2N5-001..010` traceable | ✅ |
+| PH2-CHK-008 | PRT-003/007 | `design.md` | `nec-cli/main.rs`, `warnings.rs` | `scriptability_contract.rs`, `core_flags_contract.rs` | stream/exit-code contracts locked | ✅ |
+
+### Phase 3 — UX & workflow (complete, v0.5.0)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH3-CHK-001 | GAP-002 | `nec4-support.md` | card status index | `corpus_validation.rs` | 25-row card table | ✅ |
+| PH3-CHK-002 | PRT-004, GAP-009 | `contributing.md` | docs | frontmatter gate | contributor guide | ✅ |
+| PH3-CHK-003 | GAP-004, BLK-004 | `plugin-api-design.md` | `nec_model`, `nec_report` (EP-1/2) | doctests | EP-1/EP-2 exercised | ✅ |
+| PH3-CHK-004/005 | PRT-004, GAP-010 | `project-format.md` | `nec_project/lib.rs` | `project_roundtrip.rs` | project + run history | ✅ |
+| PH3-CHK-006 | PRT-005 | `automation-guide.md` | `nec-cli/sweep_config.rs` | `sweep_contract.rs` | `--sweep-config` | ✅ |
+| PH3-CHK-007 | PRT-005/006 | — | `nec_parser/template.rs`, `nec-cli/vars_config.rs` | `template_contract.rs` | `--vars` engine | ✅ |
+| PH3-CHK-008 | PRT-006, GAP-012 | — | `nec-cli/resonance_search.rs` | `resonance_contract.rs` | bisection resonance | ✅ |
+| PH3-CHK-009..011 | PRT-004 | `design.md` | `nec-gui/*` | `gui_smoke.rs` (47) | solve/sweep/pattern/currents | ✅ |
+| PH3-CHK-012 | GAP-009, PRT-004 | `usability-benchmark-ph3.md` | — | benchmark record | ≤7-action sweep; vs xnec2c | ✅ |
+
+### Phase 4 — extensibility (complete, v0.5.0)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH4-CHK-001 | GAP-008, BLK-005 | `dependency-policy.md` | `deny.toml`, SBOM | `cargo deny check licenses` | 13-ID allowlist; clean | ✅ |
+| PH4-CHK-002 | GAP-004 | `plugin-api-design.md` | `nec_report` (EP-3) | doctests + unit | ReportSection | ✅ |
+| PH4-CHK-003 | FR-008, PRT-007 | `json-output-schema.md` | `nec-cli` `--output-format json` | `json_output_contract.rs` | schema v1 stable | ✅ |
+| PH4-CHK-004 | FR-008, COMP-012 | `python-bindings.md` | `bindings/fnec_py/` | `test_smoke.py` | pyo3 `solve/sweep_deck_str` | ✅ |
+| PH4-CHK-005 | GAP-004 | `plugin-api-design.md` | `nec_model` (EP-4) | `deck_validator.rs` | DeckValidator | ✅ |
+| PH4-CHK-006 | GAP-012 | `automation-guide.md` | docs + example | frontmatter gate | automation guide | ✅ |
+| PH4-CHK-007 | PRT-009, GAP-009 | `phase5-entry-criteria.md` | — | frontmatter gate | measurable GPU entry gate | ✅ |
+
+### Phase 5 — GPU acceleration (complete, v0.5.0; gates G1–G7)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH5-CHK-001 | GAP-007 | `gpu-arch.md` | — | — | wgpu chosen; G1–G7 defined | ✅ |
+| PH5-CHK-002 | DEC-003 | `gpu-arch.md` | `nec_accel/wgpu_device.rs` | `nec_accel` unit | device enum + no-op pipeline | ✅ |
+| PH5-CHK-003 | DEC-003 | `gpu-arch.md` | RP WGSL shader | `hallen_fr_cpu_reference.rs` | G3 RP parity | ✅ |
+| PH5-CHK-004 | DEC-003 | `gpu-arch.md` | `nec-cli` `--exec gpu` | `gpu_rp_exec.rs` | G4 CLI RP parity | ✅ |
+| PH5-CHK-005 | DEC-003 | `gpu-arch.md` | benchmark path | `gpu_benchmark_gate.rs` | G5 timing gate | ✅ |
+| PH5-CHK-006 | DEC-003 | `gpu-arch.md` | `zmatrix_fill.wgsl` | `gpu_zmatrix_parity.rs` | G6 rel err 2.12e-6 | ✅ |
+| PH5-CHK-007 | DEC-003 | `gpu-arch.md` | `nec_accel`, `nec_solver` | `gpu_hallen_solve.rs` | G7 ΔR=ΔX=0 Ω | ✅ |
+
+### Phase 6 — scale-out & multi-vendor GPU (complete, v0.6.0)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH6-CHK-001 | — | `benchmark-artifact-schema.md` | `benchmark-dashboard.yml` | benchmark gate | dashboard + gh-pages | ✅ |
+| PH6-CHK-002 | PRT-009, CP-009 | `nec5-frontier.md` | corpus rows | `corpus_validation.rs` | wire-only; `PH6N5-*` | ✅ |
+| PH6-CHK-003 | DEC-011 | `rooftop-basis-plan.md` | `nec_solver/basis.rs`, `linear.rs` | `sinusoidal_a2_regression.rs` | sinusoidal EFIE; warning retired | ✅ |
+| PH6-CHK-004 | DEC-008, CP-009 | `multi-vendor-gpu.md` | `nec_accel` | wgpu parity tests | AMD Vulkan validated | ✅ |
+| PH6-CHK-005 | PRT-011, CP-011 | `distributed-execution-design.md` | — | — | transport/authN design | ✅ |
+| PH6-CHK-006 | PRT-011 | `worker-deployment.md` | `nec_worker/*` | `worker_integration.rs` | two-node solve match | ✅ |
+| PH6-CHK-007 | PRT-011 | `distributed-execution-design.md` | `nec_worker/result_cache.rs` | `result_cache_contract.rs` | hit/miss/invalidation | ✅ |
+
+### Phase 7 — GPU productionization (complete, v0.7.0)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH7-CHK-001 | — | `ph7-chk-001-gpu-stub-retirement.md` | `nec_accel/gpu_kernels.rs`, `lib.rs` | `nec_accel` unit | scaffold retired; no fake GPU time | ✅ |
+| PH7-CHK-002 | — | `ph7-chk-002-gpu-microbenchmark.md` | `wgpu_device.rs` (`microbench_*`) | `gpu_microbench.rs` | 61 ms init vs 268 µs dispatch; 10/10 | ✅ |
+| PH7-CHK-003 | CP-011 | `ph7-chk-003-gpu-resident-solve.md` | `hallen_normal_solve.wgsl`, `solve_hallen_gpu_resident` | `gpu_resident_solve.rs`, `gpu_resident_solve_cli.rs` | ΔR=0.012 Ω vs f64 CPU | ✅ |
+| PH7-CHK-004 | PRT-011, CP-011 | `ph7-chk-004-distributed-gpu-execution.md` | `nec_worker/protocol.rs`, `solve.rs` | `worker_gpu_exec.rs`, `gpu_exec.rs` | GPU node Δ≈0.009 Ω; CPU fallback | ✅ |
+| PH7-CHK-005 | DEC-008, CP-009 | `ph7-chk-005-real-gpu-benchmark.md` | `examples/gpu_crossover.rs` | benchmark artifact | ~240× Z-fill at 1536 seg | ✅ |
+| PH7-CHK-006 | DEC-008, CP-009 | `multi-vendor-gpu.md` | — | frontmatter gate | dated ROCm/SYCL deferral | ✅ |
+
+### Phase 8 — deck-portability frontier (in progress)
+
+| ID | Req | Design | Impl | Tests | Result | S |
+|:---|:----|:-------|:-----|:------|:-------|:-:|
+| PH8-CHK-001 | CP-003, PRT-002 | roadmap row | `nec_solver/excitation.rs`, `nec-cli/solve_session.rs` | `ex_cards.rs` (+ new fixture) | — | 📋 |
+| PH8-CHK-002 | CP-003, PRT-002 | `ph8-chk-002-plane-wave-excitation.md` | `nec_model/card.rs` (ExCard), `nec_parser`, `nec_solver/excitation.rs` | `ex_cards.rs` (+ `dipole-ex2-planewave-*`) | **Foundation merged (#255):** NEC2 EX-type alignment decision + `nec2c` reference deck `docs/dev/ph8-planewave-ref-theta30.nec`. Solve pending. | 🔨 |
+| PH8-CHK-003 | CP-003, PRT-002 | roadmap row | `nec_solver/excitation.rs` | `ex_cards.rs` (+ fixture) | — | 📋 |
+| PH8-CHK-004 | CP-003, PRT-002 | roadmap row | `nec_solver/tl.rs` (`build_nt_stamps`) | new `nt_*` fixture | — | 📋 |
+| PH8-CHK-005 | CP-003, PRT-002 | roadmap row | `nec_solver/tl.rs` (lossy) | `tl_cards.rs` (+ fixture) | — | 📋 |
+| PH8-CHK-006 | CP-002, PRT-001 | `nec4-support.md` | `nec_solver` ground path | `ground_diagnostics.rs`, corpus | — | 📋 |
+
+---
+
+## In-flight focus: PH8-CHK-002
+
+Full chain for the item currently being implemented:
+
+- **Requirement**: CP-003 (missing source cards break deck portability),
+  PRT-002. Roadmap `PH8-CHK-002`.
+- **Design / decisions**: `docs/ph8-chk-002-plane-wave-excitation.md` — two
+  decisions: (1) **align EX-type numbering to NEC2** (type 1 = plane wave; current
+  source → type 4), user-approved 2026-06-27; (2) plane-wave RHS lives in the
+  integral-equation **forcing term** (`exp(-jk_s s)` closed form for straight
+  wires), not the delta-gap RHS.
+- **Implementation** (staged): `nec_model/card.rs` (`ExCard` + polarization
+  field) → `nec_parser` (read the field) → `nec_solver/excitation.rs`
+  (plane-wave forcing RHS) → `nec-cli/solve_session.rs` + `warnings.rs`
+  (route type 1 as plane wave, retire the EX-0 warning) → `nec_report`
+  (induced-current / receiving-voltage output).
+- **Tests**: `apps/nec-cli/tests/ex_cards.rs` extended; new corpus fixture
+  `dipole-ex2-planewave-*`; external `nec2c` parity + internal Rayleigh–Carson
+  reciprocity gates.
+- **Tooling / reference**: `docs/dev/ph8-planewave-ref-theta30.nec` (`nec2c`
+  induced-current reference, needs `XQ`), plus the reciprocity cross-check against
+  the validated RP far-field path.
+- **Result**: foundation (decision + parser/model support + reference deck)
+  merged in **PR #255** (`4bf66e4`). Solve increment pending — this row updates as
+  each staged increment lands.


### PR DESCRIPTION
## What

Adds a consolidated **traceability layer** under `docs/project/` that ties the whole delivery chain together — requirements/changes → architecture/design → implementation → tests → test results → helper/validation tooling — with an end-to-end **traceability matrix** as the centerpiece.

Requested: *"create full traceability for the project … create a traceability matrix and keep it up to date at least before each push. use documents in md format and put them in docs/project."*

### New docs (`docs/project/`)
- **README.md** — the chain, document map, source-of-truth policy, and the **pre-push maintenance rule** (keep the matrix current before every push).
- **traceability-matrix.md** — ★ centerpiece. *View A* = requirement coverage; *View B* = per-checklist five-layer matrix for Phases 1–8, with the in-flight **PH8-CHK-002** chain called out.
- **requirements-register.md** — every FR/NFR/COMP/DEC/PRT/CP/GAP/BLK ID with source + coverage state.
- **architecture-design-index.md** — foundational + per-checklist design/decision docs.
- **implementation-map.md** — 7 crates + 2 apps + 1 py binding, module responsibilities and requirements served.
- **test-catalog.md** — every test file, measured `#[test]` counts (266 integration + 266 unit), and the checklist each gates.
- **test-results.md** — recorded run at `4bf66e4` / rustc 1.94.1: **539 passing** (default features, 53 binaries), **29 passing** wgpu GPU tests, clippy clean; standing gates + milestone evidence.
- **tooling-catalog.md** — scripts, benchmark harnesses, corpus, and external reference engines (`nec2c`, Python MoM).

Linked from `docs/README.md`.

## Also: unblock the push gate (separate commit)

The advisory DB updated 2026-07-02 and two `quick-xml` DoS advisories (RUSTSEC-2026-0194/0195) began failing the pre-push `cargo audit` gate, blocking **all** pushes. `quick-xml` is a **build-time-only** proc-macro dep of `wayland-scanner` (trusted in-crate Wayland XML), unreachable from any runtime path; the root fix (`quick-xml ≥ 0.41`) is blocked upstream (newest `wayland-scanner` 0.31.10 still pins `^0.39`). Per the documented exception process (DEC-007), a dated, scoped ignore with a revisit trigger is added to **both** gates (`.cargo/audit.toml`, `deny.toml`) and recorded in `docs/dependency-policy.md`.

## Validation
- `scripts/validate-docs-frontmatter.sh` — pass
- `cargo test --workspace` — 539 passed, 0 failed
- `cargo audit` — pass (2 advisories ignored w/ rationale; 8 allowed warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)