### PR TITLE
feat(gui-chk-002): render wire geometry in the 3-D viewport

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -102,6 +102,20 @@ pub struct AppState {
     // ── Currents tab state ─────────────────────────────────────────────────
     /// Current-distribution phase.
     pub currents_phase: CurrentsPhase,
+    // ── 3-D viewport state (GUI redesign) ──────────────────────────────────
+    /// GPU viewport: camera + built line mesh + status (`docs/gui-redesign-plan.md`).
+    pub viewport: ViewportState,
+}
+
+/// State of the GPU 3-D viewport. The camera and mesh are pure data (rendered by
+/// the binary's `viewport/` wgpu module); `scene_rev` bumps whenever the mesh
+/// changes so the renderer knows to re-upload the vertex buffer.
+#[derive(Debug, Clone, Default)]
+pub struct ViewportState {
+    pub camera: crate::camera::Camera,
+    pub scene: Option<std::sync::Arc<crate::mesh::MeshData>>,
+    pub scene_rev: u64,
+    pub status: String,
 }
 
 impl Default for AppState {
@@ -120,6 +134,7 @@ impl Default for AppState {
             pattern_phi_deg: "0.0".into(),
             pattern_phase: PatternPhase::default(),
             currents_phase: CurrentsPhase::default(),
+            viewport: ViewportState::default(),
         }
     }
 }
@@ -174,6 +189,11 @@ pub enum Message {
     RunCurrents,
     /// Background current-distribution computation completed.
     CurrentsComplete(Result<Vec<CurrentPoint>, String>),
+    // ── 3-D viewport ──────────────────────────────────────────────────────
+    /// User clicked "Load geometry" in the 3-D view.
+    LoadGeometry,
+    /// Background geometry build completed (parse + `build_geometry`, no solve).
+    GeometryLoaded(Result<crate::mesh::SceneGeometry, String>),
 }
 
 impl AppState {
@@ -241,6 +261,20 @@ impl AppState {
             }
             Message::CurrentsComplete(Err(e)) => {
                 self.currents_phase = CurrentsPhase::Failed(e.clone());
+            }
+            Message::LoadGeometry => {
+                self.viewport.status = "Loading geometry…".into();
+            }
+            Message::GeometryLoaded(Ok(geo)) => {
+                let (center, radius) = geo.bounds();
+                self.viewport.camera.fit(center, radius);
+                self.viewport.scene = Some(std::sync::Arc::new(crate::mesh::build_scene(geo)));
+                self.viewport.scene_rev = self.viewport.scene_rev.wrapping_add(1);
+                self.viewport.status = format!("{} wire segments", geo.wires.len());
+            }
+            Message::GeometryLoaded(Err(e)) => {
+                self.viewport.scene = None;
+                self.viewport.status = format!("Error: {e}");
             }
         }
     }

--- a/apps/nec-gui/src/camera.rs
+++ b/apps/nec-gui/src/camera.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Orbit camera for the 3-D viewport (GUI-CHK-002 fit + fixed view; the
+//! orbit/zoom/pan interaction lands in GUI-CHK-003).
+//!
+//! Pure `glam` math, unit-tested headlessly. NEC geometry is **z-up**, so the
+//! view matrix uses `Vec3::Z` as the up vector and antennas stand upright.
+
+use glam::{Mat4, Vec3};
+
+/// An orbit ("turntable") camera: it looks at `target` from `distance` away,
+/// oriented by `yaw` (about z) and `pitch` (elevation from the xy-plane).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Camera {
+    pub target: Vec3,
+    pub distance: f32,
+    /// Azimuth about the z-axis, radians.
+    pub yaw: f32,
+    /// Elevation from the xy-plane, radians (clamped to ±89°).
+    pub pitch: f32,
+    /// Vertical field of view, radians.
+    pub fov_y: f32,
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        // A three-quarter isometric-ish view.
+        Self {
+            target: Vec3::ZERO,
+            distance: 10.0,
+            yaw: -0.9,
+            pitch: 0.5,
+            fov_y: std::f32::consts::FRAC_PI_4,
+        }
+    }
+}
+
+const PITCH_LIMIT: f32 = 1.552; // ~89°
+
+impl Camera {
+    /// Camera eye position in world space (z-up spherical about `target`).
+    pub fn eye(&self) -> Vec3 {
+        let cp = self.pitch.cos();
+        let dir = Vec3::new(cp * self.yaw.cos(), cp * self.yaw.sin(), self.pitch.sin());
+        self.target + dir * self.distance
+    }
+
+    /// Combined view-projection matrix for the given viewport aspect ratio.
+    pub fn view_proj(&self, aspect: f32) -> Mat4 {
+        let far = self.distance * 10.0 + 100.0;
+        let near = (self.distance * 0.01).max(0.001);
+        let proj = Mat4::perspective_rh(self.fov_y, aspect.max(0.01), near, far);
+        let view = Mat4::look_at_rh(self.eye(), self.target, Vec3::Z);
+        proj * view
+    }
+
+    /// Frame a bounding box: centre the target and back off so the sphere of the
+    /// given `radius` fits the vertical field of view (with a small margin).
+    pub fn fit(&mut self, center: [f32; 3], radius: f32) {
+        self.target = Vec3::from_array(center);
+        self.distance = (radius / (self.fov_y * 0.5).sin() * 1.25).max(0.5);
+    }
+
+    /// Orbit by screen-space deltas (radians). Pitch is clamped. (GUI-CHK-003.)
+    pub fn orbit(&mut self, d_yaw: f32, d_pitch: f32) {
+        self.yaw += d_yaw;
+        self.pitch = (self.pitch + d_pitch).clamp(-PITCH_LIMIT, PITCH_LIMIT);
+    }
+
+    /// Zoom by scroll steps (positive = closer). Distance stays positive.
+    pub fn zoom(&mut self, steps: f32) {
+        self.distance = (self.distance * 0.88f32.powf(steps)).clamp(0.05, 1.0e6);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_centers_target_and_backs_off() {
+        let mut c = Camera::default();
+        c.fit([1.0, 2.0, 3.0], 5.0);
+        assert_eq!(c.target, Vec3::new(1.0, 2.0, 3.0));
+        // Distance grows with radius and exceeds it.
+        assert!(
+            c.distance > 5.0,
+            "camera should sit outside the geometry sphere"
+        );
+        let mut c2 = Camera::default();
+        c2.fit([0.0; 3], 10.0);
+        assert!(c2.distance > c.distance, "larger bbox → farther camera");
+    }
+
+    #[test]
+    fn eye_is_distance_from_target() {
+        let c = Camera {
+            target: Vec3::new(1.0, 1.0, 1.0),
+            distance: 7.0,
+            ..Camera::default()
+        };
+        assert!((c.eye().distance(c.target) - 7.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn target_projects_near_screen_center() {
+        let mut c = Camera::default();
+        c.fit([0.0; 3], 3.0);
+        let m = c.view_proj(1.5);
+        let clip = m * c.target.extend(1.0);
+        let ndc = clip.truncate() / clip.w;
+        // The look-at target lands at the center of the frame.
+        assert!(ndc.x.abs() < 1e-3 && ndc.y.abs() < 1e-3, "ndc={ndc:?}");
+        // ...and in front of the camera (0 < depth < 1 for wgpu clip space).
+        assert!((0.0..=1.0).contains(&ndc.z), "depth {} out of range", ndc.z);
+    }
+
+    #[test]
+    fn pitch_is_clamped() {
+        let mut c = Camera::default();
+        c.orbit(0.0, 100.0);
+        assert!(c.pitch <= PITCH_LIMIT + 1e-6);
+        c.orbit(0.0, -100.0);
+        assert!(c.pitch >= -PITCH_LIMIT - 1e-6);
+    }
+
+    #[test]
+    fn zoom_scales_distance_and_stays_positive() {
+        let mut c = Camera::default();
+        let d0 = c.distance;
+        c.zoom(1.0);
+        assert!(c.distance < d0, "zoom in should shrink distance");
+        c.zoom(-1.0);
+        assert!((c.distance - d0).abs() < 1e-3, "zoom out should restore");
+        c.zoom(1000.0);
+        assert!(c.distance > 0.0);
+    }
+}

--- a/apps/nec-gui/src/lib.rs
+++ b/apps/nec-gui/src/lib.rs
@@ -5,4 +5,6 @@
 //! the iced binary and the headless test suite.
 
 pub mod app_state;
+pub mod camera;
+pub mod mesh;
 pub mod solve;

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -16,8 +16,8 @@ use nec_gui::app_state::{
     ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase, SweepSortCol,
 };
 use nec_gui::solve::{
-    current_distribution_deck_path, pattern_slice_deck_path, solve_deck_path, sweep_deck_path,
-    SolveResult, SweepPoint,
+    current_distribution_deck_path, load_geometry_path, pattern_slice_deck_path, solve_deck_path,
+    sweep_deck_path, SolveResult, SweepPoint,
 };
 use std::path::PathBuf;
 
@@ -39,6 +39,7 @@ impl FnecGui {
         let spawn_sweep = matches!(message, Message::RunSweep);
         let spawn_pattern = matches!(message, Message::RunPattern);
         let spawn_currents = matches!(message, Message::RunCurrents);
+        let spawn_geometry = matches!(message, Message::LoadGeometry);
         self.state.apply(&message);
 
         if spawn_solve {
@@ -103,6 +104,17 @@ impl FnecGui {
             Task::perform(
                 async move { current_distribution_deck_path(&path, vars.as_deref()) },
                 Message::CurrentsComplete,
+            )
+        } else if spawn_geometry {
+            let path = PathBuf::from(self.state.deck_path.clone());
+            let vars: Option<String> = if self.state.vars_path.is_empty() {
+                None
+            } else {
+                Some(self.state.vars_path.clone())
+            };
+            Task::perform(
+                async move { load_geometry_path(&path, vars.as_deref()) },
+                Message::GeometryLoaded,
             )
         } else {
             Task::none()
@@ -192,15 +204,24 @@ impl FnecGui {
     /// (a triangle) to prove the iced-0.13 custom-wgpu integration; later phases
     /// replace it with the wire geometry, currents, and pattern lobe.
     fn viewport_view(&self) -> Element<'_, Message> {
-        let caption = text(
-            "GPU 3-D viewport (Phase 0 spike). The colored triangle confirms the \
-             wgpu shader-widget integration; wire geometry lands in GUI-CHK-002.",
-        );
-        let scene = shader(viewport::Scene)
+        let load_btn = if self.state.deck_path.is_empty() {
+            button("Load geometry")
+        } else {
+            button("Load geometry").on_press(Message::LoadGeometry)
+        };
+        let status = text(if self.state.viewport.status.is_empty() {
+            "Load a deck's geometry to view it in 3-D (wires, axes, ground grid).".to_string()
+        } else {
+            self.state.viewport.status.clone()
+        });
+        let controls = row![load_btn, status]
+            .spacing(12)
+            .align_y(iced::Alignment::Center);
+        let scene = shader(viewport::Scene::new(&self.state.viewport))
             .width(Length::Fill)
             .height(Length::Fill);
         column![
-            caption,
+            controls,
             container(scene).width(Length::Fill).height(Length::Fill)
         ]
         .spacing(8)

--- a/apps/nec-gui/src/mesh.rs
+++ b/apps/nec-gui/src/mesh.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Pure line-mesh construction for the 3-D viewport (GUI-CHK-002).
+//!
+//! All functions here are display-free and unit-tested headlessly: the solved
+//! geometry becomes a flat list of colored line vertices (wires + coordinate
+//! axes + an optional ground grid), which the wgpu viewport uploads as a single
+//! `LineList` buffer. Kept in the library crate so the CI gates can cover it.
+
+use bytemuck::{Pod, Zeroable};
+
+/// One vertex of a colored line segment (GPU vertex-buffer layout).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable)]
+pub struct LineVertex {
+    pub pos: [f32; 3],
+    pub color: [f32; 4],
+}
+
+impl LineVertex {
+    fn new(pos: [f32; 3], color: [f32; 4]) -> Self {
+        Self { pos, color }
+    }
+}
+
+/// The solved wire geometry handed from the solver thread to the viewport: wire
+/// segment endpoints (metres) plus the axis-aligned bounding box and whether a
+/// ground plane is present. Cheap to clone; `Send` for `Task::perform`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SceneGeometry {
+    /// Each wire segment as `(start, end)` in metres.
+    pub wires: Vec<([f32; 3], [f32; 3])>,
+    pub bbox_min: [f32; 3],
+    pub bbox_max: [f32; 3],
+    /// True when the deck defines a ground plane (draw the z=0 grid).
+    pub has_ground: bool,
+}
+
+impl SceneGeometry {
+    /// Build from solver `(start, end)` segment endpoints, computing the bbox.
+    pub fn from_segments(wires: Vec<([f32; 3], [f32; 3])>, has_ground: bool) -> Self {
+        let mut lo = [f32::INFINITY; 3];
+        let mut hi = [f32::NEG_INFINITY; 3];
+        for (a, b) in &wires {
+            for p in [a, b] {
+                for k in 0..3 {
+                    lo[k] = lo[k].min(p[k]);
+                    hi[k] = hi[k].max(p[k]);
+                }
+            }
+        }
+        if wires.is_empty() {
+            lo = [-1.0; 3];
+            hi = [1.0; 3];
+        }
+        Self {
+            wires,
+            bbox_min: lo,
+            bbox_max: hi,
+            has_ground,
+        }
+    }
+
+    /// Bounding-box centre and half-diagonal ("radius"), used for camera fit.
+    pub fn bounds(&self) -> ([f32; 3], f32) {
+        let c = [
+            0.5 * (self.bbox_min[0] + self.bbox_max[0]),
+            0.5 * (self.bbox_min[1] + self.bbox_max[1]),
+            0.5 * (self.bbox_min[2] + self.bbox_max[2]),
+        ];
+        let d = [
+            self.bbox_max[0] - self.bbox_min[0],
+            self.bbox_max[1] - self.bbox_min[1],
+            self.bbox_max[2] - self.bbox_min[2],
+        ];
+        let r = 0.5 * (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt();
+        (c, r.max(0.1))
+    }
+}
+
+/// A built list of line vertices (2 per segment), ready for a `LineList` draw.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MeshData {
+    pub vertices: Vec<LineVertex>,
+}
+
+impl MeshData {
+    pub fn segment_count(&self) -> usize {
+        self.vertices.len() / 2
+    }
+}
+
+const WIRE_COLOR: [f32; 4] = [0.90, 0.82, 0.24, 1.0];
+const GRID_COLOR: [f32; 4] = [0.30, 0.32, 0.36, 1.0];
+const AXIS_X: [f32; 4] = [0.85, 0.25, 0.25, 1.0];
+const AXIS_Y: [f32; 4] = [0.30, 0.75, 0.35, 1.0];
+const AXIS_Z: [f32; 4] = [0.35, 0.55, 0.95, 1.0];
+
+/// Assemble the full scene mesh: ground grid (if any) → axes → wires. Wires are
+/// appended **last** so their indices are stable for per-segment recoloring
+/// (currents, GUI-CHK-004): wire segment `i` occupies vertices
+/// `[wire_base + 2i, wire_base + 2i + 1]`.
+pub fn build_scene(geo: &SceneGeometry) -> MeshData {
+    let (center, radius) = geo.bounds();
+    let mut v = Vec::new();
+
+    if geo.has_ground {
+        push_ground_grid(&mut v, center, radius);
+    }
+    push_axes(&mut v, radius);
+    for (a, b) in &geo.wires {
+        v.push(LineVertex::new(*a, WIRE_COLOR));
+        v.push(LineVertex::new(*b, WIRE_COLOR));
+    }
+    MeshData { vertices: v }
+}
+
+/// Index of the first wire vertex in a mesh built by [`build_scene`], so callers
+/// can recolor wires in place without rebuilding the grid/axes.
+pub fn wire_vertex_base(geo: &SceneGeometry) -> usize {
+    let (_, radius) = geo.bounds();
+    let grid = if geo.has_ground {
+        ground_grid_vertex_count(center_extent(radius))
+    } else {
+        0
+    };
+    grid + AXIS_VERTS
+}
+
+const AXIS_VERTS: usize = 6; // 3 axes × 2 vertices
+
+fn push_axes(v: &mut Vec<LineVertex>, radius: f32) {
+    let l = radius * 0.6;
+    v.push(LineVertex::new([0.0, 0.0, 0.0], AXIS_X));
+    v.push(LineVertex::new([l, 0.0, 0.0], AXIS_X));
+    v.push(LineVertex::new([0.0, 0.0, 0.0], AXIS_Y));
+    v.push(LineVertex::new([0.0, l, 0.0], AXIS_Y));
+    v.push(LineVertex::new([0.0, 0.0, 0.0], AXIS_Z));
+    v.push(LineVertex::new([0.0, 0.0, l], AXIS_Z));
+}
+
+/// Grid extent (half-width) and step, chosen to comfortably frame the geometry.
+fn center_extent(radius: f32) -> (f32, f32) {
+    let extent = (radius * 1.5).max(1.0);
+    // ~10 divisions per side, rounded to a "nice" step.
+    let raw = extent / 10.0;
+    let mag = 10f32.powf(raw.log10().floor());
+    let step = (raw / mag).ceil() * mag;
+    (extent, step)
+}
+
+fn ground_grid_vertex_count((extent, step): (f32, f32)) -> usize {
+    let n = (extent / step).floor() as i32;
+    // lines from -n..=n in each of two directions, 2 vertices each.
+    (((2 * n + 1) * 2) as usize) * 2
+}
+
+fn push_ground_grid(v: &mut Vec<LineVertex>, center: [f32; 3], radius: f32) {
+    let (extent, step) = center_extent(radius);
+    let (cx, cy) = (center[0], center[1]);
+    let n = (extent / step).floor() as i32;
+    for i in -n..=n {
+        let off = i as f32 * step;
+        // Lines parallel to x (vary y).
+        v.push(LineVertex::new([cx - extent, cy + off, 0.0], GRID_COLOR));
+        v.push(LineVertex::new([cx + extent, cy + off, 0.0], GRID_COLOR));
+        // Lines parallel to y (vary x).
+        v.push(LineVertex::new([cx + off, cy - extent, 0.0], GRID_COLOR));
+        v.push(LineVertex::new([cx + off, cy + extent, 0.0], GRID_COLOR));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tri_deck_geo() -> SceneGeometry {
+        SceneGeometry::from_segments(
+            vec![
+                ([0.0, 0.0, 0.0], [1.0, 0.0, 0.0]),
+                ([1.0, 0.0, 0.0], [1.0, 2.0, 0.0]),
+                ([1.0, 2.0, 0.0], [0.0, 0.0, 3.0]),
+            ],
+            false,
+        )
+    }
+
+    #[test]
+    fn bbox_spans_all_endpoints() {
+        let g = tri_deck_geo();
+        assert_eq!(g.bbox_min, [0.0, 0.0, 0.0]);
+        assert_eq!(g.bbox_max, [1.0, 2.0, 3.0]);
+        let (c, r) = g.bounds();
+        assert_eq!(c, [0.5, 1.0, 1.5]);
+        assert!((r - 0.5 * (1.0f32 + 4.0 + 9.0).sqrt()).abs() < 1e-5);
+    }
+
+    #[test]
+    fn scene_has_two_vertices_per_wire_plus_axes() {
+        let g = tri_deck_geo();
+        let m = build_scene(&g);
+        // 3 wires × 2 + 3 axes × 2, no grid (free space).
+        assert_eq!(m.vertices.len(), 3 * 2 + AXIS_VERTS);
+        // Wire vertices are last and match the endpoints.
+        let base = wire_vertex_base(&g);
+        assert_eq!(base, AXIS_VERTS);
+        assert_eq!(m.vertices[base].pos, [0.0, 0.0, 0.0]);
+        assert_eq!(m.vertices[base + 1].pos, [1.0, 0.0, 0.0]);
+        assert_eq!(m.vertices[base + 5].pos, [0.0, 0.0, 3.0]);
+    }
+
+    #[test]
+    fn ground_adds_grid_before_wires() {
+        let g = SceneGeometry::from_segments(vec![([0.0, 0.0, 1.0], [0.0, 0.0, 3.0])], true);
+        let m = build_scene(&g);
+        let base = wire_vertex_base(&g);
+        // Grid present → base is past the axes.
+        assert!(base > AXIS_VERTS, "grid should precede axes+wires");
+        // Grid vertex count is even (line pairs) and matches the helper.
+        assert_eq!(m.vertices.len(), base + 2);
+        // The last two vertices are the single wire.
+        assert_eq!(m.vertices[base].pos, [0.0, 0.0, 1.0]);
+        assert_eq!(m.vertices[base + 1].pos, [0.0, 0.0, 3.0]);
+    }
+
+    #[test]
+    fn empty_geometry_has_unit_bbox() {
+        let g = SceneGeometry::from_segments(vec![], false);
+        assert_eq!(g.bbox_min, [-1.0, -1.0, -1.0]);
+        assert_eq!(g.bbox_max, [1.0, 1.0, 1.0]);
+    }
+}

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -12,7 +12,7 @@ use nec_parser::parse;
 use nec_solver::{
     assemble_z_matrix_with_ground, build_excitation, build_geometry, build_hallen_rhs, build_loads,
     build_tl_stamps, compute_radiation_pattern, detect_wire_junctions, ground_model_from_deck,
-    solve_hallen, wire_endpoints_from_segs, FarFieldPoint,
+    solve_hallen, wire_endpoints_from_segs, FarFieldPoint, GroundModel,
 };
 use num_complex::Complex64;
 
@@ -134,6 +134,36 @@ pub fn solve_deck_path(path: &Path, vars_path: Option<&str>) -> Result<SolveResu
         .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
     let input = apply_vars(&input, vars_path)?;
     solve_deck_str(&input)
+}
+
+/// Parse a deck (with optional `$VAR` substitution) and build **only** its
+/// geometry — no solve — for the 3-D viewport (GUI-CHK-002). Cheap enough to run
+/// on every valid edit for instant visual feedback.
+pub fn load_geometry_path(
+    path: &Path,
+    vars_path: Option<&str>,
+) -> Result<crate::mesh::SceneGeometry, String> {
+    let input = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
+    load_geometry_str(&input)
+}
+
+/// Build the viewport geometry from a raw NEC deck string.
+pub fn load_geometry_str(deck_text: &str) -> Result<crate::mesh::SceneGeometry, String> {
+    let parsed = parse(deck_text).map_err(|e| e.to_string())?;
+    let deck = &parsed.deck;
+    let segs = build_geometry(deck).map_err(|e| e.to_string())?;
+    if segs.is_empty() {
+        return Err("deck has no wire geometry (no GW cards?)".to_string());
+    }
+    let has_ground = !matches!(
+        ground_model_from_deck(deck),
+        GroundModel::FreeSpace | GroundModel::Deferred { .. }
+    );
+    let f3 = |p: [f64; 3]| [p[0] as f32, p[1] as f32, p[2] as f32];
+    let wires = segs.iter().map(|s| (f3(s.start), f3(s.end))).collect();
+    Ok(crate::mesh::SceneGeometry::from_segments(wires, has_ground))
 }
 
 /// Run a Hallen solve on `deck_text` (a raw NEC deck string).

--- a/apps/nec-gui/src/viewport/mod.rs
+++ b/apps/nec-gui/src/viewport/mod.rs
@@ -3,33 +3,61 @@
 
 //! GPU 3-D viewport (GUI redesign — see `docs/gui-redesign-plan.md`).
 //!
-//! Phase 0 (GUI-CHK-001) is a shader-widget spike: a `shader::Program` that
-//! renders a hard-coded triangle into iced's own wgpu frame, proving the
-//! iced-0.13 custom-wgpu integration end-to-end before any real geometry lands.
+//! `Scene` is the `shader::Program`: it holds the camera and an `Arc` to the
+//! built line mesh (from the headless `nec_gui::mesh`), and on each `draw()`
+//! bakes the view-projection matrix (using the widget's aspect ratio) into a
+//! cheap [`primitive::ScenePrimitive`]. GUI-CHK-002 renders wires + axes + grid
+//! with a fixed camera; interaction lands in GUI-CHK-003.
 
 mod primitive;
+
+use std::sync::Arc;
 
 use iced::mouse;
 use iced::widget::shader;
 use iced::Rectangle;
-
 use nec_gui::app_state::Message;
+use nec_gui::camera::Camera;
+use nec_gui::mesh::MeshData;
 
-/// The 3-D scene. For the Phase-0 spike it is stateless and draws a triangle;
-/// later phases carry the camera + mesh handles here.
-#[derive(Debug, Default)]
-pub struct Scene;
+/// The 3-D scene bound to the current viewport state.
+#[derive(Debug)]
+pub struct Scene {
+    camera: Camera,
+    mesh: Option<Arc<MeshData>>,
+    rev: u64,
+}
+
+impl Scene {
+    /// Build from the headless viewport state (called each `view()`).
+    pub fn new(state: &nec_gui::app_state::ViewportState) -> Self {
+        Self {
+            camera: state.camera,
+            mesh: state.scene.clone(),
+            rev: state.scene_rev,
+        }
+    }
+}
 
 impl shader::Program<Message> for Scene {
     type State = ();
-    type Primitive = primitive::TrianglePrimitive;
+    type Primitive = primitive::ScenePrimitive;
 
     fn draw(
         &self,
         _state: &Self::State,
         _cursor: mouse::Cursor,
-        _bounds: Rectangle,
+        bounds: Rectangle,
     ) -> Self::Primitive {
-        primitive::TrianglePrimitive
+        let aspect = if bounds.height > 0.0 {
+            bounds.width / bounds.height
+        } else {
+            1.0
+        };
+        primitive::ScenePrimitive {
+            view_proj: self.camera.view_proj(aspect).to_cols_array_2d(),
+            mesh: self.mesh.clone(),
+            rev: self.rev,
+        }
     }
 }

--- a/apps/nec-gui/src/viewport/primitive.rs
+++ b/apps/nec-gui/src/viewport/primitive.rs
@@ -1,45 +1,104 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
-//! GUI-CHK-001 shader spike — the `shader::Primitive` that renders a triangle
-//! into iced's own wgpu frame. It shares iced's `Device`/`Queue`/`target` (no
-//! swapchain of its own), draws with `LoadOp::Load` so iced's UI underneath is
-//! preserved, and owns a private depth texture (iced provides none) recreated on
-//! resize.
+//! GUI-CHK-002 — the `shader::Primitive` that renders the wire scene (wires +
+//! axes + ground grid) as a colored line-list into iced's own wgpu frame.
+//!
+//! It shares iced's `Device`/`Queue`/`target` (no swapchain of its own), draws
+//! with `LoadOp::Load` so iced's UI beneath is preserved, and owns a private
+//! `Depth32Float` texture (iced provides none) recreated on resize. GPU
+//! resources persist in the shader `Storage`; the vertex buffer is re-uploaded
+//! only when the scene revision changes.
+
+use std::sync::Arc;
 
 use iced::widget::shader::{self, wgpu};
 use iced::Rectangle;
+use nec_gui::mesh::{LineVertex, MeshData};
 
-/// A trivial primitive: it carries no geometry (the triangle is baked into the
-/// vertex shader), so every `draw()` produces a cheap zero-size value.
+/// A cheap per-frame handle bundle: the camera matrix plus an `Arc` to the
+/// current mesh and its revision (buffers re-upload only when `rev` changes).
 #[derive(Debug)]
-pub struct TrianglePrimitive;
+pub struct ScenePrimitive {
+    pub view_proj: [[f32; 4]; 4],
+    pub mesh: Option<Arc<MeshData>>,
+    pub rev: u64,
+}
 
 /// GPU resources cached in the shader `Storage` (keyed by type) across frames.
 struct Pipeline {
     pipeline: wgpu::RenderPipeline,
+    uniform: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    vertices: Option<wgpu::Buffer>,
+    vertex_count: u32,
+    uploaded_rev: Option<u64>,
     depth: wgpu::TextureView,
     depth_size: (u32, u32),
 }
 
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
 impl Pipeline {
     fn new(device: &wgpu::Device, format: wgpu::TextureFormat, size: (u32, u32)) -> Self {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("gui.viewport.triangle"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/triangle.wgsl").into()),
+            label: Some("gui.viewport.lines"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/lines.wgsl").into()),
+        });
+        let uniform = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("gui.viewport.camera"),
+            size: 64, // one mat4x4<f32>
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("gui.viewport.bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gui.viewport.bg"),
+            layout: &bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform.as_entire_binding(),
+            }],
         });
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("gui.viewport.triangle.layout"),
-            bind_group_layouts: &[],
+            label: Some("gui.viewport.layout"),
+            bind_group_layouts: &[&bgl],
             push_constant_ranges: &[],
         });
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("gui.viewport.triangle.pipeline"),
+            label: Some("gui.viewport.lines.pipeline"),
             layout: Some(&layout),
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
-                buffers: &[],
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<LineVertex>() as u64,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x3,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x4,
+                            offset: 12,
+                            shader_location: 1,
+                        },
+                    ],
+                }],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
@@ -50,7 +109,10 @@ impl Pipeline {
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
             }),
-            primitive: wgpu::PrimitiveState::default(),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineList,
+                ..wgpu::PrimitiveState::default()
+            },
             depth_stencil: Some(wgpu::DepthStencilState {
                 format: DEPTH_FORMAT,
                 depth_write_enabled: true,
@@ -63,6 +125,11 @@ impl Pipeline {
         });
         Self {
             pipeline,
+            uniform,
+            bind_group,
+            vertices: None,
+            vertex_count: 0,
+            uploaded_rev: None,
             depth: create_depth(device, size),
             depth_size: size,
         }
@@ -74,9 +141,35 @@ impl Pipeline {
             self.depth_size = size;
         }
     }
-}
 
-const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+    fn upload_mesh(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        mesh: &MeshData,
+        rev: u64,
+    ) {
+        if self.uploaded_rev == Some(rev) {
+            return;
+        }
+        let bytes: &[u8] = bytemuck::cast_slice(&mesh.vertices);
+        let need = bytes.len() as u64;
+        let have = self.vertices.as_ref().map_or(0, wgpu::Buffer::size);
+        if have < need || self.vertices.is_none() {
+            self.vertices = Some(device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("gui.viewport.vertices"),
+                size: need.max(16),
+                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+        }
+        if let Some(buf) = &self.vertices {
+            queue.write_buffer(buf, 0, bytes);
+        }
+        self.vertex_count = mesh.vertices.len() as u32;
+        self.uploaded_rev = Some(rev);
+    }
+}
 
 fn create_depth(device: &wgpu::Device, (w, h): (u32, u32)) -> wgpu::TextureView {
     let tex = device.create_texture(&wgpu::TextureDescriptor {
@@ -96,11 +189,11 @@ fn create_depth(device: &wgpu::Device, (w, h): (u32, u32)) -> wgpu::TextureView 
     tex.create_view(&wgpu::TextureViewDescriptor::default())
 }
 
-impl shader::Primitive for TrianglePrimitive {
+impl shader::Primitive for ScenePrimitive {
     fn prepare(
         &self,
         device: &wgpu::Device,
-        _queue: &wgpu::Queue,
+        queue: &wgpu::Queue,
         format: wgpu::TextureFormat,
         storage: &mut shader::Storage,
         _bounds: &Rectangle,
@@ -111,8 +204,13 @@ impl shader::Primitive for TrianglePrimitive {
         if !storage.has::<Pipeline>() {
             storage.store(Pipeline::new(device, format, size));
         }
-        if let Some(p) = storage.get_mut::<Pipeline>() {
-            p.ensure_depth(device, size);
+        let Some(p) = storage.get_mut::<Pipeline>() else {
+            return;
+        };
+        p.ensure_depth(device, size);
+        queue.write_buffer(&p.uniform, 0, bytemuck::cast_slice(&[self.view_proj]));
+        if let Some(mesh) = &self.mesh {
+            p.upload_mesh(device, queue, mesh, self.rev);
         }
     }
 
@@ -127,12 +225,11 @@ impl shader::Primitive for TrianglePrimitive {
             return;
         };
         let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("gui.viewport.triangle.pass"),
+            label: Some("gui.viewport.pass"),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                 view: target,
                 resolve_target: None,
                 ops: wgpu::Operations {
-                    // Preserve iced's already-rendered UI underneath us.
                     load: wgpu::LoadOp::Load,
                     store: wgpu::StoreOp::Store,
                 },
@@ -148,7 +245,6 @@ impl shader::Primitive for TrianglePrimitive {
             timestamp_writes: None,
             occlusion_query_set: None,
         });
-        // Confine drawing to the widget's rectangle within iced's frame.
         pass.set_scissor_rect(
             clip_bounds.x,
             clip_bounds.y,
@@ -163,7 +259,12 @@ impl shader::Primitive for TrianglePrimitive {
             0.0,
             1.0,
         );
+        let (Some(vbuf), true) = (&p.vertices, p.vertex_count > 0) else {
+            return;
+        };
         pass.set_pipeline(&p.pipeline);
-        pass.draw(0..3, 0..1);
+        pass.set_bind_group(0, &p.bind_group, &[]);
+        pass.set_vertex_buffer(0, vbuf.slice(..));
+        pass.draw(0..p.vertex_count, 0..1);
     }
 }

--- a/apps/nec-gui/src/viewport/shaders/lines.wgsl
+++ b/apps/nec-gui/src/viewport/shaders/lines.wgsl
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+//
+// GUI-CHK-002: colored line-list rendering (wires + axes + ground grid) under a
+// view-projection camera uniform. wgpu 0.19 / naga 0.19 — keep it plain.
+
+struct Camera {
+    view_proj: mat4x4<f32>,
+};
+@group(0) @binding(0) var<uniform> camera: Camera;
+
+struct VertexOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) color: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@location(0) pos: vec3<f32>, @location(1) color: vec4<f32>) -> VertexOut {
+    var out: VertexOut;
+    out.clip_pos = camera.view_proj * vec4<f32>(pos, 1.0);
+    out.color = color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -331,6 +331,47 @@ fn viewport_tab_selectable() {
     assert_eq!(state.active_tab, ActiveTab::Solve);
 }
 
+/// GUI-CHK-002: loading a deck's geometry builds a scene mesh, bumps the scene
+/// revision, and frames the camera on the geometry — all headlessly.
+#[test]
+fn geometry_load_builds_scene_and_fits_camera() {
+    // A center-fed λ/2 dipole along z, 0.5λ ≈ 10 m at ~14 MHz.
+    let deck = "\
+CM dipole\nCE\nGW 1 11 0 0 -5 0 0 5 0.001\nGE 0\nEX 0 1 6 0 1 0\nFR 0 1 0 0 14.2 0\nEN\n";
+    let geo = nec_gui::solve::load_geometry_str(deck).expect("geometry builds");
+    assert_eq!(geo.wires.len(), 11, "11 segments → 11 wire lines");
+    assert!(!geo.has_ground, "free-space deck has no ground");
+    assert!((geo.bbox_min[2] + 5.0).abs() < 1e-3 && (geo.bbox_max[2] - 5.0).abs() < 1e-3);
+
+    let mut state = AppState::default();
+    assert!(state.viewport.scene.is_none());
+    let rev0 = state.viewport.scene_rev;
+    state.apply(&Message::GeometryLoaded(Ok(geo)));
+    let vp = &state.viewport;
+    assert!(vp.scene.is_some(), "scene mesh should be built");
+    assert!(vp.scene_rev > rev0, "scene revision must bump");
+    // Camera framed on the geometry: target at the dipole center, backed off.
+    assert!(
+        vp.camera.target.z.abs() < 1e-3,
+        "camera target centered on wire"
+    );
+    assert!(vp.camera.distance > 5.0, "camera outside the geometry");
+    assert!(
+        vp.status.contains("11"),
+        "status reports segment count: {}",
+        vp.status
+    );
+}
+
+/// GUI-CHK-002: a bad deck surfaces an error and leaves no scene.
+#[test]
+fn geometry_load_error_clears_scene() {
+    let mut state = AppState::default();
+    state.apply(&Message::GeometryLoaded(Err("no geometry".into())));
+    assert!(state.viewport.scene.is_none());
+    assert!(state.viewport.status.starts_with("Error:"));
+}
+
 /// sorted_sweep_rows returns rows sorted by |Z| descending when requested.
 #[test]
 fn sorted_sweep_rows_zmag_descending() {

--- a/docs/gui-redesign-plan.md
+++ b/docs/gui-redesign-plan.md
@@ -373,7 +373,7 @@ headless).
 | # | ID | Goal | Effort |
 |:--|:---|:-----|:-----|
 | 0 | GUI-CHK-001 | Shader-widget spike: hello-triangle in a Viewport tab — **✅ code + headless gates done (2026-07-10)**; visual gates pending a display | 1–2 d |
-| 1 | GUI-CHK-002 | Wire geometry rendered in 3-D (+ axes, ground grid) | 2–3 d |
+| 1 | GUI-CHK-002 | Wire geometry rendered in 3-D (+ axes, ground grid) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2–3 d |
 | 2 | GUI-CHK-003 | Orbit / zoom / pan camera | 2 d |
 | 3 | GUI-CHK-004 | Currents painted on wires + colormap legend | 1–2 d |
 | 4 | GUI-CHK-005 | 3-D pattern lobe overlay (full-sphere, rayon) | 3 d |


### PR DESCRIPTION
## Summary (GUI redesign Phase 1)

Replaces the Phase-0 triangle with the actual antenna: **wires + coordinate axes + an optional ground grid**, rendered as a colored wgpu line-list under a camera.

**Pure, headless-tested math (library crate → CI covers it):**
- `nec_gui::mesh` — `LineVertex` (Pod), `SceneGeometry` (segment endpoints + bbox + ground flag), `build_scene()` assembling grid → axes → wires as a `LineList` (wires appended **last** so their vertex indices stay stable for current-coloring in GUI-CHK-004).
- `nec_gui::camera` — z-up orbit `Camera` with `view_proj` (glam) + `fit()`; unit-tested framing, eye distance, target-projects-to-center, pitch clamp, zoom.

**Wiring:** `solve.rs::load_geometry_{path,str}` (parse + `build_geometry`, **no solve**); `ViewportState` + `Message::LoadGeometry`/`GeometryLoaded` (builds mesh, bumps `scene_rev`, fits camera); `viewport/{mod.rs,primitive.rs,shaders/lines.wgsl}` (bake `view_proj` from widget aspect each `draw()`, upload the camera uniform per frame + vertex buffer only on `scene_rev` change, LineList pipeline + depth); a "Load geometry" button + status in the 3-D View tab.

## Gates
- ✅ **Headless**: mesh/camera unit tests + a geometry-load integration test (11-seg dipole → 11 wire lines, camera framed on the wire, revision bumps; bad deck clears the scene). `cargo test -p nec-gui` green (59 tests), clippy `-D warnings` + fmt clean, zero workspace regression.
- ⏸️ **Visual** (dipole/yagi matches the deck coordinates on screen) needs a display — handed off: `cargo run -p nec-gui`, set a deck path, open **3D View**, **Load geometry**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)