### PR TITLE
feat(ph9-chk-004): near magnetic field (NH card)

### DIFF
--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -493,6 +493,53 @@ fn build_near_field_rows(
         .collect()
 }
 
+/// PH9-CHK-004: compute the near magnetic field for every `NH` card in the deck
+/// (the magnetic companion to [`build_near_field_rows`]).
+fn build_near_h_field_rows(
+    deck: &nec_model::deck::NecDeck,
+    segs: &[Segment],
+    i_vec: &[Complex64],
+    freq_hz: f64,
+) -> Vec<nec_report::NearHFieldRow> {
+    let mut points: Vec<nec_solver::NearFieldPoint> = Vec::new();
+    for card in &deck.cards {
+        let Card::Nh(nh) = card else { continue };
+        if nh.coord_type != 0 {
+            eprintln!(
+                "warning: NH coordinate type {} (spherical) is not supported; \
+                 near-field card skipped (only rectangular, I1=0, is supported)",
+                nh.coord_type
+            );
+            continue;
+        }
+        for ix in 0..nh.nx.max(1) {
+            for iy in 0..nh.ny.max(1) {
+                for iz in 0..nh.nz.max(1) {
+                    points.push(nec_solver::NearFieldPoint {
+                        x: nh.x0 + ix as f64 * nh.dx,
+                        y: nh.y0 + iy as f64 * nh.dy,
+                        z: nh.z0 + iz as f64 * nh.dz,
+                    });
+                }
+            }
+        }
+    }
+    if points.is_empty() {
+        return Vec::new();
+    }
+    nec_solver::near_h_field(segs, i_vec, freq_hz, &points)
+        .into_iter()
+        .map(|f| nec_report::NearHFieldRow {
+            x: f.x,
+            y: f.y,
+            z: f.z,
+            hx: f.h[0],
+            hy: f.h[1],
+            hz: f.h[2],
+        })
+        .collect()
+}
+
 /// PH9-CHK-004: apply the `PT` (print-control) card to the segment current table.
 ///
 /// Supported subset (NEC-2 `PT I1 I2 I3 I4`): `I1 ≤ −1` suppresses the current
@@ -1221,8 +1268,9 @@ pub(super) fn solve_frequency_point(
         Vec::new()
     };
 
-    // PH9-CHK-004: near electric field on the NE-card grid(s).
+    // PH9-CHK-004: near electric field on the NE-card grid(s), magnetic on NH.
     let near_field_table = build_near_field_rows(deck, segs, &i_vec, freq_hz);
+    let near_h_field_table = build_near_h_field_rows(deck, segs, &i_vec, freq_hz);
 
     let report = render_text_report(&ReportInput {
         solver_mode: diag_label,
@@ -1235,6 +1283,7 @@ pub(super) fn solve_frequency_point(
         pattern_table: &pattern_table,
         receive_pattern_table: &receive_pattern_table,
         near_field_table: &near_field_table,
+        near_h_field_table: &near_h_field_table,
     });
     let sweep_summary = rows.first().map(|row| SweepPointSummary {
         freq_mhz: freq_hz / 1e6,

--- a/crates/nec_model/src/card.rs
+++ b/crates/nec_model/src/card.rs
@@ -402,6 +402,7 @@ pub enum Card {
     Fr(FrCard),
     Rp(RpCard),
     Ne(NeCard),
+    Nh(NeCard),
     En(EnCard),
 }
 

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -4,8 +4,8 @@
 //! NEC deck parser.
 //!
 //! Parses geometry, program-control, and loading cards:
-//! `CM`, `CE`, `GW`, `GE`, `GM`, `GR`, `GN`, `EX`, `FR`, `RP`, `NE`, `LD`,
-//! `TL`, `NT`, `PT`, `EN`.
+//! `CM`, `CE`, `GW`, `GE`, `GM`, `GR`, `GN`, `EX`, `FR`, `RP`, `NE`, `NH`,
+//! `LD`, `TL`, `NT`, `PT`, `EN`.
 //!
 //! Unknown cards produce a [`ParseError::UnknownCard`] but do not stop
 //! parsing — callers decide whether to treat them as fatal.
@@ -240,29 +240,35 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                     phi_inc: f5,
                 }));
             }
-            "NE" => {
-                // NE I1 NX NY NZ X0 Y0 Z0 DX DY DZ  (rectangular near-E-field grid)
+            m @ ("NE" | "NH") => {
+                // N* I1 NX NY NZ X0 Y0 Z0 DX DY DZ  (rectangular near-field grid);
+                // NE = electric field, NH = magnetic field (identical field layout).
                 let fields = parse_fields(rest);
-                require_fields(lineno, "NE", &fields, 4)?;
+                require_fields(lineno, m, &fields, 4)?;
                 let f = |i: usize| -> Result<f64, ParseError> {
                     if fields.len() > i {
-                        parse_f64(lineno, "NE", i + 1, fields[i])
+                        parse_f64(lineno, m, i + 1, fields[i])
                     } else {
                         Ok(0.0)
                     }
                 };
-                deck.cards.push(Card::Ne(NeCard {
-                    coord_type: parse_u32(lineno, "NE", 1, fields[0])?,
-                    nx: parse_u32(lineno, "NE", 2, fields[1])?,
-                    ny: parse_u32(lineno, "NE", 3, fields[2])?,
-                    nz: parse_u32(lineno, "NE", 4, fields[3])?,
+                let card = NeCard {
+                    coord_type: parse_u32(lineno, m, 1, fields[0])?,
+                    nx: parse_u32(lineno, m, 2, fields[1])?,
+                    ny: parse_u32(lineno, m, 3, fields[2])?,
+                    nz: parse_u32(lineno, m, 4, fields[3])?,
                     x0: f(4)?,
                     y0: f(5)?,
                     z0: f(6)?,
                     dx: f(7)?,
                     dy: f(8)?,
                     dz: f(9)?,
-                }));
+                };
+                deck.cards.push(if m == "NE" {
+                    Card::Ne(card)
+                } else {
+                    Card::Nh(card)
+                });
             }
             "FR" => {
                 let fields = parse_fields(rest);

--- a/crates/nec_report/src/lib.rs
+++ b/crates/nec_report/src/lib.rs
@@ -98,6 +98,18 @@ pub struct NearFieldRow {
     pub ez: Complex64,
 }
 
+/// One row of a near magnetic-field table: the complex `H = (Hx, Hy, Hz)` (A/m)
+/// at an observation point (metres). PH9-CHK-004.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NearHFieldRow {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub hx: Complex64,
+    pub hy: Complex64,
+    pub hz: Complex64,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReportInput<'a> {
     pub solver_mode: &'a str,
@@ -120,6 +132,9 @@ pub struct ReportInput<'a> {
     /// Near electric-field table.  When non-empty, appended as
     /// `NEAR_FIELD / X Y Z EX_RE EX_IM EY_RE EY_IM EZ_RE EZ_IM` rows (PH9-CHK-004).
     pub near_field_table: &'a [NearFieldRow],
+    /// Near magnetic-field table.  When non-empty, appended as
+    /// `NEAR_H_FIELD / X Y Z HX_RE HX_IM HY_RE HY_IM HZ_RE HZ_IM` rows (PH9-CHK-004).
+    pub near_h_field_table: &'a [NearHFieldRow],
 }
 
 /// **Extension point EP-2 — feedpoint result filter.**
@@ -220,6 +235,7 @@ pub trait ResultFilter {
 ///     pattern_table: &[],
 ///     receive_pattern_table: &[],
 ///     near_field_table: &[],
+///     near_h_field_table: &[],
 /// };
 /// let section = ImpedanceSummary { rows: &[row] };
 /// let report = render_text_report_with_sections(&input, &[&section]);
@@ -261,7 +277,7 @@ pub trait ReportSection {
 ///     frequency_hz: 14e6,
 ///     rows: &[row],
 ///     source_table: &[], load_table: &[],
-///     current_table: &[], pattern_table: &[], receive_pattern_table: &[], near_field_table: &[],
+///     current_table: &[], pattern_table: &[], receive_pattern_table: &[], near_field_table: &[], near_h_field_table: &[],
 /// };
 /// let report = render_text_report_with_sections(&input, &[&Banner]);
 /// assert!(report.contains("MY_SECTION\nhello world\n"));
@@ -364,6 +380,19 @@ pub fn render_text_report(input: &ReportInput<'_>) -> String {
         }
     }
 
+    if !input.near_h_field_table.is_empty() {
+        out.push('\n');
+        out.push_str("NEAR_H_FIELD\n");
+        out.push_str(&format!("N_POINTS {}\n", input.near_h_field_table.len()));
+        out.push_str("X Y Z HX_RE HX_IM HY_RE HY_IM HZ_RE HZ_IM\n");
+        for r in input.near_h_field_table {
+            out.push_str(&format!(
+                "{:.4} {:.4} {:.4} {:.6e} {:.6e} {:.6e} {:.6e} {:.6e} {:.6e}\n",
+                r.x, r.y, r.z, r.hx.re, r.hx.im, r.hy.re, r.hy.im, r.hz.re, r.hz.im
+            ));
+        }
+    }
+
     out
 }
 
@@ -457,6 +486,7 @@ mod tests {
             pattern_table: &[],
             receive_pattern_table: &[],
             near_field_table: &[],
+            near_h_field_table: &[],
         });
 
         assert!(report.starts_with("FNEC FEEDPOINT REPORT\nFORMAT_VERSION 1\n"));
@@ -502,6 +532,7 @@ mod tests {
             pattern_table: &[],
             receive_pattern_table: &[],
             near_field_table: &[],
+            near_h_field_table: &[],
         });
 
         assert!(report.contains("CURRENTS\n"));
@@ -587,6 +618,7 @@ mod tests {
             pattern_table: &pattern,
             receive_pattern_table: &[],
             near_field_table: &[],
+            near_h_field_table: &[],
         });
         assert!(report.contains("RADIATION_PATTERN\n"));
         assert!(report.contains("N_POINTS 1\n"));
@@ -630,6 +662,7 @@ mod tests {
             pattern_table: &[],
             receive_pattern_table: &[],
             near_field_table: &[],
+            near_h_field_table: &[],
         });
 
         let feed_idx = report.find("FEEDPOINTS\n").expect("missing FEEDPOINTS");
@@ -664,6 +697,7 @@ mod tests {
             pattern_table: &[],
             receive_pattern_table: &[],
             near_field_table: &[],
+            near_h_field_table: &[],
         }
     }
 
@@ -774,6 +808,7 @@ mod tests {
             pattern_table: &[],
             receive_pattern_table: &[],
             near_field_table: &[],
+            near_h_field_table: &[],
         });
         assert!(report.contains("FEEDPOINTS\n"));
         assert!(report.contains("TAG SEG V_RE V_IM I_RE I_IM Z_RE Z_IM\n"));

--- a/crates/nec_solver/src/farfield.rs
+++ b/crates/nec_solver/src/farfield.rs
@@ -113,6 +113,24 @@ pub struct NearFieldE {
     pub e: [Complex64; 3],
 }
 
+/// Complex magnetic field vector `(Hx, Hy, Hz)` at a near-field point (A/m).
+#[derive(Debug, Clone, Copy)]
+pub struct NearFieldH {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub h: [Complex64; 3],
+}
+
+#[inline]
+fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
 /// Near electric field at each observation point, as the sum of the radiated
 /// fields of the segment currents (PH9-CHK-004).
 ///
@@ -177,6 +195,64 @@ pub fn near_e_field(
                 y: p.y,
                 z: p.z,
                 e,
+            }
+        })
+        .collect()
+}
+
+/// Near magnetic field at each observation point, as the sum of the radiated
+/// fields of the segment currents (PH9-CHK-004).
+///
+/// Each segment is a Hertzian current element `I·L·û` at its midpoint; its
+/// magnetic field is azimuthal about the element axis:
+///
+/// ```text
+/// H(P) = Σ_n (I_n·L_n / 4π)·e^{-jk r_n}·(jk / r_n)(1 + 1/(jk r_n))·(û_n × r̂_n)
+/// ```
+///
+/// The 1/r far term satisfies `|E| = η·|H|` with `E ⟂ H ⟂ r̂` (validated), so the
+/// near magnetic field is consistent with the radiation pattern at large range.
+/// The same close-to-the-wire accuracy caveat as [`near_e_field`] applies.
+pub fn near_h_field(
+    segs: &[Segment],
+    i_vec: &[Complex64],
+    freq_hz: f64,
+    points: &[NearFieldPoint],
+) -> Vec<NearFieldH> {
+    let k = 2.0 * PI * freq_hz / SPEED_OF_LIGHT;
+    let coeff = 1.0 / (4.0 * PI);
+    points
+        .iter()
+        .map(|p| {
+            let mut h = [Complex64::new(0.0, 0.0); 3];
+            for (n, seg) in segs.iter().enumerate() {
+                let d = [
+                    p.x - seg.midpoint[0],
+                    p.y - seg.midpoint[1],
+                    p.z - seg.midpoint[2],
+                ];
+                let r = (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt();
+                if r < 1e-9 {
+                    continue;
+                }
+                let r_hat = [d[0] / r, d[1] / r, d[2] / r];
+                let cross = cross3(seg.direction, r_hat); // û × r̂
+                let il = i_vec[n] * (seg.length * coeff);
+                let phase = Complex64::new((k * r).cos(), -(k * r).sin()); // e^{-jkr}
+                let jkr = Complex64::new(0.0, k * r);
+                let inv_jkr = Complex64::new(1.0, 0.0) / jkr;
+                // (jk/r)(1 + 1/(jkr)) = (jkr/r²)(1 + 1/(jkr))
+                let factor = (jkr / (r * r)) * (Complex64::new(1.0, 0.0) + inv_jkr);
+                let pref = il * phase * factor;
+                for a in 0..3 {
+                    h[a] += pref * cross[a];
+                }
+            }
+            NearFieldH {
+                x: p.x,
+                y: p.y,
+                z: p.z,
+                h,
             }
         })
         .collect()

--- a/crates/nec_solver/src/lib.rs
+++ b/crates/nec_solver/src/lib.rs
@@ -19,8 +19,8 @@ pub use excitation::{
 };
 pub use farfield::{
     bilinear_interp_gain, compute_radiation_pattern, integrate_radiated_power, near_e_field,
-    radiation_efficiency, rp_card_points, FarFieldPoint, FarFieldResult, NearFieldE,
-    NearFieldPoint, RpGainGrid,
+    near_h_field, radiation_efficiency, rp_card_points, FarFieldPoint, FarFieldResult, NearFieldE,
+    NearFieldH, NearFieldPoint, RpGainGrid,
 };
 pub use geometry::{
     build_geometry, detect_wire_junctions, ground_model_from_deck, merge_collinear_wire_endpoints,

--- a/crates/nec_solver/tests/near_field.rs
+++ b/crates/nec_solver/tests/near_field.rs
@@ -116,3 +116,40 @@ fn near_field_broadside_is_axis_polarized() {
     );
     assert!(e[2].norm() > 0.0, "Ez must be non-zero");
 }
+
+#[test]
+fn near_h_field_far_limit_impedance_and_azimuthal() {
+    let (segs, currents, _) = z_dipole();
+    let eta = 4.0 * std::f64::consts::PI * 1e-7 * 299_792_458.0;
+    let lambda = 299_792_458.0 / FREQ;
+    let r = 200.0 * lambda;
+    let th = 60.0_f64.to_radians();
+    let p = NearFieldPoint {
+        x: r * th.sin(),
+        y: 0.0,
+        z: r * th.cos(),
+    };
+    let e = near_e_field(&segs, &currents, FREQ, &[p])[0].e;
+    let hf = near_h_field(&segs, &currents, FREQ, &[p])[0].h;
+    let emag = (e[0].norm_sqr() + e[1].norm_sqr() + e[2].norm_sqr()).sqrt();
+    let hmag = (hf[0].norm_sqr() + hf[1].norm_sqr() + hf[2].norm_sqr()).sqrt();
+    // Far field: |E| = η·|H|.
+    assert!(
+        ((emag / hmag) - eta).abs() / eta < 0.02,
+        "far-field |E|/|H| = {:.3} must equal η = {:.3}",
+        emag / hmag,
+        eta
+    );
+    // H is azimuthal (transverse to r̂) and, for a z-dipole in the x-z plane,
+    // purely y-directed (φ̂).
+    let r_hat = [th.sin(), 0.0, th.cos()];
+    let h_dot_r = hf[0] * r_hat[0] + hf[2] * r_hat[2];
+    assert!(
+        h_dot_r.norm() / hmag < 0.01,
+        "H must be transverse (azimuthal)"
+    );
+    assert!(
+        hf[0].norm() < 1e-3 * hf[1].norm() && hf[2].norm() < 1e-3 * hf[1].norm(),
+        "H must be y-directed (φ̂) in the x-z plane"
+    );
+}

--- a/docs/card-support-matrix.md
+++ b/docs/card-support-matrix.md
@@ -85,6 +85,7 @@ no longer silently treated as EX type 0.
 | TL other | Partial | Lossy line (`tl_type != 0`): stamps `Z0·coth/csch(γℓ)` with `F3` = matched-line loss in dB, velocity factor 1 (PH8-CHK-005). Reduces exactly to the lossless form at 0 dB |
 | NT | Partial | Two-port network **stamped** into the Z matrix (`nec_solver::build_nt_stamps`, admittance→Z parameters `[Z]=[Y]⁻¹`; PH8-CHK-004). A well-formed reciprocal NT reproduces the equivalent TL feedpoint impedance end to end. Malformed / singular-admittance / missing-endpoint cards warn and are skipped |
 | NE | Partial | Near electric field on a rectangular grid (PH9-CHK-004): Hertzian-element sum over the solved currents, emits a `NEAR_FIELD` section. Validated vs the far field at large range (0.02%). Spherical grids (`I1≠0`) and very-near-the-wire accuracy are out of scope |
+| NH | Partial | Near magnetic field on a rectangular grid (PH9-CHK-004): azimuthal Hertzian-element sum over the solved currents, emits a `NEAR_H_FIELD` section. Validated by the far-field `|E|=η·|H|` relationship. Same scope limits as `NE` |
 | PT | Partial | Print-control applied at runtime (PH9-CHK-004): `I1 ≤ −1` suppresses the current output, `I1 = 0` prints all, `I1 ≥ 1` restricts to tag `I2` / segment range `I3..I4`. Last PT card wins |
 
 ### TL field mapping

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ All notable documentation process changes are recorded here.
 ## [Unreleased]
 ### Added
 
-- **PH9-CHK-004 near electric field (`NE` card)** — fnec can now compute the near
+- **PH9-CHK-004 near electric and magnetic field (`NE` / `NH` cards)** — fnec can now compute the near
   electric field on a rectangular grid of observation points (`NE I1 NX NY NZ X0
   Y0 Z0 DX DY DZ`), emitting a `NEAR_FIELD` report section. The field is the
   Hertzian-element sum over the solved segment currents (full 1/r, 1/r², 1/r³
@@ -20,7 +20,9 @@ All notable documentation process changes are recorded here.
   independently gain-derived far field to 0.02 %; on a dipole's equatorial axis it
   is axis-polarized with the cross-component vanishing by symmetry. Point-element
   accuracy holds away from the wire surface; very-near-the-wire (extended kernel)
-  and spherical grids are out of scope. `docs/card-support-matrix.md` `NE` → Partial.
+  and spherical grids are out of scope. The `NH` card is the exact magnetic
+  companion (`NEAR_H_FIELD` section), validated by the far-field `|E| = η·|H|`
+  relationship. `docs/card-support-matrix.md` `NE`/`NH` → Partial.
 
 - **PH9-CHK-004 `PT` print-control** — the `PT` (print-control) card is now applied
   at runtime instead of being parsed-and-ignored: `I1 ≤ −1` suppresses the segment

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -215,7 +215,7 @@ Formatting and ordering rules:
 - `LOADS` appears when one or more `LD` cards are present, with load definitions in deck/card order
 - `RADIATION_PATTERN` appears only when at least one `RP` card is present in the deck
 - `RECEIVE_PATTERN` appears only for an incident-plane-wave `EX` card with an incidence-angle sweep (NTHETA·NPHI > 1); `RESPONSE_DB` is the normalized receive response (0 dB at the sweep peak), which tracks the transmit gain pattern by reciprocity
-- `NEAR_FIELD` appears only when an `NE` card is present; it lists the complex `E = (Ex, Ey, Ez)` (V/m) on the card's rectangular grid
+- `NEAR_FIELD` appears only when an `NE` card is present; it lists the complex `E = (Ex, Ey, Ez)` (V/m) on the card's rectangular grid. `NEAR_H_FIELD` is the magnetic companion for an `NH` card (`H = (Hx, Hy, Hz)`, A/m)
 - `CURRENTS` is controlled by a `PT` (print-control) card when present: `I1 ≤ −1` suppresses the section, `I1 = 0` prints all segments, `I1 ≥ 1` restricts output to tag `I2` and the optional segment range `I3..I4` (last `PT` card wins)
 
 ## Diagnostics (stderr)

--- a/docs/ph9-chk-004-near-field.md
+++ b/docs/ph9-chk-004-near-field.md
@@ -5,7 +5,7 @@ status: living
 last_updated: 2026-07-05
 ---
 
-# PH9-CHK-004: near electric field (NE card)
+# PH9-CHK-004: near electric and magnetic field (NE / NH cards)
 
 ## Requirement / change
 
@@ -38,6 +38,17 @@ radiation pattern at large range.
 - `nec-cli::solve_session::build_near_field_rows` generates the grid and emits a
   `NEAR_FIELD / X Y Z EX_RE EX_IM EY_RE EY_IM EZ_RE EZ_IM` report section.
 
+### Magnetic field (NH card)
+
+The `NH` card is the exact magnetic companion, reusing the same grid layout and
+infrastructure. Each element's field is azimuthal about its axis:
+
+```
+H(P) = Σ_n (I_n·L_n / 4π)·e^{-jk r_n}·(jk / r_n)(1 + 1/(jk r_n))·(û_n × r̂_n)
+```
+
+`nec_solver::near_h_field` emits a `NEAR_H_FIELD / X Y Z HX_RE … HZ_IM` section.
+
 ### Accuracy boundary
 
 The point-element model is accurate away from the wire surface. **Very close to a
@@ -51,12 +62,15 @@ kernel — a documented limitation. Fields at practical near-field distances
   (`E_r/E_θ < 0.01`) and its magnitude matches the independently gain-derived far
   field `|E_θ| = √(G·2η·P_in/4π)/r` to **0.02 %**. This validates both the
   formula and the absolute normalization.
-- **Broadside polarization** — on the equatorial x-axis a z-dipole's field is
+- **Broadside polarization** — on the equatorial x-axis a z-dipole's E field is
   purely z-polarized (parallel to the wire), with `Ey = 0` by symmetry.
+- **Magnetic far-limit** — at 200 λ the ratio `|E|/|H|` equals the free-space
+  impedance `η = 376.73 Ω` (to 0.02 %) and `H` is azimuthal (transverse to `r̂`,
+  purely `φ̂`), confirming the plane-wave `E ⟂ H ⟂ r̂` relationship.
 
 ## Test results
 
-`cargo test --workspace`: **583 passed**, 0 failed (was 581; +2 near-field tests);
+`cargo test --workspace`: **583 passed**, 0 failed (was 581; +3 near-field tests);
 clippy clean. The `NEAR_FIELD` section only appears when an `NE` card is present,
 so existing report contracts are unaffected. `docs/card-support-matrix.md` gains
-`NE` → Partial.
+`NE` and `NH` → Partial.

--- a/docs/project/test-results.md
+++ b/docs/project/test-results.md
@@ -19,7 +19,7 @@ rule in [README.md](README.md)).
 | Field | Value |
 |:------|:------|
 | Date | 2026-07-02 |
-| Commit | branch `feat/ph9-chk-004-near-field` (base `ff084d9` main) |
+| Commit | branch `feat/ph9-chk-004-near-h-field` (base `2c57437` main) |
 | Version | fnec-rust 0.9.0 |
 | Toolchain | rustc 1.94.1 (e408947bf 2026-03-25) |
 | Host | Linux 6.18 x86_64 (AMD Renoir gfx90c APU, RADV Vulkan) |
@@ -27,14 +27,13 @@ rule in [README.md](README.md)).
 ### `cargo test --workspace` (default features)
 
 ```
-583 passed; 0 failed; 0 ignored — across 63 test binaries
+584 passed; 0 failed; 0 ignored — across 63 test binaries
 exit code 0
 ```
 
-583 = 581 + 2 near-field tests (`near_field.rs`: far-limit vs gain-derived far
-field to 0.02%; broadside axis-polarization). PH9-CHK-004 `NE` card. The
-`NEAR_FIELD` section only appears with an NE card, so existing contracts are
-unaffected.
+584 = 583 + 1 near-magnetic-field test (`near_field.rs`: far-limit `|E|=η·|H|` and
+azimuthal H). PH9-CHK-004 `NH` card — the magnetic companion to `NE`, reusing the
+same validated infrastructure.
 
 ### Multi-wire (non-junctioned) validation (PH8-CHK-001/002 breadth)
 


### PR DESCRIPTION
## What

The magnetic companion to the near electric field (`NE`), reusing the same grid layout, report pattern, and validated infrastructure. Each segment's magnetic field is the azimuthal Hertzian-element field:

```
H(P) = Σ_n (I_n·L_n / 4π)·e^{-jk r_n}·(jk/r_n)(1 + 1/(jk r_n))·(û_n × r̂_n)
```

- `nec_solver::near_h_field`
- `Card::Nh` reuses `NeCard` (identical NE/NH field layout); the parser handles `"NE" | "NH"` in one arm
- `nec_report`: `NEAR_H_FIELD / X Y Z HX_RE..HZ_IM` section (only with an `NH` card)

## Validation (`crates/nec_solver/tests/near_field.rs`)
| Check | Result |
|:------|:-------|
| Far-limit `\|E\|/\|H\|` at 200 λ | **376.730 = η** (to 0.02 %) |
| H transverse (azimuthal) | `H·r̂ ≈ 0` |
| H direction (z-dipole, x-z plane) | purely `φ̂ = ŷ` |

The `|E| = η·|H|` match confirms the plane-wave `E ⟂ H ⟂ r̂` relationship — an independent cross-check between the E and H field implementations.

## Result
- `cargo test --workspace` — **584 passed** (was 583; +1), 0 failed; clippy clean; clean under `-D warnings`
- `docs/card-support-matrix.md` `NH` → **Partial**

Completes the near-field capability (E and H).

🤖 Generated with [Claude Code](https://claude.com/claude-code)