### PR TITLE
feat(ph9-chk-007): guard warning recommends --solver mpie for degree-3/loops

### DIFF
--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -608,22 +608,28 @@ fn warn_if_low_finite_ground(segs: &[Segment], ground: &GroundModel, freq_hz: f6
 /// ≈111 − j146 Ω. This surfaces the limitation instead of silently returning a wrong
 /// number — the loop case in particular is missed by [`warn_if_feedpoint_at_junction`]
 /// because the feed need not sit on the junction.
-fn warn_if_unsupported_topology(segs: &[Segment]) {
-    match classify_unsupported_topology(segs) {
-        Some(UnsupportedTopology::ClosedLoop) => eprintln!(
-            "warning: geometry contains a closed loop (a conductor with no free end); \
-             the Hallén solve does not yet model the periodic loop closure, so the reported \
-             impedance, currents, and pattern for this geometry are unreliable \
-             (loop support is deferred — see PH9-CHK-002)"
-        ),
-        Some(UnsupportedTopology::HighDegreeJunction) => eprintln!(
-            "warning: geometry contains a junction where three or more wires meet (a T/Y \
-             junction); the Hallén solve does not yet model the Kirchhoff current split there, \
-             so the reported impedance, currents, and pattern for this geometry are unreliable \
-             (branching-junction support is deferred — see PH9-CHK-002)"
-        ),
-        None => {}
-    }
+fn warn_if_unsupported_topology(deck: &nec_model::deck::NecDeck, segs: &[Segment]) {
+    let kind = match classify_unsupported_topology(segs) {
+        Some(UnsupportedTopology::ClosedLoop) => {
+            "a closed loop (a conductor with no free end); the Hallén solve does not model \
+             the periodic loop closure"
+        }
+        Some(UnsupportedTopology::HighDegreeJunction) => {
+            "a junction where three or more wires meet (a T/Y junction); the Hallén solve does \
+             not model the Kirchhoff current split there"
+        }
+        None => return,
+    };
+    // The MPIE second solver handles both topologies; point the user to it when
+    // the deck is MPIE-compatible, otherwise say support is deferred.
+    let remedy = if mpie_compatible_deck(deck) {
+        "so the reported impedance, currents, and pattern are unreliable — re-run with \
+         `--solver mpie`, which solves this geometry correctly (PH9-CHK-007)"
+    } else {
+        "so the reported impedance, currents, and pattern for this geometry are unreliable \
+         (support for this combination is deferred — see PH9-CHK-002)"
+    };
+    eprintln!("warning: geometry contains {kind}, {remedy}");
 }
 
 /// PH9-CHK-004: compute the near electric field for every `NE` card in the deck.
@@ -1100,6 +1106,28 @@ fn solve_mpie_session(
     Ok(segment_currents(&geom, &sol.basis_currents))
 }
 
+/// Whether a deck can be solved on the MPIE path: it is driven by at least one
+/// voltage source (`EX` type 0) and has no loads / transmission lines / networks
+/// and no plane-wave or current-source excitation (all unsupported by the MPIE).
+fn mpie_compatible_deck(deck: &nec_model::deck::NecDeck) -> bool {
+    let mut has_voltage_source = false;
+    for card in &deck.cards {
+        match card {
+            Card::Ld(_) | Card::Tl(_) | Card::Nt(_) => return false,
+            Card::Ex(ex) => {
+                if ex.kind().is_plane_wave()
+                    || ex.kind() == nec_model::card::ExcitationKind::CurrentSource
+                {
+                    return false;
+                }
+                has_voltage_source = true;
+            }
+            _ => {}
+        }
+    }
+    has_voltage_source
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn solve_frequency_point(
     deck: &nec_model::deck::NecDeck,
@@ -1470,7 +1498,10 @@ pub(super) fn solve_frequency_point(
     // wires, so the single-segment V/I is not the true feedpoint impedance and can
     // be unphysical (e.g. negative resistance). Warn rather than report it as
     // trustworthy; accurate junction-fed impedance is PH9-CHK-002.
-    warn_if_unsupported_topology(segs);
+    // The MPIE solves these topologies correctly, so only warn on other solvers.
+    if !matches!(solver_mode, SolverMode::Mpie) {
+        warn_if_unsupported_topology(deck, segs);
+    }
     warn_if_feedpoint_at_junction(deck, segs);
     warn_if_low_finite_ground(segs, ground, freq_hz);
     warn_if_negative_resistance(&rows, solver_mode);

--- a/apps/nec-cli/tests/junction_feedpoint.rs
+++ b/apps/nec-cli/tests/junction_feedpoint.rs
@@ -175,7 +175,8 @@ fn closed_loop_is_guarded() {
     // the feedpoint-at-junction guard alone would miss it).
     let (_stdout, stderr) = run(SQUARE_LOOP_FED_MIDWIRE, "square-loop");
     assert!(
-        stderr.contains("closed loop") && stderr.contains("PH9-CHK-002"),
-        "a closed loop must be flagged as unsupported; stderr:\n{stderr}"
+        stderr.contains("closed loop") && stderr.contains("--solver mpie"),
+        "a closed loop must be flagged as unsupported and point to --solver mpie; \
+         stderr:\n{stderr}"
     );
 }

--- a/apps/nec-cli/tests/mpie_solver_cli.rs
+++ b/apps/nec-cli/tests/mpie_solver_cli.rs
@@ -127,3 +127,38 @@ EN
         "missing LD rejection message:\n{stderr}"
     );
 }
+
+/// A degree-3 Y-junction on the DEFAULT (Hallén) solver keeps its guard warning
+/// (results are not silently changed), and the warning now points the user to
+/// `--solver mpie` as the fix.
+#[test]
+fn guarded_topology_warning_recommends_mpie() {
+    let deck = write_deck(
+        "yguard",
+        "\
+CM Y-junction on the default solver
+CE
+GW 1 20 0.0 0.0 0.0 5.0 0.0 0.0 0.001
+GW 2 20 0.0 0.0 0.0 -2.5 4.330127 0.0 0.001
+GW 3 20 0.0 0.0 0.0 -2.5 -4.330127 0.0 0.001
+GE 0
+FR 0 1 0 0 14.2 0
+EX 0 1 10 0 1.0 0.0
+EN
+",
+    );
+    let out = run_fnec(&[deck.to_str().unwrap()]); // no --solver flag
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--solver mpie"),
+        "guard warning should recommend --solver mpie:\n{stderr}"
+    );
+    // And using the MPIE explicitly clears the warning and solves it physically.
+    let out2 = run_fnec(&["--solver", "mpie", deck.to_str().unwrap()]);
+    assert!(out2.status.success());
+    let stderr2 = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        !stderr2.contains("unreliable"),
+        "MPIE solve should not emit the unreliable-topology warning:\n{stderr2}"
+    );
+}


### PR DESCRIPTION
## Summary

The default (Hallén) solver guards degree-3 (T/Y) junctions and closed loops and returns an unreliable per-wire fallback. The MPIE now solves both, so this makes the guard **actionable**: when the deck is MPIE-compatible (voltage source, no `LD`/`TL`/`NT`, no plane-wave/current-source), the topology warning tells the user to re-run with `--solver mpie`; otherwise it keeps the "support deferred" wording. An explicit `--solver mpie` run suppresses the warning.

## Why not silent auto-routing (§3 as originally framed)

I prototyped auto-switching the default solver to the MPIE for these topologies, but it **changed results for an existing pinned corpus deck** — `dipole-loaded` (a dipole with a closed-loop stub) went from the Hallén-fallback 12.39 Ω to the MPIE's 13.84 Ω — and would silently change a user's solver. Keeping the Hallén result plus a clear pointer preserves **zero corpus regression** and user control while still delivering the fix. (The MPIE answer is likely more accurate, but re-pinning corpus references to a different solver's output is a separate, deliberate decision — not a silent side effect.)

## Tests

- `mpie_solver_cli::guarded_topology_warning_recommends_mpie` — a Y-junction on the default solver warns and names `--solver mpie`; the explicit MPIE run is clean.
- `junction_feedpoint` closed-loop assertion updated to the new wording.
- Zero regression: corpus green, 78 test binaries pass, clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)