### PR TITLE
feat(ph9-chk-006): --ground-solver sommerfeld (opt-in surface-wave near-ground Z)

### DIFF
--- a/apps/nec-cli/src/cli_args.rs
+++ b/apps/nec-cli/src/cli_args.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use super::bench::BenchFormat;
 use super::exec_profile::ExecutionMode;
-use super::solve_session::{PulseRhsMode, SolverMode};
+use super::solve_session::{GroundSolver, PulseRhsMode, SolverMode};
 
-pub const USAGE: &str = "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--sin-fallback-rel-max <value>] [--bench] [--bench-format <human|csv|json>] [--output-format <text|json>] [--sweep-config <file.toml>] [--vars <vars.toml|vars.json>] [--hosts <hosts.toml>] <deck.nec>";
+pub const USAGE: &str = "Usage: fnec [--solver <pulse|hallen|continuity|sinusoidal>] [--ground-solver <rcm|sommerfeld>] [--pulse-rhs <raw|nec2>] [--exec <cpu|hybrid|gpu>] [--sin-fallback-rel-max <value>] [--bench] [--bench-format <human|csv|json>] [--output-format <text|json>] [--sweep-config <file.toml>] [--vars <vars.toml|vars.json>] [--hosts <hosts.toml>] <deck.nec>";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
@@ -15,6 +15,7 @@ pub enum OutputFormat {
 #[derive(Debug, Clone)]
 pub struct ParsedArgs {
     pub solver_mode: SolverMode,
+    pub ground_solver: GroundSolver,
     pub pulse_rhs_mode: PulseRhsMode,
     pub execution_mode: ExecutionMode,
     pub enable_benchmarking: bool,
@@ -29,6 +30,7 @@ pub struct ParsedArgs {
 
 pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
     let mut solver_mode = SolverMode::Hallen;
+    let mut ground_solver = GroundSolver::Rcm;
     let mut pulse_rhs_mode = PulseRhsMode::Nec2;
     let mut execution_mode = ExecutionMode::Cpu;
     let mut enable_benchmarking = false;
@@ -59,6 +61,24 @@ pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
                     other => {
                         return Err(format!(
                             "invalid --solver value '{other}' (expected: hallen|pulse|continuity|sinusoidal)"
+                        ))
+                    }
+                };
+            }
+            "--ground-solver" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err(
+                        "missing value after --ground-solver (expected: rcm|sommerfeld)"
+                            .to_string(),
+                    );
+                }
+                ground_solver = match args[i].as_str() {
+                    "rcm" => GroundSolver::Rcm,
+                    "sommerfeld" => GroundSolver::Sommerfeld,
+                    other => {
+                        return Err(format!(
+                            "invalid --ground-solver value '{other}' (expected: rcm|sommerfeld)"
                         ))
                     }
                 };
@@ -209,6 +229,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
     let path = deck_path.ok_or_else(|| "missing deck path".to_string())?;
     Ok(ParsedArgs {
         solver_mode,
+        ground_solver,
         pulse_rhs_mode,
         execution_mode,
         enable_benchmarking,

--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -33,7 +33,7 @@ use nec_worker::{
 };
 use solve_session::{
     execute_frequency_sweep, frequencies_from_fr, solve_frequency_point, BenchRecord,
-    FrequencySolveResult, PulseRhsMode, SolverMode, SweepPointSummary,
+    FrequencySolveResult, GroundSolver, PulseRhsMode, SolverMode, SweepPointSummary,
     SINUSOIDAL_REL_RESIDUAL_MAX_DEFAULT,
 };
 use std::process::ExitCode;
@@ -68,6 +68,7 @@ fn main() -> ExitCode {
 
     let ParsedArgs {
         solver_mode,
+        ground_solver,
         pulse_rhs_mode,
         mut execution_mode,
         enable_benchmarking,
@@ -316,6 +317,7 @@ fn main() -> ExitCode {
             execution_mode,
             sin_fallback_rel_max,
             freq_hz,
+            ground_solver,
         )
     };
 
@@ -759,6 +761,7 @@ fn run_sweep_subcommand(args: &[String]) -> ExitCode {
             ExecutionMode::Cpu,
             SINUSOIDAL_REL_RESIDUAL_MAX_DEFAULT,
             freq_hz,
+            GroundSolver::Rcm,
         )?;
 
         let summary = solve_result.sweep_summary.ok_or_else(|| {

--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -24,6 +24,15 @@ impl SolverMode {
     }
 }
 
+/// Near-ground impedance model (PH9-CHK-006). `Rcm` is the default scalar-Γ
+/// reflection-coefficient image; `Sommerfeld` adds the surface-wave correction for
+/// straight horizontal wires (accurate below ~0.1 λ, = nec2c GN2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GroundSolver {
+    Rcm,
+    Sommerfeld,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PulseRhsMode {
     Raw,
@@ -790,8 +799,23 @@ pub(super) fn build_feedpoint_rows(
     solver_mode: SolverMode,
     current_source_port: Option<Complex64>,
     freq_hz: f64,
+    ground: &GroundModel,
+    ground_solver: GroundSolver,
 ) -> Vec<FeedpointRow> {
     let mut rows = Vec::new();
+
+    // PH9-CHK-006: precompute the Sommerfeld surface-wave ΔZ correction inputs once
+    // (applied per feedpoint below) when the user selects the sommerfeld ground
+    // solver over finite ground.
+    let sommerfeld_ground = match (ground_solver, ground) {
+        (GroundSolver::Sommerfeld, GroundModel::SimpleFiniteGround { eps_r, sigma }) => {
+            Some((*eps_r, *sigma))
+        }
+        _ => None,
+    };
+    let midpoints: Vec<[f64; 3]> = segs.iter().map(|s| s.midpoint).collect();
+    let directions: Vec<[f64; 3]> = segs.iter().map(|s| s.direction).collect();
+    let lengths: Vec<f64> = segs.iter().map(|s| s.length).collect();
 
     for card in &deck.cards {
         let Card::Ex(ex) = card else { continue };
@@ -829,11 +853,28 @@ pub(super) fn build_feedpoint_rows(
         } else {
             v_vec[idx] * seg.length
         };
-        let z_in = if current.norm() > 1e-60 {
+        let mut z_in = if current.norm() > 1e-60 {
             v_source / current
         } else {
             v_source
         };
+
+        // PH9-CHK-006: add the Sommerfeld surface-wave correction to the near-ground
+        // feedpoint impedance for a straight horizontal wire (declined otherwise).
+        if let Some((eps_r, sigma)) = sommerfeld_ground {
+            if let Some(dz) = nec_solver::sommerfeld::horizontal_ground_z_correction(
+                &midpoints,
+                &directions,
+                &lengths,
+                i_vec,
+                idx,
+                freq_hz,
+                eps_r,
+                sigma,
+            ) {
+                z_in += dz;
+            }
+        }
 
         rows.push(FeedpointRow {
             tag: seg.tag as usize,
@@ -1019,6 +1060,7 @@ pub(super) fn solve_frequency_point(
     execution_mode: ExecutionMode,
     sin_fallback_rel_max: f64,
     freq_hz: f64,
+    ground_solver: GroundSolver,
 ) -> Result<FrequencySolveResult, String> {
     // Incident plane waves and current sources are solved on the Hallén path
     // only (crate::planewave / solve_hallen_current_source).
@@ -1341,6 +1383,8 @@ pub(super) fn solve_frequency_point(
         solver_mode,
         current_source_port,
         freq_hz,
+        ground,
+        ground_solver,
     );
 
     // PH9-CHK-005: guard the junction-fed feedpoint limitation. When the driven

--- a/apps/nec-cli/tests/sommerfeld_ground_cli.rs
+++ b/apps/nec-cli/tests/sommerfeld_ground_cli.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+//
+// PH9-CHK-006: `fnec --ground-solver sommerfeld` must correct the near-ground
+// feedpoint impedance of a low horizontal dipole to the surface-wave-inclusive
+// (nec2c GN2) value, flipping the radiation-resistance delta positive where the
+// default `--ground-solver rcm` gives the wrong-signed reflection-coefficient result.
+//
+// nec2c reference (14.2 MHz, horizontal λ/2 dipole 0.025 λ over εr=13/σ=0.005),
+// ΔR = R(ground) − R(free space): GN2 (truth) = +9.0, GN0 (RCM) = −24.
+
+use std::process::Command;
+
+fn feedpoint_r(extra_args: &[&str], deck: &str) -> f64 {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "fnec-somm-cli-{}.nec",
+        std::process::id() as u64 + fastrand_seed()
+    ));
+    std::fs::write(&path, deck).expect("write deck");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_fnec"));
+    cmd.arg("--solver").arg("hallen");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    let out = cmd.arg(&path).output().expect("run fnec");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "fnec failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|line| {
+            let p: Vec<&str> = line.split_whitespace().collect();
+            // FEEDPOINTS row: TAG SEG V_RE V_IM I_RE I_IM Z_RE Z_IM
+            if p.len() >= 8 && p[0] == "1" && p[1] == "11" {
+                p[6].parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+        .expect("no feedpoint row")
+}
+
+// Tiny unique-ish suffix so parallel test cases don't collide on the temp file.
+fn fastrand_seed() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos() as u64
+}
+
+const FREE: &str =
+    "GW 1 21 -5.278 0 0 5.278 0 0 0.001\nEX 0 1 11 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+const GROUND: &str =
+    "GW 1 21 -5.278 0 0.528 5.278 0 0.528 0.001\nGN 0 0 0 0 13 0.005\nEX 0 1 11 0 1.0 0.0\nFR 0 1 0 0 14.2 0.0\nEN\n";
+
+#[test]
+fn ground_solver_sommerfeld_flips_low_dipole_delta_r_positive() {
+    let r_free = feedpoint_r(&[], FREE);
+    let r_rcm = feedpoint_r(&["--ground-solver", "rcm"], GROUND);
+    let r_somm = feedpoint_r(&["--ground-solver", "sommerfeld"], GROUND);
+
+    let dr_rcm = r_rcm - r_free;
+    let dr_somm = r_somm - r_free;
+
+    // Default RCM undershoots: ΔR strongly negative.
+    assert!(
+        dr_rcm < -20.0,
+        "rcm ΔR should be strongly negative; got {dr_rcm:.1} (free {r_free:.1}, rcm {r_rcm:.1})"
+    );
+    // Sommerfeld flips it positive, matching nec2c GN2 truth (+9).
+    assert!(
+        dr_somm > 0.0 && (dr_somm - 9.0).abs() < 7.0,
+        "sommerfeld ΔR should be positive near nec2c GN2 +9; got {dr_somm:.1} (somm {r_somm:.1})"
+    );
+    // The surface-wave correction is a large, opposite-sign shift from RCM.
+    assert!(
+        dr_somm - dr_rcm > 30.0,
+        "surface-wave correction should be a large positive shift; got {:.1}",
+        dr_somm - dr_rcm
+    );
+}
+
+#[test]
+fn ground_solver_rcm_is_the_unchanged_default() {
+    // Omitting --ground-solver must equal --ground-solver rcm (no behavior change).
+    let r_default = feedpoint_r(&[], GROUND);
+    let r_rcm = feedpoint_r(&["--ground-solver", "rcm"], GROUND);
+    assert!(
+        (r_default - r_rcm).abs() < 1e-6,
+        "default must equal rcm; got {r_default:.4} vs {r_rcm:.4}"
+    );
+}

--- a/crates/nec_solver/src/sommerfeld.rs
+++ b/crates/nec_solver/src/sommerfeld.rs
@@ -47,6 +47,119 @@ pub fn complex_permittivity(freq_hz: f64, eps_r: f64, sigma: f64) -> Complex64 {
     Complex64::new(eps_r.max(1.0e-6), -sigma.max(0.0) / (omega * EPS0))
 }
 
+/// Normal-incidence scalar Fresnel coefficient `Γ = (√εc − 1)/(√εc + 1)` — the
+/// coefficient fnec's default (RCM) ground model applies to the geometric image
+/// (mirror of `matrix::fresnel_reflection_scalar`).
+pub fn scalar_gamma(freq_hz: f64, eps_r: f64, sigma: f64) -> Complex64 {
+    let sq = complex_permittivity(freq_hz, eps_r, sigma).sqrt();
+    (sq - Complex64::new(1.0, 0.0)) / (sq + Complex64::new(1.0, 0.0))
+}
+
+/// Surface-wave correction to the near-ground feedpoint impedance of a **straight
+/// horizontal wire** over finite ground (PH9-CHK-006).
+///
+/// Returns `ΔZ_sw = ΔZ_Sommerfeld − ΔZ_scalarΓ`, the ground-effect difference between
+/// the exact Sommerfeld reflected field and the scalar-Γ (reflection-coefficient)
+/// image fnec's default model already accounts for. Added to fnec's reported
+/// near-ground feedpoint `Z` (which ≈ the scalar-Γ / GN0 result), it upgrades that to
+/// the surface-wave-inclusive Sommerfeld (nec2c GN2) value — in particular flipping
+/// the sign of the radiation-resistance delta below ~0.05 λ.
+///
+/// Computed as an induced-EMF reaction integral over the solved segment currents
+/// (`currents[m]`, moment `currents[m]·lengths[m]`), so it is stationary in the
+/// current to first order. `feed_idx` is the driven segment (reference `I`).
+///
+/// Returns `None` when the geometry is **not** a straight horizontal wire at a single
+/// height above the `z = 0` plane — the class the collinear-axis kernel is validated
+/// for. (Bent / vertical / mixed geometry needs the full reflected dyadic, deferred.)
+#[allow(clippy::too_many_arguments)]
+pub fn horizontal_ground_z_correction(
+    midpoints: &[[f64; 3]],
+    directions: &[[f64; 3]],
+    lengths: &[f64],
+    currents: &[Complex64],
+    feed_idx: usize,
+    freq_hz: f64,
+    eps_r: f64,
+    sigma: f64,
+) -> Option<Complex64> {
+    let n = midpoints.len();
+    if n == 0 || directions.len() != n || lengths.len() != n || currents.len() != n || feed_idx >= n
+    {
+        return None;
+    }
+    const TOL: f64 = 1e-6;
+    let h = midpoints[0][2];
+    if h <= TOL {
+        return None; // must be above the ground plane
+    }
+    let axis = directions[0];
+    for i in 0..n {
+        // horizontal (no vertical component)
+        if directions[i][2].abs() > TOL {
+            return None;
+        }
+        // parallel to a common horizontal axis (straight wire)
+        let dot =
+            directions[i][0] * axis[0] + directions[i][1] * axis[1] + directions[i][2] * axis[2];
+        if dot.abs() < 1.0 - TOL {
+            return None;
+        }
+        // single height
+        if (midpoints[i][2] - h).abs() > TOL {
+            return None;
+        }
+    }
+
+    let i_feed = currents[feed_idx];
+    if i_feed.norm() < 1e-60 {
+        return None;
+    }
+    let gamma = scalar_gamma(freq_hz, eps_r, sigma);
+    let d = 2.0 * h;
+
+    // The difference kernel is smooth in ρ, so precompute it on a grid and
+    // interpolate — O(grid) integral evaluations instead of O(n²).
+    let mut rho_max = 0.0f64;
+    for m in 0..n {
+        for k in 0..n {
+            let dx = midpoints[m][0] - midpoints[k][0];
+            let dy = midpoints[m][1] - midpoints[k][1];
+            rho_max = rho_max.max((dx * dx + dy * dy).sqrt());
+        }
+    }
+    let ng = 256usize;
+    let step = rho_max / (ng - 1) as f64;
+    let grid: Vec<Complex64> = (0..ng)
+        .map(|g| {
+            let rho = step * g as f64;
+            reflected_ex_horizontal(rho, d, freq_hz, eps_r, sigma, false)
+                - gamma * reflected_ex_horizontal(rho, d, freq_hz, eps_r, sigma, true)
+        })
+        .collect();
+    let interp = |rho: f64| -> Complex64 {
+        if step <= 0.0 {
+            return grid[0];
+        }
+        let t = (rho / step).min((ng - 1) as f64);
+        let i = (t.floor() as usize).min(ng - 2);
+        let frac = t - i as f64;
+        grid[i] * (1.0 - frac) + grid[i + 1] * frac
+    };
+
+    let mut acc = Complex64::new(0.0, 0.0);
+    for m in 0..n {
+        let mom_m = currents[m] * lengths[m];
+        for k in 0..n {
+            let dx = midpoints[m][0] - midpoints[k][0];
+            let dy = midpoints[m][1] - midpoints[k][1];
+            let rho = (dx * dx + dy * dy).sqrt();
+            acc += interp(rho) * mom_m * (currents[k] * lengths[k]);
+        }
+    }
+    Some(acc / (i_feed * i_feed))
+}
+
 /// `√z` on the sheet `Im ≤ 0` (the upgoing/decaying wave `e^{-j kz z}` decays for
 /// `z > 0`).
 fn sqrt_im_neg(z: Complex64) -> Complex64 {
@@ -289,6 +402,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The reaction ΔZ correction (ΔZ_Sommerfeld − ΔZ_scalarΓ) must capture the
+    /// surface-wave gap: large-positive at 0.025 λ (nec2c GN2−GN0 ΔR ≈ +33, flipping
+    /// fnec's ≈−24 toward +9), and negligible at 0.25 λ where the surface wave dies.
+    #[test]
+    fn ground_correction_captures_surface_wave_gap() {
+        let build = |hl: f64| -> Option<Complex64> {
+            let l = LAM / 4.0;
+            let n = 41usize;
+            let k0 = k0();
+            let h = hl * LAM;
+            let xs: Vec<f64> = (0..n)
+                .map(|i| -l + 2.0 * l * i as f64 / (n - 1) as f64)
+                .collect();
+            let mids: Vec<[f64; 3]> = xs.iter().map(|&x| [x, 0.0, h]).collect();
+            let dirs = vec![[1.0, 0.0, 0.0]; n];
+            let lens = vec![2.0 * l / (n - 1) as f64; n];
+            let curr: Vec<Complex64> = xs
+                .iter()
+                .map(|&x| Complex64::new((k0 * (l - x.abs())).sin(), 0.0))
+                .collect();
+            horizontal_ground_z_correction(&mids, &dirs, &lens, &curr, n / 2, FREQ, 13.0, 0.005)
+        };
+        let low = build(0.025).expect("straight horizontal geometry qualifies");
+        let high = build(0.25).expect("straight horizontal geometry qualifies");
+        assert!(
+            low.re > 15.0,
+            "0.025λ correction ΔR must be large-positive (surface-wave gap); got {:.2}",
+            low.re
+        );
+        assert!(
+            high.re.abs() < 5.0,
+            "0.25λ correction should be negligible; got {:.2}",
+            high.re
+        );
+    }
+
+    /// Non-horizontal / vertical geometry must be declined (returns None).
+    #[test]
+    fn ground_correction_declines_vertical_geometry() {
+        let mids = vec![[0.0, 0.0, 1.0], [0.0, 0.0, 2.0]];
+        let dirs = vec![[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]];
+        let lens = vec![1.0, 1.0];
+        let curr = vec![Complex64::new(1.0, 0.0), Complex64::new(0.5, 0.0)];
+        assert!(
+            horizontal_ground_z_correction(&mids, &dirs, &lens, &curr, 0, FREQ, 13.0, 0.005)
+                .is_none()
+        );
     }
 
     /// Lossy ground: the reflected kernel must produce a *positive* real part at the

--- a/docs/card-support-matrix.md
+++ b/docs/card-support-matrix.md
@@ -2,7 +2,7 @@
 project: fnec-rust
 doc: docs/card-support-matrix.md
 status: living
-last_updated: 2026-07-08
+last_updated: 2026-07-09
 ---
 
 # NEC Card Support Matrix
@@ -21,9 +21,9 @@ Legend: **Full** — complete implementation; **Partial** — accepted and produ
 | GM | Full | Geometry move: rotate and/or translate wire ranges in place; `tag_increment > 0` appends transformed copies |
 | GR | Full | Geometry repeat: successive z-axis rotation copies |
 | GN type −1 | Full | Null-ground explicit free-space (same as omitting GN) |
-| GN type 0 | Partial | Finite ground via a **normal-incidence scalar** reflection coefficient on the (correct-signed, PH9-CHK-006) image. Impedance is accurate (≈ Sommerfeld, ~10%, gated vs nec2c) for antenna heights ≥ ~0.2 λ; below 0.1 λ it is a reflection-coefficient approximation (no surface wave) and fnec **warns**. Angle/polarization-dependent Fresnel (RCM) and the Sommerfeld surface wave are deferred. Not the true Sommerfeld method despite the historical label |
+| GN type 0 | Partial | Finite ground via a **normal-incidence scalar** reflection coefficient on the (correct-signed, PH9-CHK-006) image. Impedance is accurate (≈ Sommerfeld, ~10%, gated vs nec2c) for antenna heights ≥ ~0.2 λ; below 0.1 λ it is a reflection-coefficient approximation (no surface wave) and fnec **warns** — unless the exact **Sommerfeld surface wave** is enabled via `--ground-solver sommerfeld` for a straight horizontal wire (PH9-CHK-006), which reproduces nec2c GN2 incl. the low-height sign flip. Angle/polarization-dependent Fresnel (RCM) is deferred |
 | GN type 1 | Full | Perfect-conductor (PEC) image method (correct-signed image, PH9-CHK-006) |
-| GN type 2 | Partial | Currently **aliases the GN0 scalar finite-ground path** (not the true Sommerfeld/Norton method); low-height near-ground impedance is regression-gated. Exact Sommerfeld is deferred (PH9-CHK-006) |
+| GN type 2 | Partial | Aliases the GN0 scalar finite-ground path by default; the true Sommerfeld surface wave is available via `--ground-solver sommerfeld` for a straight horizontal wire (nec2c GN2, PH9-CHK-006). Bent/vertical/mixed geometry still uses the scalar path |
 | GN other | Deferred | Unsupported type: treated as free-space with a warning |
 
 ## Program-control cards

--- a/docs/ph9-chk-006-sommerfeld-ground.md
+++ b/docs/ph9-chk-006-sommerfeld-ground.md
@@ -110,7 +110,8 @@ approximation with no surface wave.
 | finite ground impedance, height ≥ ~0.2 λ | **accurate (≈ Sommerfeld), gated vs nec2c GN2** |
 | finite ground impedance, height < 0.1 λ | approximate → **guarded (low-height warning)** |
 | angle- & polarization-dependent Fresnel (nec2c GN0 RCM) | deferred — **low value** (fnec ≈ RCM already) |
-| Sommerfeld/Norton surface wave (nec2c GN2 exact) | **kernel implemented + validated** (`crates/nec_solver/src/sommerfeld.rs`, reproduces GN2 + sign flip); **not yet wired into the solve** — feedpoint Z still uses scalar Γ |
+| Sommerfeld/Norton surface wave (nec2c GN2 exact) — straight horizontal wire | **implemented + wired** as an opt-in solver: `fnec --ground-solver sommerfeld` (default `rcm`); reproduces nec2c GN2 incl. the low-height sign flip |
+| Sommerfeld surface wave — bent / vertical / mixed geometry | deferred (needs the full reflected dyadic); `--ground-solver sommerfeld` silently declines (keeps RCM) |
 | buried wire | deferred → fail-fast (unchanged) |
 
 The finite-ground reflection still multiplies the (now correctly-signed) image by a
@@ -185,16 +186,25 @@ structure: replace the one `Γ · elem(image)` with a small sum over complex ima
 which only needs a complex-distance Green's kernel (`exp(−jk r)/r` with complex `r`)
 alongside the existing real-image `elem`.
 
-**Production step 1 landed (2026-07-09).** The reflected-field kernel is now
-implemented in Rust — `crates/nec_solver/src/sommerfeld.rs`
-(`reflected_ex_horizontal`), with Bessel J0/J1/J2 (A&S) and the sin/cosh substitution
-quadrature. Gated by a **machine-precision PEC self-check** (reflected field vs the
-exact opposite-current image, `sommerfeld.rs` unit tests) and an **end-to-end nec2c
-GN2 gate** (`crates/nec_solver/tests/sommerfeld_ground.rs`: the reaction-integral ΔZ
-reproduces the surface-wave sign flip at 0.025 λ — ΔR positive near +9, vs RCM's
-wrong-signed −24). It is **not yet wired into the solve**: the feedpoint impedance
-still uses the scalar-Γ image. Next increment: apply the post-solve reaction ΔZ
-correction to the reported near-ground feedpoint impedance for horizontal geometry.
+**Production landed (2026-07-09) — `fnec --ground-solver sommerfeld`.** Two increments:
+
+1. **Kernel** — `crates/nec_solver/src/sommerfeld.rs` (`reflected_ex_horizontal`),
+   Bessel J0/J1/J2 (A&S) + the sin/cosh substitution quadrature. Gated by a
+   **machine-precision PEC self-check** and an **end-to-end nec2c GN2 gate**
+   (`crates/nec_solver/tests/sommerfeld_ground.rs`).
+2. **Wiring** — a new opt-in ground solver `--ground-solver <rcm|sommerfeld>` (default
+   `rcm` = the unchanged scalar-Γ behaviour). When `sommerfeld` is selected over
+   finite ground and the geometry is a **straight horizontal wire**,
+   `horizontal_ground_z_correction` adds the surface-wave reaction ΔZ
+   (`ΔZ_Sommerfeld − ΔZ_scalarΓ`, over fnec's solved currents) to the reported
+   feedpoint `Z`. Non-horizontal/bent/mixed geometry is silently declined (keeps RCM).
+
+**Measured end-to-end** (horizontal λ/2 dipole 0.025 λ over εr=13/σ=0.005; ΔR vs
+fnec free space 67.2 Ω): `--ground-solver rcm` → 26.8 Ω (**ΔR −40**, the wrong-signed
+RCM result); `--ground-solver sommerfeld` → 77.2 Ω (**ΔR +10.1**, matching nec2c GN2
+ΔR +9.0 to ~13 %). The additive correction is self-consistent because fnec's solved
+current drives *both* the scalar-Γ baseline it subtracts and the Sommerfeld term it
+adds. CLI gate: `apps/nec-cli/tests/sommerfeld_ground_cli.rs`.
 
 **What remains for production — now de-risked.** The hardest and riskiest step (the
 **horizontal** dipole's half-space reflected kernel with correct TE+TM coupling, and


### PR DESCRIPTION
## Summary

Wires the validated Sommerfeld reflected-field kernel (merged in #294) into the CLI as a **user-selectable ground solver**, parallel to the existing `--solver` flag:

```
fnec --ground-solver <rcm|sommerfeld>     # default: rcm (unchanged behaviour)
```

When `sommerfeld` is selected over finite ground **and the geometry is a straight horizontal wire**, fnec adds the surface-wave reaction ΔZ to the reported near-ground feedpoint `Z`, correcting it from the reflection-coefficient result to the exact Sommerfeld (nec2c GN2) value — including the low-height radiation-resistance **sign flip**. Any other geometry (bent / vertical / mixed) is silently declined and keeps the scalar-Γ result.

## How it works

`sommerfeld::horizontal_ground_z_correction` computes `ΔZ_sw = ΔZ_Sommerfeld − ΔZ_scalarΓ` as an induced-EMF reaction integral over **fnec's solved segment currents**, and `build_feedpoint_rows` adds it to `z_in`. The additive correction is self-consistent because fnec's own current drives both the scalar-Γ baseline it subtracts and the Sommerfeld term it adds (validated: the subtracted baseline reproduces fnec's actual RCM ground effect).

Default `rcm` is a byte-for-byte no-op vs prior behaviour (gated).

## Measured result (horizontal λ/2 dipole, 0.025 λ over εr=13/σ=0.005)

ΔR = R(ground) − R(free space), fnec free-space R = 67.2 Ω:

| solver | fnec Z | ΔR | nec2c |
|--|--|--:|--:|
| `--ground-solver rcm` (default) | 26.8 − j35.4 | **−40** | GN0 ΔR −24 |
| `--ground-solver sommerfeld` | 77.2 − j1.9 | **+10.1** | **GN2 ΔR +9.0** |

The surface-wave correction flips ΔR from the wrong-signed −40 to +10.1, matching the nec2c GN2 truth (+9.0) to ~13 %.

## Scope / deferred

- Only a **straight horizontal wire** over finite ground is corrected; bent / vertical / mixed geometry needs the full reflected dyadic (deferred, silently declined).
- The distributed (`--hosts`) worker path is unaffected (uses the local solve path's correction only).

## Testing

- Unit: correction captures the surface-wave gap at 0.025 λ / negligible at 0.25 λ; declines vertical geometry.
- CLI (`apps/nec-cli/tests/sommerfeld_ground_cli.rs`): `rcm` ΔR strongly negative, `sommerfeld` ΔR positive near GN2 +9, default == `rcm`.
- `clippy -D warnings` + `fmt` clean; full nec_solver + nec-cli suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBoiHzQsW8fAAH4orsKZPG