### PR TITLE
fix(parser): accept the canonical 8-field RP card (XNDA field)

### DIFF
--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -251,14 +251,21 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
             "RP" => {
                 let fields = parse_fields(rest);
                 require_fields(lineno, "RP", &fields, 7)?;
+                // Canonical NEC RP card: RP mode N1 N2 XNDA θ0 φ0 Δθ Δφ (8 fields,
+                // XNDA = output/normalization options at I4). fnec historically
+                // also accepts a 7-field form without XNDA. Distinguish by count:
+                // with >= 8 fields the four angle floats start at index 4 (after
+                // XNDA); with 7 they start at index 3. XNDA does not affect the
+                // angle grid and is not stored.
+                let a = if fields.len() >= 8 { 4 } else { 3 };
                 deck.cards.push(Card::Rp(RpCard {
                     mode: parse_u32(lineno, "RP", 1, fields[0])?,
                     n_theta: parse_u32(lineno, "RP", 2, fields[1])?,
                     n_phi: parse_u32(lineno, "RP", 3, fields[2])?,
-                    theta0: parse_f64(lineno, "RP", 4, fields[3])?,
-                    phi0: parse_f64(lineno, "RP", 5, fields[4])?,
-                    d_theta: parse_f64(lineno, "RP", 6, fields[5])?,
-                    d_phi: parse_f64(lineno, "RP", 7, fields[6])?,
+                    theta0: parse_f64(lineno, "RP", a + 1, fields[a])?,
+                    phi0: parse_f64(lineno, "RP", a + 2, fields[a + 1])?,
+                    d_theta: parse_f64(lineno, "RP", a + 3, fields[a + 2])?,
+                    d_phi: parse_f64(lineno, "RP", a + 4, fields[a + 3])?,
                 }));
             }
             "LD" => {
@@ -582,6 +589,20 @@ EN
                 polarization_ratio: 0.0,
             })
         );
+    }
+
+    #[test]
+    fn rp_card_accepts_both_7_field_and_8_field_xnda_forms() {
+        // Canonical NEC RP has 8 fields (with XNDA at I4); fnec also accepts a
+        // 7-field form. Both must parse the SAME angle grid.
+        let seven = parse("RP 0 19 1 30.0 0.0 5.0 0.0\nEN\n").expect("parse 7-field");
+        let eight = parse("RP 0 19 1 1000 30.0 0.0 5.0 0.0\nEN\n").expect("parse 8-field");
+        let (Card::Rp(r7), Card::Rp(r8)) = (&seven.deck.cards[0], &eight.deck.cards[0]) else {
+            panic!("expected RP cards");
+        };
+        assert_eq!(r7, r8, "7-field and 8-field RP must parse identical angles");
+        assert_eq!(r8.theta0, 30.0, "8-field θ0 must be 30, not XNDA=1000");
+        assert_eq!(r8.d_theta, 5.0);
     }
 
     #[test]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,8 +10,14 @@ last_updated: 2026-07-04
 All notable documentation process changes are recorded here.
 
 ## [Unreleased]
+### Fixed
 
-*(nothing currently queued)*
+- **`RP` card XNDA field** — the radiation-pattern card parser now accepts the
+  canonical 8-field NEC form (`RP mode Nθ Nφ XNDA θ0 φ0 Δθ Δφ`) in addition to
+  fnec's legacy 7-field form. Previously a standard 8-field `RP` card mis-parsed
+  θ0 (it read the XNDA/I4 value as θ0), so real 4nec2 pattern decks produced an
+  all-null pattern. Distinguished by field count; XNDA does not affect the angle
+  grid.
 
 ## [0.8.0] — 2026-07-04 — Phase 8 complete: mainstream deck portability
 ### Added

--- a/docs/ph8-chk-006-finite-ground-rp.md
+++ b/docs/ph8-chk-006-finite-ground-rp.md
@@ -65,9 +65,10 @@ near-field / Poynting computation); that is a documented follow-on.
 `cargo test --workspace`: **560 passed**, 0 failed (was 557; +3 finite-ground RP
 tests); clippy clean. Existing PEC / free-space RP corpus cases are unaffected.
 
-## Related known issue
+## Related issue — resolved
 
-fnec's `RP` card parser omits the standard NEC **XNDA (I4)** field (it reads
-`RP mode Nθ Nφ θ0 φ0 Δθ Δφ`, 7 fields, not the canonical 8). A standard 8-field
-`RP` card mis-parses θ0. This is a separate deck-portability bug, noted here for a
-future increment.
+fnec's `RP` card parser previously omitted the standard NEC **XNDA (I4)** field
+(it read 7 fields), so a canonical 8-field `RP` card mis-parsed θ0. **Fixed
+2026-07-04**: the parser now accepts both the canonical 8-field form
+(`RP mode Nθ Nφ XNDA θ0 φ0 Δθ Δφ`) and fnec's legacy 7-field form, distinguished
+by field count; XNDA is parsed for portability but does not affect the angle grid.

--- a/docs/project/test-results.md
+++ b/docs/project/test-results.md
@@ -19,7 +19,7 @@ rule in [README.md](README.md)).
 | Field | Value |
 |:------|:------|
 | Date | 2026-07-02 |
-| Commit | branch `feat/ph8-chk-005-lossy-tl` (base `ef5c4ba` main) |
+| Commit | branch `fix/rp-xnda-field` (base `14fcaec` main) |
 | Version | fnec-rust 0.8.0 |
 | Toolchain | rustc 1.94.1 (e408947bf 2026-03-25) |
 | Host | Linux 6.18 x86_64 (AMD Renoir gfx90c APU, RADV Vulkan) |
@@ -27,13 +27,13 @@ rule in [README.md](README.md)).
 ### `cargo test --workspace` (default features)
 
 ```
-563 passed; 0 failed; 0 ignored — across 58 test binaries
+564 passed; 0 failed; 0 ignored — across 58 test binaries
 exit code 0
 ```
 
-563 = 560 + 3 lossy-TL tests (`lossy_tl.rs`: lossless limit, attenuation
-monotonicity, matched-line limit). This completes the Phase 8 checklist
-(PH8-CHK-001..006). The lossless corpus TL cases are unaffected.
+564 = 563 (Phase 8 / v0.8.0) + 1 RP-parser test
+(`rp_card_accepts_both_7_field_and_8_field_xnda_forms`). The corpus 7-field RP
+decks are unaffected.
 
 ### Multi-wire (non-junctioned) validation (PH8-CHK-001/002 breadth)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -352,9 +352,7 @@ with accuracy trade-offs documented where fnec's Hallén model diverges from NEC
 
 **Documented frontier deferrals** (beyond the checklist, each with a recorded
 blocker): junctioned-multi-wire plane wave (DOF-count reformulation); NTHETA/NPHI
-plane-wave angle sweeps; buried-wire / Sommerfeld ground; non-reciprocal NT; and
-the `RP`-card `XNDA` (I4) parser field (a deck-portability fix noted in
-`docs/ph8-chk-006-finite-ground-rp.md`).
+plane-wave angle sweeps; buried-wire / Sommerfeld ground; and non-reciprocal NT. (The `RP`-card `XNDA` parser field was fixed 2026-07-04.)
 
 ## Gaps and blockers (from requirements.md)
 


### PR DESCRIPTION
## What

The `RP` (radiation-pattern) card parser omitted the standard NEC **XNDA (I4)** field, reading only 7 fields (`mode Nθ Nφ θ0 φ0 Δθ Δφ`). A canonical **8-field** card (`RP mode Nθ Nφ XNDA θ0 φ0 Δθ Δφ`) therefore mis-parsed θ0 — it read the XNDA value as θ0 — so **real 4nec2 pattern decks produced an all-null pattern** (θ0=1000 → everything below horizon).

The parser now accepts **both** forms, distinguished by field count: with ≥8 fields the four angle floats start after XNDA (index 4); with 7 they start at index 3. XNDA is parsed for portability but doesn't affect the angle grid. fnec's legacy 7-field corpus decks are unaffected.

Found while validating the finite-ground RP (PH8-CHK-006).

## Result
- New test `rp_card_accepts_both_7_field_and_8_field_xnda_forms` (7-field and 8-field parse identical angles; 8-field θ0=30, not XNDA=1000)
- Verified end-to-end: the standard 8-field ground deck now produces the correct pattern (θ=0..90, not θ=1000)
- `cargo test --workspace` — **564 passed** (was 563; +1), 0 failed; clippy clean; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)