### PR TITLE
feat(gui-chk-006): pane_grid workbench layout (controls | 3-D viewport)

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -280,6 +280,9 @@ pub enum Message {
     Pattern3dComplete(Result<crate::mesh::PatternSolve, String>),
     /// User toggled the 3-D radiation-pattern lobe overlay.
     TogglePattern(bool),
+    /// User dragged the workbench pane divider (new split ratio in [0,1]). The
+    /// `pane_grid::State` itself lives in the binary; this carries only the ratio.
+    PaneResized(f32),
 }
 
 impl AppState {
@@ -411,6 +414,8 @@ impl AppState {
                 self.viewport.show_pattern = *on;
                 self.viewport.rebuild_lobe();
             }
+            // Pane layout lives in the iced binary (see main.rs); no core state.
+            Message::PaneResized(_) => {}
             Message::Viewport(vp) => {
                 let cam = &mut self.viewport.camera;
                 match vp {

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -10,8 +10,10 @@
 
 mod viewport;
 
+use iced::widget::pane_grid::{Axis, Split};
 use iced::widget::{
-    button, checkbox, column, container, progress_bar, row, scrollable, shader, text, text_input,
+    button, checkbox, column, container, pane_grid, progress_bar, row, scrollable, shader, text,
+    text_input,
 };
 use iced::{Element, Length, Task, Theme};
 use nec_gui::app_state::{
@@ -30,10 +32,39 @@ fn main() -> iced::Result {
         .run()
 }
 
-/// Root application struct wrapping the headless [`AppState`].
-#[derive(Debug, Default)]
+/// Which workbench pane a `pane_grid` cell holds.
+#[derive(Debug, Clone, Copy)]
+enum Pane {
+    /// Controls + result tables (deck path, tabs, feedpoint/sweep/pattern/currents).
+    Main,
+    /// The always-visible GPU 3-D viewport.
+    Viewport,
+}
+
+/// Root application struct wrapping the headless [`AppState`] plus the (iced-only)
+/// pane layout. The single divider's `Split` id is kept so a resize needs only
+/// the new ratio (which is all the core `Message::PaneResized` carries).
+#[derive(Debug)]
 struct FnecGui {
     state: AppState,
+    panes: pane_grid::State<Pane>,
+    main_split: Split,
+}
+
+impl Default for FnecGui {
+    fn default() -> Self {
+        let (mut panes, main) = pane_grid::State::new(Pane::Main);
+        let (_, split) = panes
+            .split(Axis::Vertical, main, Pane::Viewport)
+            .expect("initial pane split");
+        // Give the controls pane a bit less than half by default.
+        panes.resize(split, 0.42);
+        Self {
+            state: AppState::default(),
+            panes,
+            main_split: split,
+        }
+    }
 }
 
 impl FnecGui {
@@ -45,6 +76,10 @@ impl FnecGui {
         let spawn_geometry = matches!(message, Message::LoadGeometry);
         let spawn_currents_3d = matches!(message, Message::LoadCurrents);
         let spawn_pattern_3d = matches!(message, Message::LoadPattern3d);
+        // Pane resize is an iced-layout concern handled here (not in AppState).
+        if let Message::PaneResized(ratio) = message {
+            self.panes.resize(self.main_split, ratio);
+        }
         self.state.apply(&message);
 
         if spawn_solve {
@@ -149,42 +184,41 @@ impl FnecGui {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        // ── Tab bar ──────────────────────────────────────────────────────
-        let tab_solve = if self.state.active_tab == ActiveTab::Solve {
-            button("[ Solve ]").on_press(Message::TabSelected(ActiveTab::Solve))
-        } else {
-            button("  Solve  ").on_press(Message::TabSelected(ActiveTab::Solve))
-        };
-        let tab_sweep = if self.state.active_tab == ActiveTab::Sweep {
-            button("[ Sweep ]").on_press(Message::TabSelected(ActiveTab::Sweep))
-        } else {
-            button("  Sweep  ").on_press(Message::TabSelected(ActiveTab::Sweep))
-        };
-        let tab_pattern = if self.state.active_tab == ActiveTab::Pattern {
-            button("[ Pattern ]").on_press(Message::TabSelected(ActiveTab::Pattern))
-        } else {
-            button("  Pattern  ").on_press(Message::TabSelected(ActiveTab::Pattern))
-        };
-        let tab_currents = if self.state.active_tab == ActiveTab::Currents {
-            button("[ Currents ]").on_press(Message::TabSelected(ActiveTab::Currents))
-        } else {
-            button("  Currents  ").on_press(Message::TabSelected(ActiveTab::Currents))
-        };
-        let tab_viewport = if self.state.active_tab == ActiveTab::Viewport {
-            button("[ 3D View ]").on_press(Message::TabSelected(ActiveTab::Viewport))
-        } else {
-            button("  3D View  ").on_press(Message::TabSelected(ActiveTab::Viewport))
+        // GUI-CHK-006: xnec2c-style single window — a resizable split with the
+        // controls/results on the left and the always-visible 3-D viewport right.
+        let grid = pane_grid::PaneGrid::new(&self.panes, |_id, kind, _maximized| {
+            let body: Element<Message> = match kind {
+                Pane::Main => self.main_pane(),
+                Pane::Viewport => self.viewport_view(),
+            };
+            pane_grid::Content::new(container(body).padding(6))
+        })
+        .on_resize(8, |e| Message::PaneResized(e.ratio))
+        .spacing(6)
+        .width(Length::Fill)
+        .height(Length::Fill);
+
+        container(grid).padding(6).into()
+    }
+
+    /// The left workbench pane: deck inputs, tab bar, and the active result table.
+    fn main_pane(&self) -> Element<'_, Message> {
+        let tab = |label: &str, on: ActiveTab| {
+            let caption = if self.state.active_tab == on {
+                format!("[ {label} ]")
+            } else {
+                format!("  {label}  ")
+            };
+            button(text(caption)).on_press(Message::TabSelected(on))
         };
         let tab_bar = row![
-            tab_solve,
-            tab_sweep,
-            tab_pattern,
-            tab_currents,
-            tab_viewport
+            tab("Solve", ActiveTab::Solve),
+            tab("Sweep", ActiveTab::Sweep),
+            tab("Pattern", ActiveTab::Pattern),
+            tab("Currents", ActiveTab::Currents),
         ]
         .spacing(4);
 
-        // ── Shared deck-path row ─────────────────────────────────────────
         let path_row = row![
             text("Deck file:").width(Length::Fixed(80.0)),
             text_input("Path to .nec file…", &self.state.deck_path)
@@ -194,7 +228,6 @@ impl FnecGui {
         .spacing(8)
         .align_y(iced::Alignment::Center);
 
-        // ── Optional variable-substitution file row ──────────────────────
         let vars_row = row![
             text("Vars file:").width(Length::Fixed(80.0)),
             text_input(
@@ -207,23 +240,21 @@ impl FnecGui {
         .spacing(8)
         .align_y(iced::Alignment::Center);
 
-        // ── Active tab content ───────────────────────────────────────────
         let tab_content: Element<Message> = match self.state.active_tab {
             ActiveTab::Solve => self.solve_view(),
             ActiveTab::Sweep => self.sweep_view(),
             ActiveTab::Pattern => self.pattern_view(),
             ActiveTab::Currents => self.currents_view(),
-            ActiveTab::Viewport => self.viewport_view(),
+            // The viewport is its own pane now; this tab is unreachable via UI.
+            ActiveTab::Viewport => self.solve_view(),
         };
 
-        let content = column![tab_bar, path_row, vars_row, tab_content]
-            .spacing(12)
-            .padding(20);
-
-        container(content)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
+        scrollable(
+            column![tab_bar, path_row, vars_row, tab_content]
+                .spacing(12)
+                .padding(12),
+        )
+        .into()
     }
 
     // ── Single-frequency solve view ──────────────────────────────────────

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -439,6 +439,21 @@ fn currents_solve_colors_wires_and_toggles() {
     assert!(state.viewport.scene_rev > rev1);
 }
 
+/// GUI-CHK-006: the pane-resize message is a pure layout concern (handled in the
+/// iced binary), so `apply` leaves the core solver state untouched.
+#[test]
+fn pane_resize_is_a_layout_noop_on_core_state() {
+    let mut state = AppState::default();
+    state.apply(&Message::DeckPathChanged("deck.nec".into()));
+    let before = state.deck_path.clone();
+    state.apply(&Message::PaneResized(0.3));
+    assert_eq!(
+        state.deck_path, before,
+        "pane resize must not touch core state"
+    );
+    assert!(state.can_solve());
+}
+
 /// GUI-CHK-005: solving the pattern builds a lobe overlay that toggles on/off.
 #[test]
 fn pattern_solve_builds_lobe_and_toggles() {

--- a/docs/gui-redesign-plan.md
+++ b/docs/gui-redesign-plan.md
@@ -377,7 +377,7 @@ headless).
 | 2 | GUI-CHK-003 | Orbit / zoom / pan camera — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2 d |
 | 3 | GUI-CHK-004 | Currents painted on wires + colormap legend — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 1–2 d |
 | 4 | GUI-CHK-005 | 3-D pattern lobe overlay (full-sphere) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 3 d |
-| 5 | GUI-CHK-006 | pane_grid layout shell; tabs dissolve into panes | 2–3 d |
+| 5 | GUI-CHK-006 | pane_grid layout shell; tabs dissolve into panes — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2–3 d |
 | 6 | GUI-CHK-007 | Deck writer + GW wire table editor (live preview) | 3–4 d |
 | 7 | GUI-CHK-008 | EX / GN / LD / FR editors + Apply-and-Solve | 3 d |
 | 8 | GUI-CHK-009 | Streaming sweep, SWR/|Z| canvas plot, frequency slider | 3 d |


### PR DESCRIPTION
## Summary (GUI redesign Phase 5)

Moves from the tab-only window to an **xnec2c-style single window**: a resizable `iced::widget::pane_grid` split with controls/results on the left and the **always-visible 3-D viewport** on the right.

- **`main.rs`**: `Pane { Main, Viewport }`; `FnecGui` holds a `pane_grid::State<Pane>` + the single divider's `Split` (manual `Default` via `State::new` + `split` on `Axis::Vertical`, ratio 0.42). `view()` is a `PaneGrid` — the Main cell renders the extracted `main_pane()` (deck inputs + Solve/Sweep/Pattern/Currents tab bar + active result table, scrollable), the Viewport cell renders the viewport. The redundant "3D View" tab is dropped.
- **`app_state.rs`**: `Message::PaneResized(f32)` carries only the new ratio (the `pane_grid::State` lives in the binary, so `AppState` stays iced-free); `apply()` no-ops it; the resize is applied in `FnecGui::update`.

The tab helper builds its label with `text(String)` — no per-frame leak.

## Gates
- ✅ **Headless**: a `gui_smoke` test asserts `PaneResized` is a layout no-op on core state; all prior state/message tests unchanged. `cargo test -p nec-gui` green (71 tests), clippy `-D warnings` + fmt clean, zero regression.
- ⏸️ **Visual** (two resizable panes, drag the divider, 3-D view always shown beside the results) needs a display — handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)