### PR TITLE
feat(ph9-chk-005): warn on physically-impossible negative feedpoint resistance

### DIFF
--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -442,6 +442,30 @@ fn warn_if_feedpoint_at_junction(deck: &nec_model::deck::NecDeck, segs: &[Segmen
     }
 }
 
+/// PH9-CHK-005: a passive antenna cannot have a negative input resistance. On the
+/// Hallén path a negative `Re(Z)` is therefore a reliable post-solve signal that
+/// the result is unphysical — in practice a junctioned-geometry limitation (a
+/// bend, stepped-radius, or start-to-start split that the collinear fix does not
+/// cover; see PH9-CHK-002). This catches cases the pre-solve junction-*fed* warning
+/// misses, e.g. a bent antenna fed away from the bend. Scoped to `Hallen`: the
+/// pulse current-source path has documented negative-`R` corpus values.
+fn warn_if_negative_resistance(rows: &[FeedpointRow], solver_mode: SolverMode) {
+    if !matches!(solver_mode, SolverMode::Hallen) {
+        return;
+    }
+    for r in rows {
+        if r.z_in.re < 0.0 {
+            eprintln!(
+                "warning: feedpoint tag {} segment {} has negative resistance \
+                 (Re Z = {:.3} Ω), which is physically impossible for a passive antenna; \
+                 the result is unreliable — commonly a junctioned-geometry limitation \
+                 (see PH9-CHK-002)",
+                r.tag, r.seg, r.z_in.re
+            );
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // cohesive feedpoint inputs; splitting would obscure
 pub(super) fn build_feedpoint_rows(
     deck: &nec_model::deck::NecDeck,
@@ -970,6 +994,7 @@ pub(super) fn solve_frequency_point(
     // be unphysical (e.g. negative resistance). Warn rather than report it as
     // trustworthy; accurate junction-fed impedance is PH9-CHK-002.
     warn_if_feedpoint_at_junction(deck, segs);
+    warn_if_negative_resistance(&rows, solver_mode);
 
     let current_table: Vec<CurrentRow> = segs
         .iter()

--- a/apps/nec-cli/tests/junction_feedpoint.rs
+++ b/apps/nec-cli/tests/junction_feedpoint.rs
@@ -70,4 +70,24 @@ fn single_wire_feedpoint_does_not_warn() {
         !stderr.contains("is on a wire junction"),
         "single-wire dipole should not warn; stderr:\n{stderr}"
     );
+    assert!(
+        !stderr.contains("negative resistance"),
+        "single-wire dipole (R>0) must not trip the negative-resistance check; stderr:\n{stderr}"
+    );
+}
+
+// A dipole modeled as two arms bent 15° at the feed, fed on one arm AWAY from the
+// bend (segment 7). The junction-*fed* warning does not fire (feed is not on the
+// junction), but the geometry is still mis-solved → negative resistance, which the
+// post-solve check must catch.
+const BENT_DIPOLE_FED_AWAY: &str =
+    "GW 1 26 0 0 0 1.367 0 5.104 0.001\nGW 2 26 0 0 0 -1.367 0 -5.104 0.001\nGE 0\nEX 0 1 7 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+
+#[test]
+fn negative_resistance_is_flagged_when_junction_warning_is_missed() {
+    let stderr = run_stderr(BENT_DIPOLE_FED_AWAY, "bent-fed-away");
+    assert!(
+        stderr.contains("negative resistance") && stderr.contains("PH9-CHK-002"),
+        "an unphysical negative-R junction result should warn; stderr:\n{stderr}"
+    );
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,14 @@ All notable documentation process changes are recorded here.
 ## [Unreleased]
 ### Added
 
+- **Negative-resistance guardrail (PH9-CHK-005)** — a passive antenna cannot have a
+  negative input resistance, so a negative `Re(Z)` on the Hallén path now warns that
+  the result is unphysical (a junctioned-geometry limitation; see PH9-CHK-002). This
+  complements the junction-*fed* warning by catching cases fed *away* from a bad
+  junction (e.g. a bent dipole fed mid-arm). Scoped to `--solver hallen` (the pulse
+  current-source path has documented negative-`R` values); no valid Hallén corpus
+  case trips it.
+
 - **PH9-CHK-002 collinear junction fix** — a straight conductor split across
   several `GW` cards is now solved as one wire. Root cause: fnec's Hallén
   homogeneous solution (`cos(k·s)` + constant) was built per `GW` wire and reset at

--- a/docs/ph9-chk-005-junction-feed-guardrail.md
+++ b/docs/ph9-chk-005-junction-feed-guardrail.md
@@ -58,6 +58,20 @@ from a junction, or a single-wire geometry, does not warn. (Note: a junction at 
 PH9-CHK-002 diagnosis; the junction-*fed* warning is a deliberately conservative
 signal, not a complete junction-accuracy check.)
 
+## Complementary post-solve check: negative resistance
+
+The junction-*fed* warning is a pre-solve check on the feed location, so it misses
+a genuinely mis-solved junction geometry that happens to be fed *away* from the
+junction (e.g. a bent dipole fed mid-arm still yields a nonsense impedance).
+`warn_if_negative_resistance` closes that gap after the solve: **a passive antenna
+cannot have a negative input resistance**, so a negative `Re(Z)` on the Hallén path
+is a reliable, general signal that the result is unphysical (in practice a
+junctioned-geometry limitation — see PH9-CHK-002). It is scoped to `--solver hallen`
+because the pulse current-source path has documented negative-`R` corpus values.
+Together the two checks cover both junction-fed and fed-away failure modes without
+false-warning on any valid geometry (all passing corpus/reference cases on the
+Hallén path have `Re(Z) > 0`).
+
 ## Validation (`apps/nec-cli/tests/junction_feedpoint.rs`)
 
 - **Junction-fed warns** — the split-dipole-fed-at-junction deck warns and names

--- a/docs/project/test-results.md
+++ b/docs/project/test-results.md
@@ -19,7 +19,7 @@ rule in [README.md](README.md)).
 | Field | Value |
 |:------|:------|
 | Date | 2026-07-02 |
-| Commit | branch `feat/ph9-chk-002-collinear-fix` (base `84067cb` main) |
+| Commit | branch `feat/ph9-negative-resistance-guard` (base `a00959a` main) |
 | Version | fnec-rust 0.8.0 |
 | Toolchain | rustc 1.94.1 (e408947bf 2026-03-25) |
 | Host | Linux 6.18 x86_64 (AMD Renoir gfx90c APU, RADV Vulkan) |
@@ -27,14 +27,13 @@ rule in [README.md](README.md)).
 ### `cargo test --workspace` (default features)
 
 ```
-576 passed; 0 failed; 0 ignored — across 61 test binaries
+577 passed; 0 failed; 0 ignored — across 61 test binaries
 exit code 0
 ```
 
-576 = 571 + 5 collinear-merge tests (`collinear_merge.rs`: split chain recovers
-the single-wire impedance; merge is a no-op for single/bent/stepped geometry).
-PH9-CHK-002 collinear fix — validated zero regression (single-wire, dipole-loaded,
-Yagi, TL-linked all byte-for-byte unchanged).
+577 = 576 + 1 negative-resistance guardrail test (`junction_feedpoint.rs`: a bent
+dipole fed away from the bend now warns). Complements the PH9-CHK-002 collinear fix.
+No valid Hallén corpus case trips the negative-R check.
 
 ### Multi-wire (non-junctioned) validation (PH8-CHK-001/002 breadth)
 


### PR DESCRIPTION
## What

The junction-*fed* warning (PH9-CHK-005) is a pre-solve check on the feed location, so it **misses** a mis-solved junction geometry that's fed *away* from the junction — e.g. a bent dipole fed mid-arm returns a nonsense impedance with no warning. This adds a general post-solve check:

> **A passive antenna cannot have a negative input resistance.** A negative `Re(Z)` on the Hallén path is a reliable signal the result is unphysical — in practice a junctioned-geometry limitation (bend, stepped-radius, start-to-start split; see PH9-CHK-002).

- `warn_if_negative_resistance` warns per feedpoint with `Re(Z) < 0`. **Scoped to `--solver hallen`**: the pulse current-source path has documented negative-`R` corpus values (`dipole-ex{1,4,5}-pulse-current`). No valid Hallén corpus/reference case has negative R.

Together with `warn_if_feedpoint_at_junction`, this covers **both** the junction-fed and fed-away failure modes.

## Validation
| Case | Behavior |
|:-----|:---------|
| bent dipole fed mid-arm (Re Z = −0.037 Ω) | **warns**, names PH9-CHK-002 |
| single-wire dipole (R = 74) | no warning |
| fixed collinear chain (R = 74.41) | no warning |

## Result
- `cargo test --workspace` — **577 passed** (was 576; +1), 0 failed; clippy clean; clean under `-D warnings`
- No valid Hallén corpus case trips it; the 3 documented negative-R pulse cases are out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)