### PR TITLE
docs: draft Phase 9 (accuracy frontier & scattering breadth)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,16 @@ last_updated: 2026-07-04
 All notable documentation process changes are recorded here.
 
 ## [Unreleased]
+### Docs
+
+- **Phase 9 drafted** (`docs/roadmap.md` "Phase 9: accuracy frontier & scattering
+  breadth") — six planned items grounded in the surviving `PRT-*` gaps and the
+  Phase 8 frontier deferrals: incidence-angle sweeps + receive pattern, junctioned
+  multi-wire receive solves, absolute gain over lossy ground, PT + full RP output
+  modes, a difficult-geometry accuracy corpus, and a first Sommerfeld/buried
+  near-ground increment. A draft for review; first-frontier priority is a product
+  decision.
+
 ### Fixed
 
 - **`RP` card XNDA field** — the radiation-pattern card parser now accepts the

--- a/docs/project/traceability-matrix.md
+++ b/docs/project/traceability-matrix.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/project/traceability-matrix.md
 status: living
-last_updated: 2026-07-02
+last_updated: 2026-07-04
 ---
 
 # Traceability matrix
@@ -33,7 +33,7 @@ Status legend: ✅ done · 🔨 in progress · 📋 planned.
 |:------------|:-------------|:------|
 | FR-001 reusable Rust crates | 7 crates + 2 apps | ✅ |
 | FR-002 CLI + GUI | `apps/nec-cli`, `apps/nec-gui` | ✅ |
-| FR-003 execute real NEC decks | Phases 1–2; Phase 8 residual cards | 🔨 (Phase 8) |
+| FR-003 execute real NEC decks | Phases 1–2, Phase 8 (EX 0–5, NT, TL, ground) | ✅ (PT deferred) |
 | FR-004 Markdown project I/O | `nec_project` (GAP-015) | ✅ |
 | FR-005 4nec2-like text reports | PH2-CHK-004 report contract v1 | ✅ |
 | FR-006 plugin/scripting | EP-1..4 (Phase 3–4) | ✅ |
@@ -49,8 +49,8 @@ Status legend: ✅ done · 🔨 in progress · 📋 planned.
 | COMP-001 tolerant parsing | `nec_parser` | ✅ |
 | COMP-002/008 tolerance-gated accuracy | corpus gate | ✅ |
 | COMP-003 versioned NEC-4 scope | `nec4-support.md`, `card-support-matrix.md` | ✅ (living) |
-| PRT-001 ground modeling | Phase 2; PH8-CHK-006 extends | 🔨 (Phase 8) |
-| PRT-002 loads/TL/network/source | Phase 2; PH8-CHK-001..005 | 🔨 (Phase 8) |
+| PRT-001 ground modeling | Phase 2 + PH8-CHK-006 (finite-ground RP); Sommerfeld → Phase 9 | 🔨 (Phase 9) |
+| PRT-002 loads/TL/network/source | Phase 2 + PH8-CHK-001..005 | ✅ |
 | PRT-003 sweep/gain/pattern/report | Phase 1–2 | ✅ |
 | PRT-004 GUI/workflow | Phase 3 | ✅ |
 | PRT-005/006 optimization/automation | Phase 3–4 | ✅ |
@@ -59,7 +59,7 @@ Status legend: ✅ done · 🔨 in progress · 📋 planned.
 | PRT-009 NEC-5 surfaces | wire-only decision (`nec5-frontier.md`) | ✅ (decided) |
 | PRT-010 NEC-5 validation matrix | PH2-CHK-007 | ✅ |
 | PRT-011 distributed execution | Phases 6–7 | ✅ |
-| CP-003 deck-portability cards | **Phase 8 (in flight)** | 🔨 |
+| CP-003 deck-portability cards | Phase 8 (EX 0–5, NT, lossy TL) | ✅ |
 | GAP-002..015, BLK-001..005 | see [register](requirements-register.md) | ✅ all resolved |
 
 ---
@@ -160,34 +160,27 @@ Delivered as roadmap key-deliverables rather than numbered CHK rows. Chain:
 | PH8-CHK-005 | CP-003, PRT-002 | `ph8-chk-005-lossy-tl.md` | `nec_solver/tl.rs` (lossy `coth/csch(γℓ)`) | `nec_solver/tests/lossy_tl.rs` (lossless limit, attenuation, matched-line) | **Done** 2026-07-04: lossy line stamp; F3=loss dB; reduces to lossless at 0 dB; 563 tests. TL other → Partial. | ✅ |
 | PH8-CHK-006 | CP-002, PRT-001 | `ph8-chk-006-finite-ground-rp.md` | `nec_solver/farfield.rs` (Fresnel reflection far field) | `nec_solver/tests/finite_ground_rp.rs` (PEC limit, nec2c shape, horizon null) | **In progress** 2026-07-03: RP over finite ground via Fresnel coefficients (was free-space); PEC limit <0.05 dB, nec2c shape 0.053 dB; 560 tests. Directivity (gain offset documented). Buried/Sommerfeld = documented frontier deferral. | ✅ |
 
+### Phase 9 — accuracy frontier & scattering breadth (planned, draft)
+
+Drafted 2026-07-04 (`docs/roadmap.md` "Phase 9"). Six planned items (📋): angle
+sweeps + receive pattern (PH9-CHK-001), junctioned multi-wire receive solves
+(002), absolute gain over lossy ground (003), PT + full RP output modes (004),
+difficult-geometry accuracy corpus (005), first Sommerfeld/buried near-ground
+increment (006). Theme ordering and first-frontier priority are a **product
+decision** — matrix rows land here as each item is scheduled.
+
 ---
 
-## In-flight focus: PH8-CHK-002
+## Current status (2026-07-04)
 
-Full chain for the item currently being implemented:
-
-- **Requirement**: CP-003 (missing source cards break deck portability),
-  PRT-002. Roadmap `PH8-CHK-002`.
-- **Design / decisions**: `docs/ph8-chk-002-plane-wave-excitation.md` — two
-  decisions: (1) **align EX-type numbering to NEC2** (type 1 = plane wave; current
-  source → type 4), user-approved 2026-06-27; (2) plane-wave RHS lives in the
-  integral-equation **forcing term** (`exp(-jk_s s)` closed form for straight
-  wires), not the delta-gap RHS.
-- **Implementation** (staged): ✅ *code foundation* — `ExcitationKind` NEC2
-  classifier + `ExCard.polarization_deg` F3 + accurate reject diagnostic.
-  ✅ *solve core* — `nec_solver::planewave` + `solve_hallen_planewave` (2-DOF,
-  isolated). ✅ *CLI wiring* — `nec-cli::solve_session` routes single-straight-wire
-  linear plane waves to the solve (induced `CURRENTS`, no feedpoint); elliptic,
-  multi-wire, and non-Hallén decks fail fast. ⏳ *pending* — elliptic (types 2/3),
-  NTHETA/NPHI sweeps, multi-wire geometry.
-- **Tests**: `apps/nec-cli/tests/ex_cards.rs` extended; new corpus fixture
-  `dipole-ex2-planewave-*`; external `nec2c` parity + internal Rayleigh–Carson
-  reciprocity gates.
-- **Tooling / reference**: `docs/dev/ph8-planewave-ref-theta30.nec` (`nec2c`
-  induced-current reference, needs `XQ`), plus the reciprocity cross-check against
-  the validated RP far-field path.
-- **Result**: design **#255**, code foundation **#257**, solve core **#258**
-  (nec2c shape 4.3%, reciprocity exact). CLI wiring 2026-07-02 — single-straight-
-  wire linear plane waves solve on `--solver hallen` with induced `CURRENTS`;
-  elliptic/multi-wire/non-Hallén fail fast; type-1 → Partial; 544 tests passing,
-  clippy clean. Remaining: elliptic polarization, angle sweeps, multi-wire.
+- **Released**: **v0.8.0** — Phase 8 complete (mainstream deck portability). All
+  six PH8-CHK items delivered and validated; every EX source card (0–5), NT
+  networks, lossy TL, and the finite-ground radiation pattern are user-runnable.
+- **Latest tests**: 564 passing, clippy clean (see [test-results.md](test-results.md)).
+- **Next**: **Phase 9 (planned, draft)** — accuracy frontier & scattering breadth
+  (`docs/roadmap.md` "Phase 9"). The first-frontier priority (receive-side breadth
+  vs advanced ground vs difficult-geometry accuracy) is a product decision; no
+  PH9 item is scheduled yet.
+- **Open frontier deferrals** (each with a recorded blocker): junctioned-multi-wire
+  plane wave, NTHETA/NPHI sweeps, buried/Sommerfeld ground, non-reciprocal NT,
+  absolute gain over lossy ground — all folded into the Phase 9 draft.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -354,6 +354,45 @@ with accuracy trade-offs documented where fnec's Hallén model diverges from NEC
 blocker): junctioned-multi-wire plane wave (DOF-count reformulation); NTHETA/NPHI
 plane-wave angle sweeps; buried-wire / Sommerfeld ground; and non-reciprocal NT. (The `RP`-card `XNDA` parser field was fixed 2026-07-04.)
 
+## Phase 9 (planned): accuracy frontier & scattering breadth
+
+**Goals**: Phase 8 made mainstream decks *run*; Phase 9 makes fnec *trustworthy on
+hard models* and *complete for receive/scattering*. It closes the accuracy and
+breadth gaps that the source/network/ground portability work opened up: accurate
+ground (impedance, not just the pattern), difficult geometry (junctioned
+receive-solves, stepped diameter), and the full receive/RCS output path. The
+wire-only continuation still stands (NEC-5 surfaces remain out of scope — see
+`docs/nec5-frontier.md`).
+
+**Why now**: the Phase 8 frontier deferrals and the surviving `PRT-*` parity gaps
+cluster into a coherent accuracy program. `PRT-001` (ground short of NEC-4/EZNEC),
+`PRT-008` (accuracy breadth), and `PRT-009`/`PRT-010` (difficult-geometry /
+NEC-5-informed robustness) are the remaining "better than compatible" gaps.
+
+**Scope note**: several items are genuinely harder physics than Phase 8's stamps
+(Sommerfeld ground, junction reformulation). Each ships a validated increment with
+an honest documented boundary; a hard item may land as a bounded first slice with
+the remainder deferred, as GN2/ROCm did in earlier phases.
+
+### Phase 9 implementation checklist (draft for review)
+
+Execution order recommendation (easier / receive-side first, then harder ground /
+geometry): PH9-CHK-001 → 003 → 002 → 004 → 005 → 006.
+
+| Checklist ID | Roadmap IDs | Implementation target | Validation artifacts | Done signal | Status |
+|:-------------|:------------|:----------------------|:---------------------|:------------|:-------|
+| PH9-CHK-001 | CP-003, PRT-003 | NTHETA/NPHI incident-angle sweep for plane waves: loop the incidence direction over the EX card's Nθ/Nφ + Δθ/Δφ, emit a receive-pattern section. (**Product decision**: the per-angle receive scalar — open-circuit terminal voltage vs peak induced current.) | New: EX F4/F5 (Δθ/Δφ) capture; `RECEIVE_PATTERN` report section; corpus fixture; reciprocity gate. | Per-angle receive response matches the transmit far-field pattern by reciprocity across the sweep; report contract stable. | Planned |
+| PH9-CHK-002 | CP-003, PRT-002/008 | Junctioned multi-wire for the plane-wave and current-source solves: extend the 2-DOF (cos/sin) Hallén system with junction-continuity constraints (resolve the DOF-count mismatch), so bent / connected receiving geometries solve. | Existing: `solve_hallen_planewave`, `solve_hallen_current_source`. New: junction rows; nec2c + reciprocity gates on an L-antenna. | Junctioned receive geometry solves; per-wire nec2c shape + reciprocity pass; the fail-fast is removed for the supported class. | Planned |
+| PH9-CHK-003 | CP-002, PRT-001 | Absolute gain over lossy ground: account for the ground-absorbed power so **gain** (not just directivity) matches nec2c over finite ground — closes the documented ~1.3 dB directivity-vs-gain offset. | Existing: `farfield.rs` Fresnel path, `docs/ph8-chk-006-finite-ground-rp.md`. New: ground-loss power term; nec2c absolute-gain gate. | Finite-ground gain matches nec2c within a documented tolerance (not just the shape); efficiency reported. | Planned |
+| PH9-CHK-004 | CP-003, PRT-003 | `PT` (print-control) runtime semantics + full `RP` output modes (`XNDA` normalization: X gain-normalization, N/D/A options) beyond the angle-grid fix. | Existing: `apps/nec-cli` PT warning path, RP parser (XNDA now read). New: PT semantics; RP normalization modes; contract tests. | PT controls output per its documented subset (no deferred warning for the supported form); RP normalization modes are contract-gated. | Planned |
+| PH9-CHK-005 | PRT-008/009/010 | Difficult-geometry accuracy program: a stepped-diameter / small-loop / junction sensitivity corpus mapped to the NEC-5 validation themes, with fnec's behavior and any mitigation documented and regression-tracked. | Existing: `docs/corpus-validation-strategy.md` (`PH2N5-*`), `docs/nec5-frontier.md`. New: `PH9N5-*` sensitivity cases + tolerances. | ≥3 difficult-geometry cases added with tolerances and a documented accuracy characterization; regression-gated. | Planned |
+| PH9-CHK-006 | CP-002, PRT-001 | First accurate near-ground **impedance** increment beyond the Fresnel approximation (Sommerfeld/Norton), or a bounded buried-wire first slice — with an explicit supported/deferred boundary and fail-fast for out-of-scope classes. | Existing: `nec_solver` ground path, `docs/nec4-support.md`. New: first Sommerfeld/buried case + reference gate; boundary doc. | One accurate near-ground / buried class passes a tolerance gate; deferred classes still fail fast; boundary documented. | Planned |
+
+**Estimated start**: after v0.8.0; **target completion**: TBD. This checklist is a
+**draft for review** — the theme ordering and which frontier to attempt first
+(receive-side breadth vs advanced ground vs difficult-geometry accuracy) are
+product decisions.
+
 ## Gaps and blockers (from requirements.md)
 
 | Gap | Title | Priority | Target | Owner | Resolution criteria |


### PR DESCRIPTION
## What

Phase 8 is complete and **v0.8.0** is released, so this drafts the next phase — following the project's rhythm (phase complete → release → draft next, as with Phase 7 → v0.7.0 → Phase 8).

**Phase 9: accuracy frontier & scattering breadth** targets the accuracy and breadth gaps the Phase 8 portability work opened up, grounded in the surviving `PRT-*` gaps and the documented Phase 8 frontier deferrals:

| Item | Target |
|:-----|:-------|
| PH9-CHK-001 | NTHETA/NPHI incidence-angle sweep + receive-pattern output (reciprocity-validated) |
| PH9-CHK-002 | Junctioned multi-wire for plane-wave & current-source solves (2-DOF + junction reformulation) |
| PH9-CHK-003 | Absolute gain over lossy ground (closes the documented ~1.3 dB directivity-vs-gain offset) |
| PH9-CHK-004 | `PT` runtime semantics + full `RP` output modes (`XNDA` normalization) |
| PH9-CHK-005 | Difficult-geometry accuracy corpus (stepped-diameter / loops / junctions, NEC-5-informed) |
| PH9-CHK-006 | First Sommerfeld/Norton near-ground **impedance** increment (or buried-wire first slice) |

Marked a **draft for review** — the first-frontier priority (receive-side breadth vs advanced ground vs difficult-geometry accuracy) is a product decision, so no PH9 item is scheduled yet.

Also refreshes the traceability matrix: Phase 8 marked complete, a "Current status" section replaces the stale in-flight block, and View A states updated (PRT-002 / CP-003 → ✅).

## Result
- Docs-only; no code change. 564 tests still pass; frontmatter gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)