### PR TITLE
feat(ph9-chk-004): RP XNDA A-digit — average power gain

### DIFF
--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -1681,6 +1681,30 @@ pub(super) fn solve_frequency_point(
     let near_field_table = build_near_field_rows(deck, segs, &i_vec, freq_hz);
     let near_h_field_table = build_near_h_field_rows(deck, segs, &i_vec, freq_hz);
 
+    // PH9-CHK-004: average power gain (RP XNDA A-digit) — the solid-angle-weighted
+    // mean gain over the pattern region (= radiation efficiency over the full
+    // sphere). Uniform (θ,φ) grid, so the Δθ·Δφ weights cancel and each point is
+    // weighted by sinθ; below-horizon nulls over ground are skipped.
+    let avg_power_gain = if deck
+        .cards
+        .iter()
+        .any(|c| matches!(c, Card::Rp(rp) if rp.avg_power_gain))
+        && !pattern_table.is_empty()
+    {
+        let (mut num, mut den) = (0.0_f64, 0.0_f64);
+        for row in &pattern_table {
+            if row.gain_total_dbi <= -900.0 {
+                continue;
+            }
+            let w = row.theta_deg.to_radians().sin();
+            num += 10f64.powf(row.gain_total_dbi / 10.0) * w;
+            den += w;
+        }
+        (den > 0.0).then(|| num / den)
+    } else {
+        None
+    };
+
     let report = render_text_report(&ReportInput {
         solver_mode: diag_label,
         pulse_rhs: pulse_rhs_mode.as_contract_str(),
@@ -1697,6 +1721,7 @@ pub(super) fn solve_frequency_point(
             .cards
             .iter()
             .any(|c| matches!(c, Card::Rp(rp) if rp.normalize)),
+        avg_power_gain,
     });
     let sweep_summary = rows.first().map(|row| SweepPointSummary {
         freq_mhz: freq_hz / 1e6,

--- a/apps/nec-cli/tests/rp_avg_power_gain.rs
+++ b/apps/nec-cli/tests/rp_avg_power_gain.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+//
+// PH9-CHK-004: RP XNDA `A` digit — average power gain. The solid-angle-weighted
+// mean gain over the pattern region equals the radiation efficiency over the full
+// sphere (≈1 for a lossless antenna). Validated against nec2c, which prints
+// "AVERAGE POWER GAIN: 9.9795E-01" for the free-space λ/2 dipole below.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn run_fnec(deck: &str, name: &str) -> String {
+    let path = std::env::temp_dir().join(format!("fnec_apg_{name}.nec"));
+    std::fs::write(&path, deck).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_fnec"))
+        .arg(&path)
+        .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../.."))
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "fnec failed for {name}: {out:?}");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const DIPOLE: &str =
+    "CM dipole\nCE\nGW 1 21 0 0 -5.28 0 0 5.28 0.001\nGE 0\nFR 0 1 0 0 14.2 0\nEX 0 1 11 0 1.0 0.0\n";
+
+fn avg_power_gain(stdout: &str) -> Option<f64> {
+    stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("AVERAGE_POWER_GAIN"))
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|t| t.parse().ok())
+}
+
+/// A full-sphere RP with the `A` digit set emits AVERAGE_POWER_GAIN ≈ 1
+/// (nec2c: 0.998 for this lossless free-space dipole).
+#[test]
+fn average_power_gain_matches_nec2c() {
+    // RP 0 NTHETA NPHI XNDA=1002 θ0 φ0 Δθ Δφ — full sphere, A digit = 2.
+    let deck = format!("{DIPOLE}RP 0 19 37 1002 0 0 10 10\nEN\n");
+    let apg = avg_power_gain(&run_fnec(&deck, "sphere")).expect("AVERAGE_POWER_GAIN line");
+    assert!(
+        (apg - 0.998).abs() / 0.998 < 0.02,
+        "average power gain {apg} not within 2% of nec2c 0.998"
+    );
+}
+
+/// Without the `A` digit (XNDA=1000), no AVERAGE_POWER_GAIN line is emitted.
+#[test]
+fn no_a_digit_no_average_power_gain() {
+    let deck = format!("{DIPOLE}RP 0 19 37 1000 0 0 10 10\nEN\n");
+    assert!(
+        avg_power_gain(&run_fnec(&deck, "noa")).is_none(),
+        "AVERAGE_POWER_GAIN must not appear without the XNDA A digit"
+    );
+}

--- a/crates/nec_model/src/card.rs
+++ b/crates/nec_model/src/card.rs
@@ -217,6 +217,11 @@ pub struct RpCard {
     /// on the canonical 8-field card). When set, a `NORMALIZED_PATTERN` section
     /// (gain relative to the pattern peak) is emitted. PH9-CHK-004.
     pub normalize: bool,
+    /// Average-power-gain output requested by the `XNDA` field's `A` (units) digit.
+    /// When set, an `AVERAGE_POWER_GAIN` line (the solid-angle-weighted mean gain
+    /// over the pattern region, = radiation efficiency over the full sphere) is
+    /// emitted, matching nec2c's "AVERAGE POWER GAIN". PH9-CHK-004.
+    pub avg_power_gain: bool,
 }
 
 /// GN — Ground definition card.

--- a/crates/nec_parser/src/lib.rs
+++ b/crates/nec_parser/src/lib.rs
@@ -299,12 +299,16 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                 // with >= 8 fields the four angle floats start at index 4 (after
                 // XNDA); with 7 they start at index 3. The XNDA `X` digit (its
                 // thousands digit) requests normalized-gain output.
+                // With >= 8 fields the four angle floats start at index 4 (after
+                // XNDA); with 7 they start at index 3. The XNDA `X` (thousands)
+                // digit requests normalized-gain output; the `A` (units) digit
+                // requests the average power gain.
                 let a = if fields.len() >= 8 { 4 } else { 3 };
-                let normalize = if fields.len() >= 8 {
+                let (normalize, avg_power_gain) = if fields.len() >= 8 {
                     let xnda = parse_u32(lineno, "RP", 4, fields[3])?;
-                    (xnda / 1000) % 10 != 0
+                    ((xnda / 1000) % 10 != 0, xnda % 10 != 0)
                 } else {
-                    false
+                    (false, false)
                 };
                 deck.cards.push(Card::Rp(RpCard {
                     mode: parse_u32(lineno, "RP", 1, fields[0])?,
@@ -315,6 +319,7 @@ pub fn parse(input: &str) -> Result<ParseResult, ParseError> {
                     d_theta: parse_f64(lineno, "RP", a + 3, fields[a + 2])?,
                     d_phi: parse_f64(lineno, "RP", a + 4, fields[a + 3])?,
                     normalize,
+                    avg_power_gain,
                 }));
             }
             "LD" => {
@@ -577,6 +582,7 @@ EN
                 d_theta: 5.0,
                 d_phi: 0.0,
                 normalize: false,
+                avg_power_gain: false,
             })
         );
         // EN

--- a/crates/nec_report/src/lib.rs
+++ b/crates/nec_report/src/lib.rs
@@ -139,6 +139,10 @@ pub struct ReportInput<'a> {
     /// THETA PHI GAIN_NORM_DB` section — the total gain relative to the pattern
     /// peak — is emitted from `pattern_table` (PH9-CHK-004).
     pub normalize_pattern: bool,
+    /// When set (RP `XNDA` A-digit), an `AVERAGE_POWER_GAIN <value>` line — the
+    /// solid-angle-weighted mean gain over the pattern region — is emitted
+    /// (PH9-CHK-004).
+    pub avg_power_gain: Option<f64>,
 }
 
 /// **Extension point EP-2 — feedpoint result filter.**
@@ -241,6 +245,7 @@ pub trait ResultFilter {
 ///     near_field_table: &[],
 ///     near_h_field_table: &[],
 ///     normalize_pattern: false,
+///     avg_power_gain: None,
 /// };
 /// let section = ImpedanceSummary { rows: &[row] };
 /// let report = render_text_report_with_sections(&input, &[&section]);
@@ -282,7 +287,7 @@ pub trait ReportSection {
 ///     frequency_hz: 14e6,
 ///     rows: &[row],
 ///     source_table: &[], load_table: &[],
-///     current_table: &[], pattern_table: &[], receive_pattern_table: &[], near_field_table: &[], near_h_field_table: &[], normalize_pattern: false,
+///     current_table: &[], pattern_table: &[], receive_pattern_table: &[], near_field_table: &[], near_h_field_table: &[], normalize_pattern: false, avg_power_gain: None,
 /// };
 /// let report = render_text_report_with_sections(&input, &[&Banner]);
 /// assert!(report.contains("MY_SECTION\nhello world\n"));
@@ -421,6 +426,11 @@ pub fn render_text_report(input: &ReportInput<'_>) -> String {
         }
     }
 
+    if let Some(apg) = input.avg_power_gain {
+        out.push('\n');
+        out.push_str(&format!("AVERAGE_POWER_GAIN {apg:.4}\n"));
+    }
+
     out
 }
 
@@ -516,6 +526,7 @@ mod tests {
             near_field_table: &[],
             near_h_field_table: &[],
             normalize_pattern: false,
+            avg_power_gain: None,
         });
 
         assert!(report.starts_with("FNEC FEEDPOINT REPORT\nFORMAT_VERSION 1\n"));
@@ -563,6 +574,7 @@ mod tests {
             near_field_table: &[],
             near_h_field_table: &[],
             normalize_pattern: false,
+            avg_power_gain: None,
         });
 
         assert!(report.contains("CURRENTS\n"));
@@ -650,6 +662,7 @@ mod tests {
             near_field_table: &[],
             near_h_field_table: &[],
             normalize_pattern: false,
+            avg_power_gain: None,
         });
         assert!(report.contains("RADIATION_PATTERN\n"));
         assert!(report.contains("N_POINTS 1\n"));
@@ -695,6 +708,7 @@ mod tests {
             near_field_table: &[],
             near_h_field_table: &[],
             normalize_pattern: false,
+            avg_power_gain: None,
         });
 
         let feed_idx = report.find("FEEDPOINTS\n").expect("missing FEEDPOINTS");
@@ -731,6 +745,7 @@ mod tests {
             near_field_table: &[],
             near_h_field_table: &[],
             normalize_pattern: false,
+            avg_power_gain: None,
         }
     }
 
@@ -843,6 +858,7 @@ mod tests {
             near_field_table: &[],
             near_h_field_table: &[],
             normalize_pattern: false,
+            avg_power_gain: None,
         });
         assert!(report.contains("FEEDPOINTS\n"));
         assert!(report.contains("TAG SEG V_RE V_IM I_RE I_IM Z_RE Z_IM\n"));

--- a/docs/card-support-matrix.md
+++ b/docs/card-support-matrix.md
@@ -106,7 +106,7 @@ no longer silently treated as EX type 0.
 
 | Card | Support | Notes |
 |------|---------|-------|
-| RP | Full | Far-field radiation pattern; all RP grid points computed and included in the `RADIATION_PATTERN` report section. `XNDA` X-digit → `NORMALIZED_PATTERN` section (PH9-CHK-004) |
+| RP | Full | Far-field radiation pattern; all RP grid points computed and included in the `RADIATION_PATTERN` report section. `XNDA` X-digit → `NORMALIZED_PATTERN` section; `XNDA` A-digit → `AVERAGE_POWER_GAIN` line (solid-angle-weighted mean gain = radiation efficiency over the full sphere, matches nec2c to <1%) (PH9-CHK-004). The `N`/`D` digits (gain-component labeling / dB-vs-ratio output-format toggles) are deferred — fnec always emits vertical/horizontal/total gain in dBi |
 
 ## Unknown / other cards
 


### PR DESCRIPTION
## Summary (§4 — RP average power gain)

Implements the RP card's `XNDA` `A` (units) digit: the average power gain over the pattern region. nec2c prints "AVERAGE POWER GAIN"; fnec now emits an `AVERAGE_POWER_GAIN <value>` line.

The value is the solid-angle-weighted mean gain over the RP grid (`Σ G_lin·sinθ / Σ sinθ` on the uniform θ/φ grid, below-horizon nulls skipped) — over the full sphere this equals the radiation efficiency (≈1 for a lossless antenna). **Validated against a live nec2c run**: free-space λ/2 dipole over the full sphere gives **1.0026 vs nec2c 0.9980** (<0.5%).

## Tests (`apps/nec-cli/tests/rp_avg_power_gain.rs`)

- value within 2% of nec2c 0.998;
- no `AVERAGE_POWER_GAIN` line without the `A` digit.

The parser decodes `xnda % 10` into `RpCard::avg_power_gain`; `ReportInput::avg_power_gain: Option<f64>` drives the report line. Docs: card-support-matrix RP row (A-digit done; the `N`/`D` gain-labeling / output-format toggle digits documented as deferred — fnec always emits vertical/horizontal/total gain in dBi). Zero regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)