### PR TITLE
docs(gui-chk-007): mark Phase 6 code-complete

### DIFF
--- a/docs/gui-redesign-plan.md
+++ b/docs/gui-redesign-plan.md
@@ -378,7 +378,7 @@ headless).
 | 3 | GUI-CHK-004 | Currents painted on wires + colormap legend — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 1–2 d |
 | 4 | GUI-CHK-005 | 3-D pattern lobe overlay (full-sphere) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 3 d |
 | 5 | GUI-CHK-006 | pane_grid layout shell; tabs dissolve into panes — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2–3 d |
-| 6 | GUI-CHK-007 | Deck writer + GW wire table editor (live preview) | 3–4 d |
+| 6 | GUI-CHK-007 | Deck writer + GW wire table editor (live preview) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 3–4 d |
 | 7 | GUI-CHK-008 | EX / GN / LD / FR editors + Apply-and-Solve | 3 d |
 | 8 | GUI-CHK-009 | Streaming sweep, SWR/|Z| canvas plot, frequency slider | 3 d |
 | 9 | GUI-CHK-010 | Polish: file dialogs, view options, fit/reset, project save | 2–3 d |


### PR DESCRIPTION
Marks the GUI-CHK-007 row in the redesign plan as code + headless gates done (visual pending a display). Follows PRs #323 (writer + model core) and #324 (wire editor UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)