### PR TITLE
feat(gui-chk-003): orbit / zoom / pan camera interaction

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -116,6 +116,22 @@ pub struct ViewportState {
     pub scene: Option<std::sync::Arc<crate::mesh::MeshData>>,
     pub scene_rev: u64,
     pub status: String,
+    /// Bounding sphere `(center, radius)` of the loaded geometry, for Reset View.
+    pub fit_bounds: Option<([f32; 3], f32)>,
+}
+
+/// A camera-interaction message for the 3-D viewport (GUI-CHK-003). Deltas are
+/// already in camera units — the widget's `Program::update` converts raw pixels.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ViewportMsg {
+    /// Orbit by yaw/pitch deltas in radians.
+    Orbit { d_yaw: f32, d_pitch: f32 },
+    /// Zoom by scroll steps (positive = closer).
+    Zoom(f32),
+    /// Pan the target by screen-fraction deltas (`dx` right, `dy` up).
+    Pan { dx: f32, dy: f32 },
+    /// Re-frame the camera on the loaded geometry.
+    ResetView,
 }
 
 impl Default for AppState {
@@ -194,6 +210,8 @@ pub enum Message {
     LoadGeometry,
     /// Background geometry build completed (parse + `build_geometry`, no solve).
     GeometryLoaded(Result<crate::mesh::SceneGeometry, String>),
+    /// Camera interaction from the 3-D viewport widget (GUI-CHK-003).
+    Viewport(ViewportMsg),
 }
 
 impl AppState {
@@ -268,6 +286,7 @@ impl AppState {
             Message::GeometryLoaded(Ok(geo)) => {
                 let (center, radius) = geo.bounds();
                 self.viewport.camera.fit(center, radius);
+                self.viewport.fit_bounds = Some((center, radius));
                 self.viewport.scene = Some(std::sync::Arc::new(crate::mesh::build_scene(geo)));
                 self.viewport.scene_rev = self.viewport.scene_rev.wrapping_add(1);
                 self.viewport.status = format!("{} wire segments", geo.wires.len());
@@ -275,6 +294,22 @@ impl AppState {
             Message::GeometryLoaded(Err(e)) => {
                 self.viewport.scene = None;
                 self.viewport.status = format!("Error: {e}");
+            }
+            Message::Viewport(vp) => {
+                let cam = &mut self.viewport.camera;
+                match vp {
+                    ViewportMsg::Orbit { d_yaw, d_pitch } => cam.orbit(*d_yaw, *d_pitch),
+                    ViewportMsg::Zoom(steps) => cam.zoom(*steps),
+                    ViewportMsg::Pan { dx, dy } => cam.pan(*dx, *dy),
+                    ViewportMsg::ResetView => {
+                        if let Some((c, r)) = self.viewport.fit_bounds {
+                            // Restore the default orientation *and* re-frame.
+                            let mut fresh = crate::camera::Camera::default();
+                            fresh.fit(c, r);
+                            *cam = fresh;
+                        }
+                    }
+                }
             }
         }
     }

--- a/apps/nec-gui/src/camera.rs
+++ b/apps/nec-gui/src/camera.rs
@@ -72,6 +72,28 @@ impl Camera {
     pub fn zoom(&mut self, steps: f32) {
         self.distance = (self.distance * 0.88f32.powf(steps)).clamp(0.05, 1.0e6);
     }
+
+    /// The camera's right and up axes in world space (z-up look-at basis).
+    fn screen_axes(&self) -> (Vec3, Vec3) {
+        let forward = (self.target - self.eye()).normalize_or_zero();
+        let mut right = forward.cross(Vec3::Z);
+        if right.length_squared() < 1e-8 {
+            // Looking straight down/up: fall back to world x.
+            right = Vec3::X;
+        }
+        let right = right.normalize();
+        let up = right.cross(forward).normalize();
+        (right, up)
+    }
+
+    /// Pan the target in the view plane by screen-space fractions of the viewport
+    /// (`dx` right, `dy` up). Scaled by distance so it feels consistent at any zoom.
+    pub fn pan(&mut self, dx: f32, dy: f32) {
+        let (right, up) = self.screen_axes();
+        // 2·distance·tan(fov/2) ≈ the visible world height at the target plane.
+        let world_per_frac = 2.0 * self.distance * (self.fov_y * 0.5).tan();
+        self.target += (right * (-dx) + up * dy) * world_per_frac;
+    }
 }
 
 #[cfg(test)]
@@ -123,6 +145,21 @@ mod tests {
         assert!(c.pitch <= PITCH_LIMIT + 1e-6);
         c.orbit(0.0, -100.0);
         assert!(c.pitch >= -PITCH_LIMIT - 1e-6);
+    }
+
+    #[test]
+    fn pan_moves_target_in_view_plane_not_toward_camera() {
+        let mut c = Camera::default();
+        c.fit([0.0; 3], 5.0);
+        let d0 = c.distance;
+        let fwd = (c.target - c.eye()).normalize();
+        c.pan(0.1, 0.0);
+        // Target moved, distance to the eye direction unchanged (in-plane move).
+        assert!(c.target.length() > 1e-4, "target should move");
+        assert!((c.distance - d0).abs() < 1e-4, "pan must not change zoom");
+        // The move is perpendicular to the view direction.
+        let moved = c.target; // was origin
+        assert!(moved.dot(fwd).abs() < 1e-3, "pan is in the view plane");
     }
 
     #[test]

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -13,7 +13,8 @@ mod viewport;
 use iced::widget::{button, column, container, row, scrollable, shader, text, text_input};
 use iced::{Element, Length, Task, Theme};
 use nec_gui::app_state::{
-    ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase, SweepSortCol,
+    ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase,
+    SweepSortCol, ViewportMsg,
 };
 use nec_gui::solve::{
     current_distribution_deck_path, load_geometry_path, pattern_slice_deck_path, solve_deck_path,
@@ -214,9 +215,19 @@ impl FnecGui {
         } else {
             self.state.viewport.status.clone()
         });
-        let controls = row![load_btn, status]
-            .spacing(12)
-            .align_y(iced::Alignment::Center);
+        let reset_btn = if self.state.viewport.fit_bounds.is_some() {
+            button("Reset view").on_press(Message::Viewport(ViewportMsg::ResetView))
+        } else {
+            button("Reset view")
+        };
+        let controls = row![
+            load_btn,
+            reset_btn,
+            text("· drag = orbit · wheel = zoom · middle/right-drag = pan"),
+            status,
+        ]
+        .spacing(12)
+        .align_y(iced::Alignment::Center);
         let scene = shader(viewport::Scene::new(&self.state.viewport))
             .width(Length::Fill)
             .height(Length::Fill);

--- a/apps/nec-gui/src/viewport/mod.rs
+++ b/apps/nec-gui/src/viewport/mod.rs
@@ -13,12 +13,31 @@ mod primitive;
 
 use std::sync::Arc;
 
-use iced::mouse;
+use iced::advanced::Shell;
+use iced::event::Status;
+use iced::mouse::{self, Button, ScrollDelta};
 use iced::widget::shader;
-use iced::Rectangle;
-use nec_gui::app_state::Message;
+use iced::{Point, Rectangle};
+use nec_gui::app_state::{Message, ViewportMsg};
 use nec_gui::camera::Camera;
 use nec_gui::mesh::MeshData;
+
+/// Radians of orbit per pixel dragged.
+const ORBIT_RAD_PER_PX: f32 = 0.008;
+
+/// Which drag gesture is in progress (widget-local; not in `AppState`).
+#[derive(Debug, Clone, Copy)]
+enum DragMode {
+    Orbit,
+    Pan,
+}
+
+/// Transient drag bookkeeping held in the shader widget's `Program::State`.
+#[derive(Debug, Default)]
+pub struct DragState {
+    mode: Option<DragMode>,
+    last: Option<Point>,
+}
 
 /// The 3-D scene bound to the current viewport state.
 #[derive(Debug)]
@@ -40,8 +59,70 @@ impl Scene {
 }
 
 impl shader::Program<Message> for Scene {
-    type State = ();
+    type State = DragState;
     type Primitive = primitive::ScenePrimitive;
+
+    fn update(
+        &self,
+        state: &mut DragState,
+        event: shader::Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+        _shell: &mut Shell<'_, Message>,
+    ) -> (Status, Option<Message>) {
+        let shader::Event::Mouse(mouse_event) = event else {
+            return (Status::Ignored, None);
+        };
+        match mouse_event {
+            mouse::Event::ButtonPressed(button) if cursor.is_over(bounds) => {
+                let mode = match button {
+                    Button::Left => Some(DragMode::Orbit),
+                    Button::Middle | Button::Right => Some(DragMode::Pan),
+                    _ => None,
+                };
+                if let Some(mode) = mode {
+                    state.mode = Some(mode);
+                    state.last = cursor.position();
+                    return (Status::Captured, None);
+                }
+                (Status::Ignored, None)
+            }
+            mouse::Event::ButtonReleased(_) => {
+                state.mode = None;
+                state.last = None;
+                (Status::Ignored, None)
+            }
+            mouse::Event::CursorMoved { position } => {
+                if let (Some(mode), Some(last)) = (state.mode, state.last) {
+                    let (dx, dy) = (position.x - last.x, position.y - last.y);
+                    state.last = Some(position);
+                    let msg = match mode {
+                        DragMode::Orbit => ViewportMsg::Orbit {
+                            d_yaw: -dx * ORBIT_RAD_PER_PX,
+                            d_pitch: -dy * ORBIT_RAD_PER_PX,
+                        },
+                        DragMode::Pan => ViewportMsg::Pan {
+                            dx: dx / bounds.width.max(1.0),
+                            dy: dy / bounds.height.max(1.0),
+                        },
+                    };
+                    return (Status::Captured, Some(Message::Viewport(msg)));
+                }
+                (Status::Ignored, None)
+            }
+            mouse::Event::WheelScrolled { delta } if cursor.is_over(bounds) => {
+                let steps = match delta {
+                    ScrollDelta::Lines { y, .. } => y,
+                    ScrollDelta::Pixels { y, .. } => y / 40.0,
+                };
+                (
+                    Status::Captured,
+                    Some(Message::Viewport(ViewportMsg::Zoom(steps))),
+                )
+            }
+            _ => (Status::Ignored, None),
+        }
+    }
 
     fn draw(
         &self,

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -372,6 +372,35 @@ fn geometry_load_error_clears_scene() {
     assert!(state.viewport.status.starts_with("Error:"));
 }
 
+/// GUI-CHK-003: viewport camera messages mutate the camera through `apply`, and
+/// Reset View re-frames on the loaded geometry.
+#[test]
+fn viewport_camera_messages_move_and_reset() {
+    use nec_gui::app_state::ViewportMsg;
+    let deck = "CM\nCE\nGW 1 11 0 0 -5 0 0 5 0.001\nGE 0\nEX 0 1 6 0 1 0\nFR 0 1 0 0 14.2 0\nEN\n";
+    let geo = nec_gui::solve::load_geometry_str(deck).unwrap();
+    let mut state = AppState::default();
+    state.apply(&Message::GeometryLoaded(Ok(geo)));
+    let fit = state.viewport.camera;
+
+    // Orbit changes yaw/pitch.
+    state.apply(&Message::Viewport(ViewportMsg::Orbit {
+        d_yaw: 0.3,
+        d_pitch: 0.1,
+    }));
+    assert!((state.viewport.camera.yaw - fit.yaw).abs() > 1e-6);
+    // Zoom in shrinks distance.
+    state.apply(&Message::Viewport(ViewportMsg::Zoom(1.0)));
+    assert!(state.viewport.camera.distance < fit.distance);
+    // Pan moves the look-at target.
+    state.apply(&Message::Viewport(ViewportMsg::Pan { dx: 0.1, dy: 0.0 }));
+    assert!(state.viewport.camera.target != fit.target);
+
+    // Reset View restores the full loaded framing (orientation + fit).
+    state.apply(&Message::Viewport(ViewportMsg::ResetView));
+    assert_eq!(state.viewport.camera, fit);
+}
+
 /// sorted_sweep_rows returns rows sorted by |Z| descending when requested.
 #[test]
 fn sorted_sweep_rows_zmag_descending() {

--- a/docs/gui-redesign-plan.md
+++ b/docs/gui-redesign-plan.md
@@ -374,7 +374,7 @@ headless).
 |:--|:---|:-----|:-----|
 | 0 | GUI-CHK-001 | Shader-widget spike: hello-triangle in a Viewport tab — **✅ code + headless gates done (2026-07-10)**; visual gates pending a display | 1–2 d |
 | 1 | GUI-CHK-002 | Wire geometry rendered in 3-D (+ axes, ground grid) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2–3 d |
-| 2 | GUI-CHK-003 | Orbit / zoom / pan camera | 2 d |
+| 2 | GUI-CHK-003 | Orbit / zoom / pan camera — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2 d |
 | 3 | GUI-CHK-004 | Currents painted on wires + colormap legend | 1–2 d |
 | 4 | GUI-CHK-005 | 3-D pattern lobe overlay (full-sphere, rayon) | 3 d |
 | 5 | GUI-CHK-006 | pane_grid layout shell; tabs dissolve into panes | 2–3 d |


### PR DESCRIPTION
## Summary (GUI redesign Phase 2)

Makes the 3-D viewport interactive: **left-drag orbits, wheel zooms about the target, middle/right-drag pans**, and a **Reset view** button re-frames.

- **`camera.rs`**: add `pan()` (moves the look-at target in the view plane via the z-up right/up basis, scaled by distance). Unit-tested that pan stays in the view plane and doesn't change zoom (plus existing pitch-clamp / zoom / fit / view-proj tests).
- **`app_state.rs`**: `ViewportMsg { Orbit, Zoom, Pan, ResetView }` + `Message::Viewport`; `apply()` mutates the camera. `GeometryLoaded` stores fit bounds so **Reset View restores the default orientation *and* re-frames**.
- **`viewport/mod.rs`**: `impl shader::Program::update` — a `DragState` translates `shader::Event::Mouse` (button press/release, cursor moved, wheel) into `ViewportMsg`, captured only while the cursor is over the widget. Verified against the real iced 0.13 signature `(&mut State, Event, Rectangle, Cursor, &mut Shell) -> (event::Status, Option<Message>)`.
- **`main.rs`**: Reset-view button + a drag/zoom/pan hint.

## Gates
- ✅ **Headless**: camera math tests + a `gui_smoke` test driving `apply(Viewport(Orbit/Zoom/Pan/ResetView))` — orbit changes yaw, zoom shrinks distance, pan moves the target, Reset restores framing. `cargo test -p nec-gui` green (61 tests), clippy `-D warnings` + fmt clean, zero regression.
- ⏸️ **Visual** (drag orbits on screen) needs a display — handed off: `cargo run -p nec-gui`, Load geometry, then drag/scroll in the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)