### PR TITLE
feat(gui-chk-007): visual GW wire editor with live 3-D preview

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -21,6 +21,8 @@ pub enum ActiveTab {
     Pattern,
     /// Segment current-distribution bar chart.
     Currents,
+    /// Visual wire (GW) editor with live 3-D preview (GUI-CHK-007).
+    Editor,
     /// GPU 3-D viewport (GUI redesign — `docs/gui-redesign-plan.md`).
     Viewport,
 }
@@ -105,6 +107,24 @@ pub struct AppState {
     // ── 3-D viewport state (GUI redesign) ──────────────────────────────────
     /// GPU viewport: camera + built line mesh + status (`docs/gui-redesign-plan.md`).
     pub viewport: ViewportState,
+    // ── Wire-editor state (GUI-CHK-007) ────────────────────────────────────
+    /// Editable deck document + editor UI status.
+    pub editor: EditorState,
+}
+
+/// State of the visual wire editor (GUI-CHK-007). Holds the editable document
+/// plus the last preview error and save status. The 3-D preview itself lives in
+/// [`ViewportState`]: every valid edit rebuilds `viewport.scene` from the doc.
+#[derive(Debug, Clone, Default)]
+pub struct EditorState {
+    /// The editable deck (wire table + preserved control cards).
+    pub doc: crate::model_doc::ModelDoc,
+    /// Whether a deck has been loaded into the editor yet.
+    pub loaded: bool,
+    /// Last validation/preview error (row/reason), shown under the table.
+    pub error: Option<String>,
+    /// Result of the most recent Save, shown to the user.
+    pub save_status: String,
 }
 
 /// State of the GPU 3-D viewport. The camera and mesh are pure data (rendered by
@@ -207,6 +227,7 @@ impl Default for AppState {
             pattern_phase: PatternPhase::default(),
             currents_phase: CurrentsPhase::default(),
             viewport: ViewportState::default(),
+            editor: EditorState::default(),
         }
     }
 }
@@ -283,6 +304,25 @@ pub enum Message {
     /// User dragged the workbench pane divider (new split ratio in [0,1]). The
     /// `pane_grid::State` itself lives in the binary; this carries only the ratio.
     PaneResized(f32),
+    // ── Wire editor (GUI-CHK-007) ─────────────────────────────────────────
+    /// User clicked "Load deck into editor".
+    EditDeckLoad,
+    /// Background parse of the deck into an editable document completed.
+    EditDeckLoaded(Result<crate::model_doc::ModelDoc, String>),
+    /// User edited one field of one wire row.
+    EditWireField {
+        row: usize,
+        field: crate::model_doc::WireField,
+        value: String,
+    },
+    /// User clicked "Add wire".
+    EditWireAdd,
+    /// User clicked the delete button on a wire row.
+    EditWireDelete(usize),
+    /// User clicked "Save deck" (the binary performs the file write).
+    SaveDeck,
+    /// Background deck write completed (`Ok(path)` or an error message).
+    DeckSaved(Result<String, String>),
 }
 
 impl AppState {
@@ -416,6 +456,46 @@ impl AppState {
             }
             // Pane layout lives in the iced binary (see main.rs); no core state.
             Message::PaneResized(_) => {}
+            Message::EditDeckLoad => {
+                self.editor.save_status = "Loading deck into editor…".into();
+            }
+            Message::EditDeckLoaded(Ok(doc)) => {
+                self.editor.doc = doc.clone();
+                self.editor.loaded = true;
+                self.editor.error = None;
+                self.editor.save_status.clear();
+                self.refresh_editor_preview();
+                // Frame the camera on the freshly loaded geometry (once).
+                if let Some((c, r)) = self.viewport.fit_bounds {
+                    self.viewport.camera.fit(c, r);
+                }
+            }
+            Message::EditDeckLoaded(Err(e)) => {
+                self.editor.error = Some(e.clone());
+                self.editor.save_status.clear();
+            }
+            Message::EditWireField { row, field, value } => {
+                self.editor.doc.edit(*row, *field, value.clone());
+                self.refresh_editor_preview();
+            }
+            Message::EditWireAdd => {
+                self.editor.doc.add_wire();
+                self.refresh_editor_preview();
+            }
+            Message::EditWireDelete(row) => {
+                self.editor.doc.delete_wire(*row);
+                self.refresh_editor_preview();
+            }
+            Message::SaveDeck => {
+                self.editor.save_status = "Saving…".into();
+            }
+            Message::DeckSaved(Ok(path)) => {
+                self.editor.doc.mark_saved();
+                self.editor.save_status = format!("Saved to {path}");
+            }
+            Message::DeckSaved(Err(e)) => {
+                self.editor.save_status = format!("Save failed: {e}");
+            }
             Message::Viewport(vp) => {
                 let cam = &mut self.viewport.camera;
                 match vp {
@@ -431,6 +511,37 @@ impl AppState {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    /// Rebuild the 3-D preview from the current editor document.
+    ///
+    /// On any valid edit the document is rendered to deck text and its geometry
+    /// rebuilt into `viewport.scene` (no solve) for instant feedback. A validation
+    /// or build failure is stored in `editor.error` and the last good preview is
+    /// left on screen. The camera is **not** refitted here — edits keep the view
+    /// steady; only [`Message::EditDeckLoaded`] frames the geometry.
+    fn refresh_editor_preview(&mut self) {
+        match self.editor.doc.to_deck_string() {
+            Ok(text) => match crate::solve::load_geometry_str(&text) {
+                Ok(geo) => {
+                    self.editor.error = None;
+                    let (center, radius) = geo.bounds();
+                    self.viewport.fit_bounds = Some((center, radius));
+                    self.viewport.geometry = Some(geo);
+                    // Editing the geometry invalidates any solved overlays.
+                    self.viewport.currents_ma = None;
+                    self.viewport.show_currents = false;
+                    self.viewport.grid = None;
+                    self.viewport.show_pattern = false;
+                    self.viewport.rebuild_scene();
+                    self.viewport.rebuild_lobe();
+                }
+                Err(e) => self.editor.error = Some(e),
+            },
+            Err((row, reason)) => {
+                self.editor.error = Some(format!("wire {}: {reason}", row + 1));
             }
         }
     }

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -20,9 +20,11 @@ use nec_gui::app_state::{
     ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase,
     SweepSortCol, ViewportMsg,
 };
+use nec_gui::model_doc::{WireField, WireRow};
 use nec_gui::solve::{
-    current_distribution_deck_path, load_currents_path, load_geometry_path, pattern_grid_path,
-    pattern_slice_deck_path, solve_deck_path, sweep_deck_path, SolveResult, SweepPoint,
+    current_distribution_deck_path, load_currents_path, load_geometry_path, load_model_doc_path,
+    pattern_grid_path, pattern_slice_deck_path, solve_deck_path, sweep_deck_path, SolveResult,
+    SweepPoint,
 };
 use std::path::PathBuf;
 
@@ -76,6 +78,8 @@ impl FnecGui {
         let spawn_geometry = matches!(message, Message::LoadGeometry);
         let spawn_currents_3d = matches!(message, Message::LoadCurrents);
         let spawn_pattern_3d = matches!(message, Message::LoadPattern3d);
+        let spawn_edit_load = matches!(message, Message::EditDeckLoad);
+        let spawn_save = matches!(message, Message::SaveDeck);
         // Pane resize is an iced-layout concern handled here (not in AppState).
         if let Message::PaneResized(ratio) = message {
             self.panes.resize(self.main_split, ratio);
@@ -178,6 +182,38 @@ impl FnecGui {
                 async move { pattern_grid_path(&path, vars.as_deref()) },
                 Message::Pattern3dComplete,
             )
+        } else if spawn_edit_load {
+            let path = PathBuf::from(self.state.deck_path.clone());
+            let vars: Option<String> = if self.state.vars_path.is_empty() {
+                None
+            } else {
+                Some(self.state.vars_path.clone())
+            };
+            Task::perform(
+                async move { load_model_doc_path(&path, vars.as_deref()) },
+                Message::EditDeckLoaded,
+            )
+        } else if spawn_save {
+            // Render the edited deck and write it back over the loaded path.
+            let path = self.state.deck_path.clone();
+            match self.state.editor.doc.to_deck_string() {
+                Ok(text) => Task::perform(
+                    async move {
+                        match std::fs::write(&path, &text) {
+                            Ok(()) => Ok(path),
+                            Err(e) => Err(e.to_string()),
+                        }
+                    },
+                    Message::DeckSaved,
+                ),
+                Err((row, reason)) => {
+                    self.state.apply(&Message::DeckSaved(Err(format!(
+                        "wire {}: {reason}",
+                        row + 1
+                    ))));
+                    Task::none()
+                }
+            }
         } else {
             Task::none()
         }
@@ -218,6 +254,7 @@ impl FnecGui {
             tab("Sweep", ActiveTab::Sweep),
             tab("Pattern", ActiveTab::Pattern),
             tab("Currents", ActiveTab::Currents),
+            tab("Edit", ActiveTab::Editor),
         ]
         .spacing(4);
 
@@ -247,6 +284,7 @@ impl FnecGui {
             ActiveTab::Sweep => self.sweep_view(),
             ActiveTab::Pattern => self.pattern_view(),
             ActiveTab::Currents => self.currents_view(),
+            ActiveTab::Editor => self.editor_view(),
             // The viewport is its own pane now; this tab is unreachable via UI.
             ActiveTab::Viewport => self.solve_view(),
         };
@@ -399,6 +437,48 @@ fn pane_container_style(theme: &Theme) -> container::Style {
     }
 }
 
+// ── Wire-editor row widgets (GUI-CHK-007) ─────────────────────────────────────
+
+/// Column width for the integer fields (tag, segments).
+const W_INT: Length = Length::Fixed(52.0);
+/// Column width for the coordinate/radius fields.
+const W_COORD: Length = Length::Fixed(74.0);
+/// Column width for the delete button.
+const W_DEL: Length = Length::Fixed(44.0);
+
+/// One field text box in a wire row. Borrows the field string, so the returned
+/// element's lifetime is tied to the [`WireRow`] (the row can't be `'static`).
+fn wire_cell(row: usize, field: WireField, value: &str, width: Length) -> Element<'_, Message> {
+    text_input("", value)
+        .on_input(move |v| Message::EditWireField {
+            row,
+            field,
+            value: v,
+        })
+        .width(width)
+        .into()
+}
+
+/// One editable wire row: nine text boxes + a delete button.
+fn wire_edit_row(row: usize, w: &WireRow) -> Element<'_, Message> {
+    iced::widget::row![
+        wire_cell(row, WireField::Tag, &w.tag, W_INT),
+        wire_cell(row, WireField::Segments, &w.segments, W_INT),
+        wire_cell(row, WireField::X1, &w.x1, W_COORD),
+        wire_cell(row, WireField::Y1, &w.y1, W_COORD),
+        wire_cell(row, WireField::Z1, &w.z1, W_COORD),
+        wire_cell(row, WireField::X2, &w.x2, W_COORD),
+        wire_cell(row, WireField::Y2, &w.y2, W_COORD),
+        wire_cell(row, WireField::Z2, &w.z2, W_COORD),
+        wire_cell(row, WireField::Radius, &w.radius, W_COORD),
+        button(text("Del"))
+            .on_press(Message::EditWireDelete(row))
+            .width(W_DEL),
+    ]
+    .spacing(4)
+    .into()
+}
+
 // ── Stand-alone helper widgets ────────────────────────────────────────────────
 
 /// Small impedance result widget for the single-frequency tab.
@@ -512,6 +592,79 @@ impl FnecGui {
         column![phi_row, run_btn, status, result_section]
             .spacing(8)
             .into()
+    }
+
+    // ── Wire editor (GUI-CHK-007) ─────────────────────────────────────────
+    fn editor_view(&self) -> Element<'_, Message> {
+        let load_btn = if self.state.deck_path.is_empty() {
+            button("Load deck into editor")
+        } else {
+            button("Load deck into editor").on_press(Message::EditDeckLoad)
+        };
+
+        if !self.state.editor.loaded {
+            return column![
+                load_btn,
+                text(
+                    "Load a deck to edit its GW wires. Every valid edit previews \
+                     live in the 3-D view."
+                )
+                .width(Length::Fill),
+            ]
+            .spacing(8)
+            .into();
+        }
+
+        let header = row![
+            text("Tag").width(W_INT),
+            text("Segs").width(W_INT),
+            text("x1").width(W_COORD),
+            text("y1").width(W_COORD),
+            text("z1").width(W_COORD),
+            text("x2").width(W_COORD),
+            text("y2").width(W_COORD),
+            text("z2").width(W_COORD),
+            text("radius").width(W_COORD),
+            text("").width(W_DEL),
+        ]
+        .spacing(4);
+
+        let mut table = column![header].spacing(3);
+        for (i, w) in self.state.editor.doc.wires.iter().enumerate() {
+            table = table.push(wire_edit_row(i, w));
+        }
+        let table = scrollable(table).direction(scrollable::Direction::Both {
+            vertical: scrollable::Scrollbar::default(),
+            horizontal: scrollable::Scrollbar::default(),
+        });
+
+        let add_btn = button("+ Add wire").on_press(Message::EditWireAdd);
+        let save_btn = button("Save deck").on_press(Message::SaveDeck);
+
+        let dirty = if self.state.editor.doc.dirty {
+            "  •unsaved"
+        } else {
+            ""
+        };
+        let status: Element<Message> = match &self.state.editor.error {
+            Some(e) => text(format!("⚠ {e}")).width(Length::Fill).into(),
+            None => text(format!(
+                "Preview OK — {} wire(s){dirty}",
+                self.state.editor.doc.wire_count()
+            ))
+            .width(Length::Fill)
+            .into(),
+        };
+        let save_status = text(self.state.editor.save_status.clone()).width(Length::Fill);
+
+        column![
+            row![load_btn, add_btn, save_btn].spacing(8),
+            table,
+            status,
+            save_status,
+        ]
+        .spacing(8)
+        .into()
     }
 
     // ── Currents view ─────────────────────────────────────────────────────

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -166,6 +166,24 @@ pub fn load_geometry_str(deck_text: &str) -> Result<crate::mesh::SceneGeometry, 
     Ok(crate::mesh::SceneGeometry::from_segments(wires, has_ground))
 }
 
+/// Parse a deck file (with optional `$VAR` substitution) into an editable
+/// [`ModelDoc`] for the visual wire editor (GUI-CHK-007). No solve.
+pub fn load_model_doc_path(
+    path: &Path,
+    vars_path: Option<&str>,
+) -> Result<crate::model_doc::ModelDoc, String> {
+    let input = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    let input = apply_vars(&input, vars_path)?;
+    load_model_doc_str(&input)
+}
+
+/// Build an editable [`ModelDoc`] from a raw NEC deck string.
+pub fn load_model_doc_str(deck_text: &str) -> Result<crate::model_doc::ModelDoc, String> {
+    let parsed = parse(deck_text).map_err(|e| e.to_string())?;
+    Ok(crate::model_doc::ModelDoc::from_deck(&parsed.deck))
+}
+
 /// Solve a deck and return its geometry **with** per-segment current magnitudes
 /// (mA), aligned to the wire order, for current-colored 3-D display (GUI-CHK-004).
 pub fn load_currents_path(

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -922,3 +922,133 @@ fn current_distribution_corpus_dipole_freesp() {
     let any_nonzero = pts.iter().any(|p| p.current_mag_ma > 1e-6);
     assert!(any_nonzero, "all currents are effectively zero");
 }
+
+// ── Wire editor tests (GUI-CHK-007) ──────────────────────────────────────────
+
+use nec_gui::model_doc::WireField;
+use nec_gui::solve::load_model_doc_str;
+
+const EDITOR_DECK: &str = "\
+CM editor test
+CE
+GW 1 11 0 0 -2.5 0 0 2.5 0.001
+GE 0
+EX 0 1 6 0 1
+FR 0 1 14.2 0
+EN
+";
+
+fn loaded_editor() -> AppState {
+    let mut state = AppState::default();
+    let doc = load_model_doc_str(EDITOR_DECK).expect("parse doc");
+    state.apply(&Message::EditDeckLoaded(Ok(doc)));
+    state
+}
+
+/// Loading a deck into the editor populates the wire table and builds a live
+/// 3-D preview, without marking the document dirty.
+#[test]
+fn editor_load_populates_table_and_previews() {
+    let state = loaded_editor();
+    assert!(state.editor.loaded);
+    assert_eq!(state.editor.doc.wire_count(), 1);
+    assert!(!state.editor.doc.dirty, "a fresh load is not dirty");
+    assert!(state.editor.error.is_none());
+    assert!(
+        state.viewport.scene.is_some(),
+        "preview mesh should be built on load"
+    );
+}
+
+/// Editing a coordinate rebuilds the preview (new scene revision) and flags the
+/// document dirty.
+#[test]
+fn editor_edit_rebuilds_preview_and_marks_dirty() {
+    let mut state = loaded_editor();
+    let rev_before = state.viewport.scene_rev;
+    state.apply(&Message::EditWireField {
+        row: 0,
+        field: WireField::Z2,
+        value: "3.0".into(),
+    });
+    assert!(state.editor.doc.dirty, "edit marks dirty");
+    assert_ne!(
+        state.viewport.scene_rev, rev_before,
+        "editing should rebuild the preview mesh"
+    );
+    assert!(state.editor.error.is_none());
+}
+
+/// Add and delete operate on the table and keep the preview valid.
+#[test]
+fn editor_add_and_delete_wire() {
+    let mut state = loaded_editor();
+    state.apply(&Message::EditWireAdd);
+    assert_eq!(state.editor.doc.wire_count(), 2);
+    assert!(state.viewport.scene.is_some());
+    state.apply(&Message::EditWireDelete(1));
+    assert_eq!(state.editor.doc.wire_count(), 1);
+}
+
+/// An invalid edit records an error but leaves the last good preview on screen.
+#[test]
+fn editor_invalid_edit_sets_error_keeps_last_preview() {
+    let mut state = loaded_editor();
+    let good_scene = state.viewport.scene.clone();
+    state.apply(&Message::EditWireField {
+        row: 0,
+        field: WireField::Radius,
+        value: "0".into(), // radius must be > 0
+    });
+    assert!(
+        state.editor.error.is_some(),
+        "invalid radius reports an error"
+    );
+    assert!(
+        state.viewport.scene.is_some(),
+        "the last valid preview is retained"
+    );
+    // Fixing the value clears the error and rebuilds.
+    state.apply(&Message::EditWireField {
+        row: 0,
+        field: WireField::Radius,
+        value: "0.002".into(),
+    });
+    assert!(state.editor.error.is_none());
+    assert!(state.viewport.scene.is_some());
+    let _ = good_scene;
+}
+
+/// A successful save clears the dirty flag and reports the path.
+#[test]
+fn editor_save_marks_clean() {
+    let mut state = loaded_editor();
+    state.apply(&Message::EditWireField {
+        row: 0,
+        field: WireField::Z2,
+        value: "3.0".into(),
+    });
+    assert!(state.editor.doc.dirty);
+    state.apply(&Message::DeckSaved(Ok("/tmp/out.nec".into())));
+    assert!(!state.editor.doc.dirty, "save clears the dirty flag");
+    assert!(state.editor.save_status.contains("/tmp/out.nec"));
+}
+
+/// Editing invalidates a previously shown currents overlay (the solve is stale).
+#[test]
+fn editor_edit_clears_stale_currents_overlay() {
+    let mut state = loaded_editor();
+    // Simulate a currents solve having painted the wires.
+    state.viewport.show_currents = true;
+    state.viewport.currents_ma = Some(vec![1.0, 2.0]);
+    state.apply(&Message::EditWireField {
+        row: 0,
+        field: WireField::Z1,
+        value: "-3.0".into(),
+    });
+    assert!(
+        !state.viewport.show_currents,
+        "edit turns off stale coloring"
+    );
+    assert!(state.viewport.currents_ma.is_none());
+}


### PR DESCRIPTION
Second half of the wire-editor phase — the UI on top of the deck writer + `ModelDoc` core (#323). **Completes GUI redesign Phase 6.**

## What's new
- A **"Edit" tab** in the controls pane. *Load deck into editor* parses the deck path into a `ModelDoc`; the GW cards become an **editable table** (Tag, Segs, x1..z2, radius) of text boxes, with per-row **Del** and **+ Add wire**. The table scrolls in both directions so it never widens the pane.
- **Live preview:** every keystroke re-renders the document to deck text and rebuilds the viewport's wire mesh (no solve), so moving a coordinate **moves the wire in the always-visible 3-D pane immediately**. Invalid input (bad float, radius ≤ 0, zero-length wire, empty box) shows a ⚠ reason under the table and keeps the last good preview. Editing clears any stale currents/pattern overlay.
- **Save deck** writes the rendered deck back over the loaded path (off-thread) and clears the dirty flag; an `•unsaved` marker and the save result are shown.

## Plumbing
`AppState` gains `EditorState` (doc + loaded/error/save_status); Messages `EditDeckLoad(ed)`/`EditWireField`/`EditWireAdd`/`EditWireDelete`/`SaveDeck`/`DeckSaved`; `solve::load_model_doc_{path,str}`; a private `refresh_editor_preview()` that rebuilds the scene without disturbing the camera. `ActiveTab::Editor` added.

## Gates
- ✅ 6 new headless smoke tests (load→preview, edit→dirty+rev-bump, add/delete, invalid→error-keeps-preview, save→clean, edit-clears-stale-overlay). `cargo test -p nec-gui` green (29 lib + 60 integration), clippy `-D warnings` + fmt clean.
- ⏸️ **Visual** (drag a z coord → wire moves in 3-D; add/delete; save) needs a display — handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)