### PR TITLE
feat(gui-chk-004): paint current magnitude on the 3-D wires

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -118,6 +118,42 @@ pub struct ViewportState {
     pub status: String,
     /// Bounding sphere `(center, radius)` of the loaded geometry, for Reset View.
     pub fit_bounds: Option<([f32; 3], f32)>,
+    /// Raw geometry, retained so the mesh can be rebuilt on a currents toggle.
+    pub geometry: Option<crate::mesh::SceneGeometry>,
+    /// Per-segment current magnitudes (mA), aligned to `geometry.wires`.
+    pub currents_ma: Option<Vec<f32>>,
+    /// Whether to paint the wires by current magnitude (GUI-CHK-004).
+    pub show_currents: bool,
+}
+
+impl ViewportState {
+    /// Rebuild the wire mesh from `geometry`, coloring by current magnitude when
+    /// `show_currents` is on and currents are available; bumps the scene revision.
+    fn rebuild_scene(&mut self) {
+        let Some(geo) = &self.geometry else {
+            return;
+        };
+        let mags = if self.show_currents {
+            self.currents_ma.as_deref()
+        } else {
+            None
+        };
+        self.scene = Some(std::sync::Arc::new(crate::mesh::build_scene_colored(
+            geo, mags,
+        )));
+        self.scene_rev = self.scene_rev.wrapping_add(1);
+    }
+
+    /// Min/max current magnitude (mA) for the legend, when currents are loaded.
+    pub fn current_range_ma(&self) -> Option<(f32, f32)> {
+        let m = self.currents_ma.as_ref()?;
+        if m.is_empty() {
+            return None;
+        }
+        let lo = m.iter().copied().fold(f32::INFINITY, f32::min);
+        let hi = m.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        Some((lo, hi))
+    }
 }
 
 /// A camera-interaction message for the 3-D viewport (GUI-CHK-003). Deltas are
@@ -212,6 +248,12 @@ pub enum Message {
     GeometryLoaded(Result<crate::mesh::SceneGeometry, String>),
     /// Camera interaction from the 3-D viewport widget (GUI-CHK-003).
     Viewport(ViewportMsg),
+    /// User clicked "Solve currents" in the 3-D view.
+    LoadCurrents,
+    /// Background geometry+currents solve completed (GUI-CHK-004).
+    CurrentsSolved(Result<crate::mesh::GeometryCurrents, String>),
+    /// User toggled current-magnitude coloring.
+    ToggleCurrents(bool),
 }
 
 impl AppState {
@@ -287,13 +329,40 @@ impl AppState {
                 let (center, radius) = geo.bounds();
                 self.viewport.camera.fit(center, radius);
                 self.viewport.fit_bounds = Some((center, radius));
-                self.viewport.scene = Some(std::sync::Arc::new(crate::mesh::build_scene(geo)));
-                self.viewport.scene_rev = self.viewport.scene_rev.wrapping_add(1);
                 self.viewport.status = format!("{} wire segments", geo.wires.len());
+                self.viewport.geometry = Some(geo.clone());
+                self.viewport.currents_ma = None;
+                self.viewport.rebuild_scene();
             }
             Message::GeometryLoaded(Err(e)) => {
                 self.viewport.scene = None;
                 self.viewport.status = format!("Error: {e}");
+            }
+            Message::LoadCurrents => {
+                self.viewport.status = "Solving currents…".into();
+            }
+            Message::CurrentsSolved(Ok(gc)) => {
+                let (center, radius) = gc.geometry.bounds();
+                self.viewport.camera.fit(center, radius);
+                self.viewport.fit_bounds = Some((center, radius));
+                self.viewport.geometry = Some(gc.geometry.clone());
+                self.viewport.currents_ma = Some(gc.currents_ma.clone());
+                self.viewport.show_currents = true;
+                self.viewport.status = match self.viewport.current_range_ma() {
+                    Some((lo, hi)) => format!(
+                        "|I| {lo:.2}–{hi:.2} mA over {} segments",
+                        gc.currents_ma.len()
+                    ),
+                    None => format!("{} segments", gc.currents_ma.len()),
+                };
+                self.viewport.rebuild_scene();
+            }
+            Message::CurrentsSolved(Err(e)) => {
+                self.viewport.status = format!("Error: {e}");
+            }
+            Message::ToggleCurrents(on) => {
+                self.viewport.show_currents = *on;
+                self.viewport.rebuild_scene();
             }
             Message::Viewport(vp) => {
                 let cam = &mut self.viewport.camera;

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -10,15 +10,17 @@
 
 mod viewport;
 
-use iced::widget::{button, column, container, row, scrollable, shader, text, text_input};
+use iced::widget::{
+    button, checkbox, column, container, row, scrollable, shader, text, text_input,
+};
 use iced::{Element, Length, Task, Theme};
 use nec_gui::app_state::{
     ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase,
     SweepSortCol, ViewportMsg,
 };
 use nec_gui::solve::{
-    current_distribution_deck_path, load_geometry_path, pattern_slice_deck_path, solve_deck_path,
-    sweep_deck_path, SolveResult, SweepPoint,
+    current_distribution_deck_path, load_currents_path, load_geometry_path,
+    pattern_slice_deck_path, solve_deck_path, sweep_deck_path, SolveResult, SweepPoint,
 };
 use std::path::PathBuf;
 
@@ -41,6 +43,7 @@ impl FnecGui {
         let spawn_pattern = matches!(message, Message::RunPattern);
         let spawn_currents = matches!(message, Message::RunCurrents);
         let spawn_geometry = matches!(message, Message::LoadGeometry);
+        let spawn_currents_3d = matches!(message, Message::LoadCurrents);
         self.state.apply(&message);
 
         if spawn_solve {
@@ -116,6 +119,17 @@ impl FnecGui {
             Task::perform(
                 async move { load_geometry_path(&path, vars.as_deref()) },
                 Message::GeometryLoaded,
+            )
+        } else if spawn_currents_3d {
+            let path = PathBuf::from(self.state.deck_path.clone());
+            let vars: Option<String> = if self.state.vars_path.is_empty() {
+                None
+            } else {
+                Some(self.state.vars_path.clone())
+            };
+            Task::perform(
+                async move { load_currents_path(&path, vars.as_deref()) },
+                Message::CurrentsSolved,
             )
         } else {
             Task::none()
@@ -220,19 +234,29 @@ impl FnecGui {
         } else {
             button("Reset view")
         };
-        let controls = row![
-            load_btn,
-            reset_btn,
-            text("· drag = orbit · wheel = zoom · middle/right-drag = pan"),
-            status,
-        ]
-        .spacing(12)
-        .align_y(iced::Alignment::Center);
+        let currents_btn = if self.state.deck_path.is_empty() {
+            button("Solve currents")
+        } else {
+            button("Solve currents").on_press(Message::LoadCurrents)
+        };
+        let currents_toggle = checkbox("Color by |I|", self.state.viewport.show_currents)
+            .on_toggle(Message::ToggleCurrents);
+        let controls = row![load_btn, currents_btn, currents_toggle, reset_btn, status]
+            .spacing(12)
+            .align_y(iced::Alignment::Center);
+        let hint: Element<Message> = match self.state.viewport.current_range_ma() {
+            Some((lo, hi)) if self.state.viewport.show_currents => text(format!(
+                "|I| legend: cold {lo:.2} mA  →  hot {hi:.2} mA   · drag orbit · wheel zoom · middle-drag pan"
+            ))
+            .into(),
+            _ => text("· drag = orbit · wheel = zoom · middle/right-drag = pan").into(),
+        };
         let scene = shader(viewport::Scene::new(&self.state.viewport))
             .width(Length::Fill)
             .height(Length::Fill);
         column![
             controls,
+            hint,
             container(scene).width(Length::Fill).height(Length::Fill)
         ]
         .spacing(8)

--- a/apps/nec-gui/src/mesh.rs
+++ b/apps/nec-gui/src/mesh.rs
@@ -97,11 +97,25 @@ const AXIS_X: [f32; 4] = [0.85, 0.25, 0.25, 1.0];
 const AXIS_Y: [f32; 4] = [0.30, 0.75, 0.35, 1.0];
 const AXIS_Z: [f32; 4] = [0.35, 0.55, 0.95, 1.0];
 
-/// Assemble the full scene mesh: ground grid (if any) → axes → wires. Wires are
-/// appended **last** so their indices are stable for per-segment recoloring
-/// (currents, GUI-CHK-004): wire segment `i` occupies vertices
-/// `[wire_base + 2i, wire_base + 2i + 1]`.
+/// Solved geometry plus per-segment current magnitudes (mA), aligned to
+/// `geometry.wires` — the payload for the current-coloring path (GUI-CHK-004).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometryCurrents {
+    pub geometry: SceneGeometry,
+    pub currents_ma: Vec<f32>,
+}
+
+/// Assemble the full scene mesh with uniform wire color.
 pub fn build_scene(geo: &SceneGeometry) -> MeshData {
+    build_scene_colored(geo, None)
+}
+
+/// Assemble the scene mesh, optionally coloring each wire segment by its current
+/// magnitude (per-segment `currents_ma`, aligned to `geo.wires`). Magnitudes are
+/// normalized by the maximum, so the feedpoint (peak `|I|`) is hot and the tips
+/// (near-zero) are cold. Grid/axes precede the wires, whose vertices stay at the
+/// stable base (see [`wire_vertex_base`]).
+pub fn build_scene_colored(geo: &SceneGeometry, currents_ma: Option<&[f32]>) -> MeshData {
     let (center, radius) = geo.bounds();
     let mut v = Vec::new();
 
@@ -109,11 +123,41 @@ pub fn build_scene(geo: &SceneGeometry) -> MeshData {
         push_ground_grid(&mut v, center, radius);
     }
     push_axes(&mut v, radius);
-    for (a, b) in &geo.wires {
-        v.push(LineVertex::new(*a, WIRE_COLOR));
-        v.push(LineVertex::new(*b, WIRE_COLOR));
+
+    let peak = currents_ma
+        .map(|m| m.iter().copied().fold(0.0_f32, f32::max))
+        .filter(|&p| p > 0.0);
+    for (i, (a, b)) in geo.wires.iter().enumerate() {
+        let color = match (currents_ma, peak) {
+            (Some(mags), Some(pk)) => colormap(mags.get(i).copied().unwrap_or(0.0) / pk),
+            _ => WIRE_COLOR,
+        };
+        v.push(LineVertex::new(*a, color));
+        v.push(LineVertex::new(*b, color));
     }
     MeshData { vertices: v }
+}
+
+/// A perceptual-ish "cool → hot" colormap for a normalized value `t ∈ [0,1]`
+/// (dark blue → cyan → green → yellow → red). Pure and unit-tested.
+pub fn colormap(t: f32) -> [f32; 4] {
+    const STOPS: [[f32; 3]; 5] = [
+        [0.10, 0.15, 0.45], // 0.00  dark blue
+        [0.10, 0.55, 0.75], // 0.25  cyan
+        [0.20, 0.70, 0.30], // 0.50  green
+        [0.90, 0.75, 0.15], // 0.75  yellow
+        [0.85, 0.20, 0.15], // 1.00  red
+    ];
+    let t = t.clamp(0.0, 1.0) * 4.0;
+    let i = (t.floor() as usize).min(3);
+    let f = t - i as f32;
+    let (lo, hi) = (STOPS[i], STOPS[i + 1]);
+    [
+        lo[0] + (hi[0] - lo[0]) * f,
+        lo[1] + (hi[1] - lo[1]) * f,
+        lo[2] + (hi[2] - lo[2]) * f,
+        1.0,
+    ]
 }
 
 /// Index of the first wire vertex in a mesh built by [`build_scene`], so callers
@@ -229,5 +273,49 @@ mod tests {
         let g = SceneGeometry::from_segments(vec![], false);
         assert_eq!(g.bbox_min, [-1.0, -1.0, -1.0]);
         assert_eq!(g.bbox_max, [1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn colormap_hits_its_stops_and_clamps() {
+        let close = |a: [f32; 4], b: [f32; 4]| a.iter().zip(&b).all(|(x, y)| (x - y).abs() < 1e-5);
+        assert!(close(colormap(0.0), [0.10, 0.15, 0.45, 1.0]));
+        assert!(close(colormap(0.5), [0.20, 0.70, 0.30, 1.0]));
+        assert!(close(colormap(1.0), [0.85, 0.20, 0.15, 1.0]));
+        // Out-of-range clamps to the endpoints.
+        assert_eq!(colormap(-1.0), colormap(0.0));
+        assert_eq!(colormap(2.0), colormap(1.0));
+        // Midpoint of the first segment interpolates.
+        let q = colormap(0.125);
+        assert!((q[1] - 0.35).abs() < 1e-5, "cyan channel lerps");
+    }
+
+    #[test]
+    fn current_coloring_paints_peak_hot_and_zero_cold() {
+        // Two collinear segments, currents 0 and 10 mA → tip cold, peak hot.
+        let g = SceneGeometry::from_segments(
+            vec![
+                ([0.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
+                ([0.0, 0.0, 1.0], [0.0, 0.0, 2.0]),
+            ],
+            false,
+        );
+        let m = build_scene_colored(&g, Some(&[0.0, 10.0]));
+        let base = wire_vertex_base(&g);
+        // First segment (mag 0) → colormap(0); second (mag 10 = peak) → colormap(1).
+        assert_eq!(m.vertices[base].color, colormap(0.0));
+        assert_eq!(m.vertices[base + 1].color, colormap(0.0));
+        assert_eq!(m.vertices[base + 2].color, colormap(1.0));
+        assert_eq!(m.vertices[base + 3].color, colormap(1.0));
+    }
+
+    #[test]
+    fn no_currents_uses_uniform_wire_color() {
+        let g = SceneGeometry::from_segments(vec![([0.0; 3], [1.0, 0.0, 0.0])], false);
+        let m = build_scene_colored(&g, None);
+        let base = wire_vertex_base(&g);
+        assert_eq!(m.vertices[base].color, WIRE_COLOR);
+        // All-zero currents also fall back to uniform (no valid peak).
+        let m0 = build_scene_colored(&g, Some(&[0.0]));
+        assert_eq!(m0.vertices[base].color, WIRE_COLOR);
     }
 }

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -166,6 +166,37 @@ pub fn load_geometry_str(deck_text: &str) -> Result<crate::mesh::SceneGeometry, 
     Ok(crate::mesh::SceneGeometry::from_segments(wires, has_ground))
 }
 
+/// Solve a deck and return its geometry **with** per-segment current magnitudes
+/// (mA), aligned to the wire order, for current-colored 3-D display (GUI-CHK-004).
+pub fn load_currents_path(
+    path: &Path,
+    vars_path: Option<&str>,
+) -> Result<crate::mesh::GeometryCurrents, String> {
+    let input = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
+    load_currents_str(&input)
+}
+
+/// Build geometry + current magnitudes from a raw NEC deck string.
+pub fn load_currents_str(deck_text: &str) -> Result<crate::mesh::GeometryCurrents, String> {
+    let (segs, currents, _freq_hz, ground) = solve_for_currents(deck_text)?;
+    let has_ground = !matches!(
+        ground,
+        GroundModel::FreeSpace | GroundModel::Deferred { .. }
+    );
+    let f3 = |p: [f64; 3]| [p[0] as f32, p[1] as f32, p[2] as f32];
+    let wires = segs.iter().map(|s| (f3(s.start), f3(s.end))).collect();
+    let currents_ma = currents
+        .iter()
+        .map(|i| (i.norm() * 1000.0) as f32)
+        .collect();
+    Ok(crate::mesh::GeometryCurrents {
+        geometry: crate::mesh::SceneGeometry::from_segments(wires, has_ground),
+        currents_ma,
+    })
+}
+
 /// Run a Hallen solve on `deck_text` (a raw NEC deck string).
 pub fn solve_deck_str(deck_text: &str) -> Result<SolveResult, String> {
     let parsed = parse(deck_text).map_err(|e| e.to_string())?;

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -401,6 +401,44 @@ fn viewport_camera_messages_move_and_reset() {
     assert_eq!(state.viewport.camera, fit);
 }
 
+/// GUI-CHK-004: solving currents attaches per-segment magnitudes, enables
+/// coloring, exposes a legend range, and the toggle rebuilds the scene.
+#[test]
+fn currents_solve_colors_wires_and_toggles() {
+    // Center-fed λ/2 dipole → current peaks at the feed (middle segment).
+    let deck = "CM\nCE\nGW 1 11 0 0 -5 0 0 5 0.001\nGE 0\nEX 0 1 6 0 1 0\nFR 0 1 0 0 14.2 0\nEN\n";
+    let gc = nec_gui::solve::load_currents_str(deck).expect("currents solve");
+    assert_eq!(gc.currents_ma.len(), 11);
+    // The peak |I| is at (or adjacent to) the center-fed segment, not a tip.
+    let peak_i = gc
+        .currents_ma
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .unwrap()
+        .0;
+    assert!(
+        (4..=6).contains(&peak_i),
+        "current should peak near center, got seg {peak_i}"
+    );
+
+    let mut state = AppState::default();
+    let rev0 = state.viewport.scene_rev;
+    state.apply(&Message::CurrentsSolved(Ok(gc)));
+    assert!(state.viewport.show_currents, "currents coloring turns on");
+    assert!(state.viewport.currents_ma.is_some());
+    assert!(state.viewport.scene.is_some());
+    assert!(state.viewport.scene_rev > rev0);
+    let (lo, hi) = state.viewport.current_range_ma().expect("legend range");
+    assert!(hi > lo && lo >= 0.0, "legend range {lo}–{hi}");
+
+    // Toggling off rebuilds the scene (uniform color) and bumps the revision.
+    let rev1 = state.viewport.scene_rev;
+    state.apply(&Message::ToggleCurrents(false));
+    assert!(!state.viewport.show_currents);
+    assert!(state.viewport.scene_rev > rev1);
+}
+
 /// sorted_sweep_rows returns rows sorted by |Z| descending when requested.
 #[test]
 fn sorted_sweep_rows_zmag_descending() {

--- a/docs/gui-redesign-plan.md
+++ b/docs/gui-redesign-plan.md
@@ -375,7 +375,7 @@ headless).
 | 0 | GUI-CHK-001 | Shader-widget spike: hello-triangle in a Viewport tab — **✅ code + headless gates done (2026-07-10)**; visual gates pending a display | 1–2 d |
 | 1 | GUI-CHK-002 | Wire geometry rendered in 3-D (+ axes, ground grid) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2–3 d |
 | 2 | GUI-CHK-003 | Orbit / zoom / pan camera — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2 d |
-| 3 | GUI-CHK-004 | Currents painted on wires + colormap legend | 1–2 d |
+| 3 | GUI-CHK-004 | Currents painted on wires + colormap legend — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 1–2 d |
 | 4 | GUI-CHK-005 | 3-D pattern lobe overlay (full-sphere, rayon) | 3 d |
 | 5 | GUI-CHK-006 | pane_grid layout shell; tabs dissolve into panes | 2–3 d |
 | 6 | GUI-CHK-007 | Deck writer + GW wire table editor (live preview) | 3–4 d |


### PR DESCRIPTION
## Summary (GUI redesign Phase 3)

Colors the wire segments by **|I|** in the 3-D viewport: solve currents, map each segment's magnitude through a cool→hot colormap, and toggle the coloring on/off.

- **`mesh.rs`** (pure, headless-tested): `colormap(t)` — a 5-stop dark-blue→cyan→green→yellow→red LUT (exact-value tests + clamp); `build_scene_colored(geo, Option<&[f32]>)` colors each wire by `mag/peak` (peak = feed → hot; tips → cold), falling back to the uniform color when currents are absent/all-zero; a `GeometryCurrents` payload.
- **`solve.rs`**: `load_currents_{path,str}` — reuse `solve_for_currents`, return geometry + per-segment |I| (mA) aligned to the wire order.
- **`app_state.rs`**: `ViewportState` gains `geometry`/`currents_ma`/`show_currents` + `rebuild_scene()` + `current_range_ma()`; messages `LoadCurrents`/`CurrentsSolved`/`ToggleCurrents` (a toggle recolors without re-solving).
- **`main.rs`**: "Solve currents" button, a "Color by |I|" checkbox, a legend line (cold min mA → hot max mA).

## Gates
- ✅ **Headless**: colormap LUT + recolor unit tests (peak hot / zero cold / uniform fallback) + a `gui_smoke` integration test (dipole current peaks near the center-fed segment; `CurrentsSolved` enables coloring + legend range + revision bump; toggle rebuilds). `cargo test -p nec-gui` green (65 tests), clippy `-D warnings` + fmt clean, zero regression.
- ⏸️ **Visual** (λ/2 dipole → bright feedpoint, dark tips) needs a display — handed off: `cargo run -p nec-gui`, 3-D View → **Solve currents**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)