### PR TITLE
feat(gui-chk-007): NEC deck writer + editable wire model (pure core)

### DIFF
--- a/apps/nec-gui/src/deck_write.rs
+++ b/apps/nec-gui/src/deck_write.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! NEC deck **writer** (GUI-CHK-007).
+//!
+//! The workspace has a parser (`nec_parser`) but no serializer — the visual
+//! editors need to turn an edited [`NecDeck`] back into deck text to preview and
+//! save it. This module is that missing half: [`write_deck`] renders a deck to a
+//! canonical NEC card stream.
+//!
+//! **Correctness oracle:** the writer is exact iff `parse(write_deck(&d)).deck`
+//! equals `d` for every deck the parser accepts. That round-trip is unit-tested
+//! here against the whole `corpus/` set, so any card whose written form the
+//! parser would read back differently is a test failure, not a silent drift.
+//!
+//! Float fields are emitted with Rust's default `f64` `Display`, which is the
+//! shortest decimal string that round-trips to the same bits — so coordinates
+//! and radii survive parse→write→parse unchanged.
+
+use nec_model::card::{Card, NeCard};
+use nec_model::deck::NecDeck;
+
+/// Serialize a whole deck to NEC card text (one card per line, `\n`-terminated).
+///
+/// The output re-parses (via `nec_parser::parse`) to a deck equal to the input
+/// for any parser-accepted deck; see the module-level round-trip tests.
+pub fn write_deck(deck: &NecDeck) -> String {
+    let mut out = String::new();
+    for card in &deck.cards {
+        out.push_str(&write_card(card));
+        out.push('\n');
+    }
+    out
+}
+
+/// Serialize a single card to its NEC line (no trailing newline).
+pub fn write_card(card: &Card) -> String {
+    match card {
+        // Comments: we cannot tell an original `CE` from a `CM` after parsing
+        // (both become `Card::Comment`), so every comment is written as `CM`.
+        // The parser reads it straight back, so the round-trip is exact.
+        Card::Comment(c) => join(&["CM".into(), c.text.clone()]),
+        Card::Gw(c) => join(&[
+            "GW".into(),
+            u(c.tag),
+            u(c.segments),
+            f(c.start[0]),
+            f(c.start[1]),
+            f(c.start[2]),
+            f(c.end[0]),
+            f(c.end[1]),
+            f(c.end[2]),
+            f(c.radius),
+        ]),
+        Card::Gm(c) => join(&[
+            "GM".into(),
+            u(c.tag_increment),
+            u(c.last_tag),
+            f(c.rot_x_deg),
+            f(c.rot_y_deg),
+            f(c.rot_z_deg),
+            f(c.translate_x),
+            f(c.translate_y),
+            f(c.translate_z),
+            u(c.first_tag),
+        ]),
+        Card::Gr(c) => join(&["GR".into(), u(c.tag_increment), u(c.count), f(c.angle_deg)]),
+        Card::Ge(c) => join(&["GE".into(), i(c.ground_reflection_flag)]),
+        Card::Gn(c) => {
+            // Bare form `GN <type>` when no medium is given; otherwise the full
+            // `GN <type> 0 0 0 <eps> <sig>` (the parser reads EPSE at field 5,
+            // SIG at field 6, so the three placeholder integers are required).
+            match (c.eps_r, c.sigma) {
+                (None, None) => join(&["GN".into(), i(c.ground_type)]),
+                (eps, sig) => join(&[
+                    "GN".into(),
+                    i(c.ground_type),
+                    "0".into(),
+                    "0".into(),
+                    "0".into(),
+                    f(eps.unwrap_or(0.0)),
+                    f(sig.unwrap_or(0.0)),
+                ]),
+            }
+        }
+        Card::Ld(c) => trim_floats(
+            vec![
+                "LD".into(),
+                i(c.load_type),
+                u(c.tag),
+                u(c.seg_first),
+                u(c.seg_last),
+                f(c.f1),
+                f(c.f2),
+                f(c.f3),
+            ],
+            5, // keep mnemonic + 4 required integer fields
+        ),
+        Card::Tl(c) => join(&[
+            "TL".into(),
+            u(c.tag1),
+            u(c.segment1),
+            u(c.tag2),
+            u(c.segment2),
+            u(c.num_segments),
+            u(c.tl_type),
+            f(c.z0),
+            f(c.length),
+            f(c.f3),
+        ]),
+        Card::Pt(c) => join_raw("PT", &c.raw_fields),
+        Card::Nt(c) => join_raw("NT", &c.raw_fields),
+        Card::Ex(c) => trim_floats(
+            vec![
+                "EX".into(),
+                u(c.excitation_type),
+                u(c.tag),
+                u(c.segment),
+                u(c.i4),
+                f(c.voltage_real),
+                f(c.voltage_imag),
+                f(c.polarization_deg),
+                f(c.theta_inc),
+                f(c.phi_inc),
+                f(c.polarization_ratio),
+            ],
+            5, // keep mnemonic + 4 required integer fields
+        ),
+        // Shorthand 4-field form `FR I1 I2 F1 F2`; the parser reads the frequency
+        // from field 3 when there are fewer than 6 fields, so this round-trips.
+        Card::Fr(c) => join(&[
+            "FR".into(),
+            u(c.step_type),
+            u(c.steps),
+            f(c.frequency_mhz),
+            f(c.step_mhz),
+        ]),
+        Card::Rp(c) => {
+            // Encode the normalize/avg-power flags back into the XNDA field the
+            // parser decodes: X (thousands) = normalize, A (units) = avg power.
+            let xnda = u32::from(c.normalize) * 1000 + u32::from(c.avg_power_gain);
+            join(&[
+                "RP".into(),
+                u(c.mode),
+                u(c.n_theta),
+                u(c.n_phi),
+                u(xnda),
+                f(c.theta0),
+                f(c.phi0),
+                f(c.d_theta),
+                f(c.d_phi),
+            ])
+        }
+        Card::Ne(c) => write_near("NE", c),
+        Card::Nh(c) => write_near("NH", c),
+        Card::En(_) => "EN".to_string(),
+    }
+}
+
+/// NE/NH share an identical 10-field layout.
+fn write_near(mnemonic: &str, c: &NeCard) -> String {
+    join(&[
+        mnemonic.to_string(),
+        u(c.coord_type),
+        u(c.nx),
+        u(c.ny),
+        u(c.nz),
+        f(c.x0),
+        f(c.y0),
+        f(c.z0),
+        f(c.dx),
+        f(c.dy),
+        f(c.dz),
+    ])
+}
+
+// ── field formatting ─────────────────────────────────────────────────────────
+
+fn u(v: u32) -> String {
+    v.to_string()
+}
+
+fn i(v: i32) -> String {
+    v.to_string()
+}
+
+/// Format a float with the shortest round-tripping decimal (Rust default), but
+/// render integral values without a trailing `.0` so `14` stays `14`, not `14`
+/// vs `14.0` churn (both parse identically, this is purely cosmetic).
+fn f(v: f64) -> String {
+    if v.fract() == 0.0 && v.abs() < 1e15 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+fn join(fields: &[String]) -> String {
+    fields
+        .iter()
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn join_raw(mnemonic: &str, raw_fields: &[String]) -> String {
+    let mut v = vec![mnemonic.to_string()];
+    v.extend(raw_fields.iter().cloned());
+    v.join(" ")
+}
+
+/// Join, then drop trailing fields that are the float literal `0` down to a
+/// minimum length. Used for EX/LD, whose trailing floats default to 0.0 in the
+/// parser, so omitting them round-trips while keeping the line uncluttered.
+fn trim_floats(mut fields: Vec<String>, min_len: usize) -> String {
+    while fields.len() > min_len && fields.last().map(String::as_str) == Some("0") {
+        fields.pop();
+    }
+    join(&fields)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nec_parser::parse;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn corpus_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../corpus")
+    }
+
+    /// The core oracle: for every corpus deck the parser accepts, parsing the
+    /// writer's output reproduces the original card list exactly.
+    #[test]
+    fn corpus_round_trips_parse_write_parse() {
+        let dir = corpus_dir();
+        let mut checked = 0usize;
+        for entry in fs::read_dir(&dir).expect("read corpus dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("nec") {
+                continue;
+            }
+            let text = fs::read_to_string(&path).expect("read deck");
+            // Only decks the parser fully accepts (no unknown cards) are a fair
+            // oracle — an unknown card is dropped on the way in and can't be
+            // reproduced. All current corpus decks parse cleanly.
+            let Ok(first) = parse(&text) else { continue };
+            if !first.warnings.is_empty() {
+                continue;
+            }
+            let written = write_deck(&first.deck);
+            let second = parse(&written)
+                .unwrap_or_else(|e| panic!("re-parse of written {} failed: {e}", path.display()));
+            assert_eq!(
+                first.deck.cards,
+                second.deck.cards,
+                "round-trip mismatch for {}\n--- written ---\n{written}",
+                path.display()
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 20,
+            "expected many corpus decks, checked {checked}"
+        );
+    }
+
+    #[test]
+    fn gw_line_is_canonical() {
+        let deck = parse("GW 1 51 0 0 -5.232 0 0 5.232 0.001\nGE 0\nEN\n")
+            .unwrap()
+            .deck;
+        let s = write_card(&deck.cards[0]);
+        assert_eq!(s, "GW 1 51 0 0 -5.232 0 0 5.232 0.001");
+    }
+
+    #[test]
+    fn gn_bare_vs_medium() {
+        let bare = parse("GN 1\nEN\n").unwrap().deck;
+        assert_eq!(write_card(&bare.cards[0]), "GN 1");
+        let med = parse("GN 2 0 0 0 13 0.005\nEN\n").unwrap().deck;
+        assert_eq!(write_card(&med.cards[0]), "GN 2 0 0 0 13 0.005");
+    }
+
+    #[test]
+    fn ex_trims_trailing_zero_floats() {
+        let deck = parse("EX 0 1 26 0 1.0 0.0\nEN\n").unwrap().deck;
+        // vr=1 kept, everything after is zero and dropped; the 4 integer fields stay.
+        assert_eq!(write_card(&deck.cards[0]), "EX 0 1 26 0 1");
+    }
+
+    #[test]
+    fn fr_shorthand_round_trips_frequency() {
+        let deck = parse("FR 0 1 0 0 14.2 0\nEN\n").unwrap().deck;
+        let s = write_card(&deck.cards[0]);
+        assert_eq!(s, "FR 0 1 14.2 0");
+        // and it reads back to the same frequency
+        let re = parse(&format!("{s}\nEN\n")).unwrap().deck;
+        assert_eq!(re.cards[0], deck.cards[0]);
+    }
+
+    #[test]
+    fn rp_encodes_normalize_and_avg_power() {
+        let deck = parse("RP 0 37 1 1001 0 0 5 0\nEN\n").unwrap().deck;
+        let s = write_card(&deck.cards[0]);
+        let re = parse(&format!("{s}\nEN\n")).unwrap().deck;
+        assert_eq!(re.cards[0], deck.cards[0]);
+    }
+}

--- a/apps/nec-gui/src/lib.rs
+++ b/apps/nec-gui/src/lib.rs
@@ -6,5 +6,7 @@
 
 pub mod app_state;
 pub mod camera;
+pub mod deck_write;
 pub mod mesh;
+pub mod model_doc;
 pub mod solve;

--- a/apps/nec-gui/src/model_doc.rs
+++ b/apps/nec-gui/src/model_doc.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Editable deck document (GUI-CHK-007).
+//!
+//! [`ModelDoc`] is the in-memory model behind the visual wire editor. It splits
+//! a parsed deck into an editable table of [`WireRow`]s (the `GW` cards) plus the
+//! surrounding cards, which are preserved verbatim. Each `WireRow` holds its
+//! fields as **strings** (what a text box edits) and validates them back to a
+//! [`GwCard`] on demand, so a half-typed `-` or empty box is an editing state,
+//! not a crash.
+//!
+//! The document tracks a `dirty` flag (set on any edit, cleared on save) and can
+//! render itself back to deck text via [`crate::deck_write::write_deck`] for the
+//! live 3-D preview and for saving.
+
+use nec_model::card::{Card, GwCard};
+use nec_model::deck::NecDeck;
+
+use crate::deck_write::write_deck;
+
+/// Which field of a [`WireRow`] an edit targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireField {
+    Tag,
+    Segments,
+    X1,
+    Y1,
+    Z1,
+    X2,
+    Y2,
+    Z2,
+    Radius,
+}
+
+/// One editable `GW` wire, fields as raw strings (text-box contents).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct WireRow {
+    pub tag: String,
+    pub segments: String,
+    pub x1: String,
+    pub y1: String,
+    pub z1: String,
+    pub x2: String,
+    pub y2: String,
+    pub z2: String,
+    pub radius: String,
+}
+
+/// Format an `f64` for a text box: shortest round-tripping decimal, integral
+/// values without a trailing `.0`.
+fn fmt_f(v: f64) -> String {
+    if v.fract() == 0.0 && v.abs() < 1e15 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+impl WireRow {
+    /// Fill a row from a parsed `GW` card.
+    pub fn from_card(c: &GwCard) -> Self {
+        Self {
+            tag: c.tag.to_string(),
+            segments: c.segments.to_string(),
+            x1: fmt_f(c.start[0]),
+            y1: fmt_f(c.start[1]),
+            z1: fmt_f(c.start[2]),
+            x2: fmt_f(c.end[0]),
+            y2: fmt_f(c.end[1]),
+            z2: fmt_f(c.end[2]),
+            radius: fmt_f(c.radius),
+        }
+    }
+
+    /// A sensible blank wire for "Add row": 1 segment, unit length on x, thin.
+    pub fn new_default(tag: u32) -> Self {
+        Self::from_card(&GwCard {
+            tag,
+            segments: 1,
+            start: [0.0, 0.0, 0.0],
+            end: [1.0, 0.0, 0.0],
+            radius: 0.001,
+        })
+    }
+
+    /// Mutable access to a field by [`WireField`].
+    pub fn field_mut(&mut self, field: WireField) -> &mut String {
+        match field {
+            WireField::Tag => &mut self.tag,
+            WireField::Segments => &mut self.segments,
+            WireField::X1 => &mut self.x1,
+            WireField::Y1 => &mut self.y1,
+            WireField::Z1 => &mut self.z1,
+            WireField::X2 => &mut self.x2,
+            WireField::Y2 => &mut self.y2,
+            WireField::Z2 => &mut self.z2,
+            WireField::Radius => &mut self.radius,
+        }
+    }
+
+    /// Validate and convert to a [`GwCard`], or return a human-readable reason.
+    pub fn to_card(&self) -> Result<GwCard, String> {
+        let tag = parse_u(&self.tag, "tag")?;
+        if tag < 1 {
+            return Err("tag must be ≥ 1".into());
+        }
+        let segments = parse_u(&self.segments, "segments")?;
+        if segments < 1 {
+            return Err("segments must be ≥ 1".into());
+        }
+        let start = [
+            parse_f(&self.x1, "x1")?,
+            parse_f(&self.y1, "y1")?,
+            parse_f(&self.z1, "z1")?,
+        ];
+        let end = [
+            parse_f(&self.x2, "x2")?,
+            parse_f(&self.y2, "y2")?,
+            parse_f(&self.z2, "z2")?,
+        ];
+        let radius = parse_f(&self.radius, "radius")?;
+        if radius <= 0.0 {
+            return Err("radius must be > 0".into());
+        }
+        if start == end {
+            return Err("start and end points are identical (zero-length wire)".into());
+        }
+        Ok(GwCard {
+            tag,
+            segments,
+            start,
+            end,
+            radius,
+        })
+    }
+}
+
+fn parse_u(s: &str, name: &str) -> Result<u32, String> {
+    let t = s.trim();
+    if t.is_empty() {
+        return Err(format!("{name} is empty"));
+    }
+    t.parse::<u32>()
+        .map_err(|_| format!("{name}: '{t}' is not a whole number"))
+}
+
+fn parse_f(s: &str, name: &str) -> Result<f64, String> {
+    let t = s.trim();
+    if t.is_empty() {
+        return Err(format!("{name} is empty"));
+    }
+    let v = t
+        .parse::<f64>()
+        .map_err(|_| format!("{name}: '{t}' is not a number"))?;
+    if !v.is_finite() {
+        return Err(format!("{name}: '{t}' is not finite"));
+    }
+    Ok(v)
+}
+
+/// An editable deck: the `GW` wires as a table, everything else preserved.
+///
+/// The non-wire cards are split around the first contiguous block of `GW` cards
+/// into `pre` (leading comments, etc.) and `post` (`GE`, `EX`, `FR`, …). On
+/// [`ModelDoc::to_deck`] they are re-emitted around the edited wire rows, so the
+/// editor never drops the control cards it doesn't yet understand.
+#[derive(Debug, Clone, Default)]
+pub struct ModelDoc {
+    pre: Vec<Card>,
+    pub wires: Vec<WireRow>,
+    post: Vec<Card>,
+    pub dirty: bool,
+}
+
+impl ModelDoc {
+    /// Build an editable document from a parsed deck.
+    pub fn from_deck(deck: &NecDeck) -> Self {
+        let mut pre = Vec::new();
+        let mut wires = Vec::new();
+        let mut post = Vec::new();
+        let mut seen_wire = false;
+        for card in &deck.cards {
+            match card {
+                Card::Gw(gw) if post.is_empty() => {
+                    // Extend the (first) contiguous wire block.
+                    wires.push(WireRow::from_card(gw));
+                    seen_wire = true;
+                }
+                other if !seen_wire => pre.push(other.clone()),
+                other => post.push(other.clone()),
+            }
+        }
+        Self {
+            pre,
+            wires,
+            post,
+            dirty: false,
+        }
+    }
+
+    /// Number of editable wires.
+    pub fn wire_count(&self) -> usize {
+        self.wires.len()
+    }
+
+    /// Edit a single field of a wire row and mark the document dirty.
+    pub fn edit(&mut self, row: usize, field: WireField, value: String) {
+        if let Some(w) = self.wires.get_mut(row) {
+            *w.field_mut(field) = value;
+            self.dirty = true;
+        }
+    }
+
+    /// Append a new wire whose tag is one past the current maximum.
+    pub fn add_wire(&mut self) {
+        let next_tag = self
+            .wires
+            .iter()
+            .filter_map(|w| w.tag.trim().parse::<u32>().ok())
+            .max()
+            .unwrap_or(0)
+            + 1;
+        self.wires.push(WireRow::new_default(next_tag));
+        self.dirty = true;
+    }
+
+    /// Remove a wire row by index (no-op if out of range).
+    pub fn delete_wire(&mut self, row: usize) {
+        if row < self.wires.len() {
+            self.wires.remove(row);
+            self.dirty = true;
+        }
+    }
+
+    /// Validate every wire, returning the reconstructed deck or the first row
+    /// that fails to validate (`(row_index, reason)`).
+    pub fn to_deck(&self) -> Result<NecDeck, (usize, String)> {
+        let mut cards = self.pre.clone();
+        for (i, w) in self.wires.iter().enumerate() {
+            let gw = w.to_card().map_err(|e| (i, e))?;
+            cards.push(Card::Gw(gw));
+        }
+        cards.extend(self.post.iter().cloned());
+        Ok(NecDeck { cards })
+    }
+
+    /// Render the current document to deck text, or the first validation error.
+    pub fn to_deck_string(&self) -> Result<String, (usize, String)> {
+        self.to_deck().map(|d| write_deck(&d))
+    }
+
+    /// Mark the document saved (clears `dirty`).
+    pub fn mark_saved(&mut self) {
+        self.dirty = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nec_parser::parse;
+
+    const DIPOLE: &str = "\
+CM test dipole
+CE
+GW 1 51 0 0 -5.232 0 0 5.232 0.001
+GE 0
+EX 0 1 26 0 1
+FR 0 1 14.2 0
+EN
+";
+
+    fn doc() -> ModelDoc {
+        ModelDoc::from_deck(&parse(DIPOLE).unwrap().deck)
+    }
+
+    #[test]
+    fn from_deck_splits_wires_and_preserves_rest() {
+        let d = doc();
+        assert_eq!(d.wire_count(), 1);
+        assert_eq!(d.wires[0].tag, "1");
+        assert_eq!(d.wires[0].z2, "5.232");
+        assert!(!d.dirty);
+        // pre = 2 comments; post = GE, EX, FR, EN.
+        let rebuilt = d.to_deck().unwrap();
+        // Round-trips exactly through the writer/parser.
+        let reparsed = parse(&write_deck(&rebuilt)).unwrap().deck;
+        assert_eq!(reparsed.cards, parse(DIPOLE).unwrap().deck.cards);
+    }
+
+    #[test]
+    fn editing_a_coordinate_changes_the_deck_and_sets_dirty() {
+        let mut d = doc();
+        d.edit(0, WireField::Z2, "6.0".into());
+        assert!(d.dirty);
+        let deck = d.to_deck().unwrap();
+        let Card::Gw(gw) = deck
+            .cards
+            .iter()
+            .find(|c| matches!(c, Card::Gw(_)))
+            .unwrap()
+        else {
+            unreachable!()
+        };
+        assert_eq!(gw.end[2], 6.0);
+    }
+
+    #[test]
+    fn add_and_delete_wire() {
+        let mut d = doc();
+        d.add_wire();
+        assert_eq!(d.wire_count(), 2);
+        assert_eq!(d.wires[1].tag, "2", "new tag is max+1");
+        d.delete_wire(0);
+        assert_eq!(d.wire_count(), 1);
+        assert_eq!(d.wires[0].tag, "2", "row 0 removed");
+    }
+
+    #[test]
+    fn invalid_fields_are_rejected_with_row_and_reason() {
+        let mut d = doc();
+        d.edit(0, WireField::Radius, "0".into());
+        let err = d.to_deck().unwrap_err();
+        assert_eq!(err.0, 0);
+        assert!(err.1.contains("radius"), "unexpected: {}", err.1);
+
+        d.edit(0, WireField::Radius, "0.001".into());
+        d.edit(0, WireField::Segments, "0".into());
+        assert!(d.to_deck().unwrap_err().1.contains("segments"));
+
+        d.edit(0, WireField::Segments, "51".into());
+        d.edit(0, WireField::X1, "abc".into());
+        assert!(d.to_deck().unwrap_err().1.contains("x1"));
+    }
+
+    #[test]
+    fn zero_length_wire_is_rejected() {
+        let mut d = doc();
+        for (f, v) in [
+            (WireField::X1, "0"),
+            (WireField::Y1, "0"),
+            (WireField::Z1, "0"),
+            (WireField::X2, "0"),
+            (WireField::Y2, "0"),
+            (WireField::Z2, "0"),
+        ] {
+            d.edit(0, f, v.into());
+        }
+        assert!(d.to_deck().unwrap_err().1.contains("zero-length"));
+    }
+
+    #[test]
+    fn empty_field_is_an_editing_state_not_a_panic() {
+        let mut d = doc();
+        d.edit(0, WireField::Z2, String::new());
+        assert!(d.to_deck().is_err());
+        // Typing resumes cleanly.
+        d.edit(0, WireField::Z2, "5.232".into());
+        assert!(d.to_deck().is_ok());
+    }
+}


### PR DESCRIPTION
First half of the wire-editor phase (GUI redesign Phase 6) — the headless, unit-tested core the visual editor is built on. **No UI yet**; the wire table + live preview land in the follow-up.

## `deck_write.rs` (new) — the serializer the workspace was missing
`write_deck` / `write_card` render a parsed `NecDeck` back to canonical NEC card text for every card the parser understands (GW/GM/GR/GE/GN/LD/TL/PT/NT/EX/FR/RP/NE/NH/EN + comments). Floats use Rust's shortest round-tripping `f64` Display, so coordinates survive parse→write→parse to the bit. Card forms are chosen to re-parse identically: bare vs medium `GN`, XNDA-encoded `RP` flags, 4-field `FR` shorthand, trailing-zero-trimmed `EX`/`LD`.

**Oracle:** a test parses → writes → re-parses **every deck in `corpus/`** and asserts card-list equality (24+ decks).

## `model_doc.rs` (new) — the editable document
`ModelDoc` splits a deck into a `Vec<WireRow>` (the GW block) plus the surrounding cards, preserved verbatim (pre/post). `WireRow` holds fields as **strings** (text-box contents) and validates back to a `GwCard` (tag≥1, segments≥1, radius>0, finite coords, non-degenerate) — a half-typed value is an editing state, not a crash. Tracks a dirty flag; `to_deck_string()` renders via the writer for live preview + save; add/delete/edit helpers report per-row errors.

## Gates
- ✅ 12 new headless tests (corpus round-trip + writer per-card forms + model edit/validate/add/delete). `cargo test -p nec-gui` green (29 lib tests), clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)