### PR TITLE
feat(gui): undo/redo with history for the wire editor

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -119,6 +119,8 @@ pub struct AppState {
 pub struct EditorState {
     /// The editable deck (wire table + preserved control cards).
     pub doc: crate::model_doc::ModelDoc,
+    /// Undo/redo history for the wire table.
+    pub history: crate::model_doc::EditHistory,
     /// Whether a deck has been loaded into the editor yet.
     pub loaded: bool,
     /// Last validation/preview error (row/reason), shown under the table.
@@ -323,6 +325,10 @@ pub enum Message {
     SaveDeck,
     /// Background deck write completed (`Ok(path)` or an error message).
     DeckSaved(Result<String, String>),
+    /// Undo the last wire-table change (button or Ctrl+Z).
+    EditUndo,
+    /// Redo the last undone wire-table change (button or Ctrl+Shift+Z / Ctrl+Y).
+    EditRedo,
 }
 
 impl AppState {
@@ -461,6 +467,7 @@ impl AppState {
             }
             Message::EditDeckLoaded(Ok(doc)) => {
                 self.editor.doc = doc.clone();
+                self.editor.history.reset();
                 self.editor.loaded = true;
                 self.editor.error = None;
                 self.editor.save_status.clear();
@@ -475,16 +482,31 @@ impl AppState {
                 self.editor.save_status.clear();
             }
             Message::EditWireField { row, field, value } => {
+                self.editor
+                    .history
+                    .before_field_edit(&self.editor.doc, *row, *field);
                 self.editor.doc.edit(*row, *field, value.clone());
                 self.refresh_editor_preview();
             }
             Message::EditWireAdd => {
+                self.editor.history.before_structural(&self.editor.doc);
                 self.editor.doc.add_wire();
                 self.refresh_editor_preview();
             }
             Message::EditWireDelete(row) => {
+                self.editor.history.before_structural(&self.editor.doc);
                 self.editor.doc.delete_wire(*row);
                 self.refresh_editor_preview();
+            }
+            Message::EditUndo => {
+                if self.editor.history.undo(&mut self.editor.doc) {
+                    self.refresh_editor_preview();
+                }
+            }
+            Message::EditRedo => {
+                if self.editor.history.redo(&mut self.editor.doc) {
+                    self.refresh_editor_preview();
+                }
             }
             Message::SaveDeck => {
                 self.editor.save_status = "Saving…".into();

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -10,12 +10,13 @@
 
 mod viewport;
 
+use iced::keyboard::{Key, Modifiers};
 use iced::widget::pane_grid::{Axis, Split};
 use iced::widget::{
     button, checkbox, column, container, pane_grid, progress_bar, row, scrollable, shader, text,
     text_input,
 };
-use iced::{Border, Element, Length, Task, Theme};
+use iced::{Border, Element, Length, Subscription, Task, Theme};
 use nec_gui::app_state::{
     ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase,
     SweepSortCol, ViewportMsg,
@@ -30,8 +31,29 @@ use std::path::PathBuf;
 
 fn main() -> iced::Result {
     iced::application("fnec-gui — Antenna Modeler", FnecGui::update, FnecGui::view)
+        .subscription(FnecGui::subscription)
         .theme(|_| Theme::Dark)
         .run()
+}
+
+/// Map a Ctrl/Cmd-modified key press to an editor undo/redo message.
+///
+/// `Ctrl+Z` undoes, `Ctrl+Shift+Z` / `Ctrl+Y` redoes. Only wired while the Edit
+/// tab is active (see [`FnecGui::subscription`]), so it never shadows typing in
+/// the other tabs.
+fn editor_hotkey(key: Key, mods: Modifiers) -> Option<Message> {
+    if !mods.command() {
+        return None;
+    }
+    match key.as_ref() {
+        Key::Character(c) if c.eq_ignore_ascii_case("z") => Some(if mods.shift() {
+            Message::EditRedo
+        } else {
+            Message::EditUndo
+        }),
+        Key::Character(c) if c.eq_ignore_ascii_case("y") => Some(Message::EditRedo),
+        _ => None,
+    }
 }
 
 /// Which workbench pane a `pane_grid` cell holds.
@@ -70,6 +92,15 @@ impl Default for FnecGui {
 }
 
 impl FnecGui {
+    /// Listen for undo/redo hotkeys, but only while the wire editor is open.
+    fn subscription(&self) -> Subscription<Message> {
+        if self.state.active_tab == ActiveTab::Editor {
+            iced::keyboard::on_key_press(editor_hotkey)
+        } else {
+            Subscription::none()
+        }
+    }
+
     fn update(&mut self, message: Message) -> Task<Message> {
         let spawn_solve = matches!(message, Message::Solve);
         let spawn_sweep = matches!(message, Message::RunSweep);
@@ -640,6 +671,16 @@ impl FnecGui {
 
         let add_btn = button("+ Add wire").on_press(Message::EditWireAdd);
         let save_btn = button("Save deck").on_press(Message::SaveDeck);
+        let undo_btn = if self.state.editor.history.can_undo() {
+            button("Undo").on_press(Message::EditUndo)
+        } else {
+            button("Undo")
+        };
+        let redo_btn = if self.state.editor.history.can_redo() {
+            button("Redo").on_press(Message::EditRedo)
+        } else {
+            button("Redo")
+        };
 
         let dirty = if self.state.editor.doc.dirty {
             "  •unsaved"
@@ -658,7 +699,7 @@ impl FnecGui {
         let save_status = text(self.state.editor.save_status.clone()).width(Length::Fill);
 
         column![
-            row![load_btn, add_btn, save_btn].spacing(8),
+            row![load_btn, add_btn, undo_btn, redo_btn, save_btn].spacing(8),
             table,
             status,
             save_status,

--- a/apps/nec-gui/src/model_doc.rs
+++ b/apps/nec-gui/src/model_doc.rs
@@ -256,6 +256,95 @@ impl ModelDoc {
     }
 }
 
+/// Upper bound on retained undo/redo snapshots (guards against unbounded growth
+/// during a long editing session).
+const MAX_HISTORY: usize = 200;
+
+/// Undo/redo history for the wire editor (GUI-CHK-007).
+///
+/// Snapshots are whole [`ModelDoc`] clones. Consecutive edits to the **same**
+/// `(row, field)` are *coalesced*: only the pre-run state is snapshotted, so
+/// typing `-5.232` into one box is a single undo step, not one step per keystroke.
+/// Structural changes (add/delete) and any undo/redo break the run.
+#[derive(Debug, Clone, Default)]
+pub struct EditHistory {
+    undo: Vec<ModelDoc>,
+    redo: Vec<ModelDoc>,
+    /// The field currently absorbing coalesced edits, if a run is open.
+    last_field: Option<(usize, WireField)>,
+}
+
+impl EditHistory {
+    /// Whether an undo is available.
+    pub fn can_undo(&self) -> bool {
+        !self.undo.is_empty()
+    }
+
+    /// Whether a redo is available.
+    pub fn can_redo(&self) -> bool {
+        !self.redo.is_empty()
+    }
+
+    /// Clear all history (called when a fresh deck is loaded into the editor).
+    pub fn reset(&mut self) {
+        self.undo.clear();
+        self.redo.clear();
+        self.last_field = None;
+    }
+
+    fn push_undo(&mut self, doc: &ModelDoc) {
+        self.undo.push(doc.clone());
+        if self.undo.len() > MAX_HISTORY {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+    }
+
+    /// Snapshot the pre-edit state before a field edit, coalescing consecutive
+    /// edits to the same `(row, field)` into one undo step. Call *before*
+    /// mutating the document.
+    pub fn before_field_edit(&mut self, doc: &ModelDoc, row: usize, field: WireField) {
+        if self.last_field == Some((row, field)) {
+            return;
+        }
+        self.push_undo(doc);
+        self.last_field = Some((row, field));
+    }
+
+    /// Snapshot the pre-change state before a structural edit (add/delete row).
+    /// Never coalesced. Call *before* mutating the document.
+    pub fn before_structural(&mut self, doc: &ModelDoc) {
+        self.push_undo(doc);
+        self.last_field = None;
+    }
+
+    /// Restore the previous snapshot into `doc`, pushing the current state onto
+    /// the redo stack. Returns `false` (and leaves `doc` untouched) if empty.
+    pub fn undo(&mut self, doc: &mut ModelDoc) -> bool {
+        match self.undo.pop() {
+            Some(prev) => {
+                self.redo.push(std::mem::replace(doc, prev));
+                self.last_field = None;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Re-apply the next redo snapshot into `doc`, pushing the current state onto
+    /// the undo stack. Returns `false` (and leaves `doc` untouched) if empty.
+    pub fn redo(&mut self, doc: &mut ModelDoc) -> bool {
+        match self.redo.pop() {
+            Some(next) => {
+                self.undo.push(std::mem::replace(doc, next));
+                self.last_field = None;
+                true
+            }
+            None => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -358,5 +447,80 @@ EN
         // Typing resumes cleanly.
         d.edit(0, WireField::Z2, "5.232".into());
         assert!(d.to_deck().is_ok());
+    }
+
+    // ── EditHistory ──────────────────────────────────────────────────────────
+
+    /// One field edited several times in a row is a single undo step, and undo
+    /// restores the original value.
+    #[test]
+    fn history_coalesces_consecutive_same_field_edits() {
+        let mut d = doc();
+        let mut h = EditHistory::default();
+        for v in ["5", "5.", "5.2", "5.23"] {
+            h.before_field_edit(&d, 0, WireField::Z2);
+            d.edit(0, WireField::Z2, v.into());
+        }
+        assert_eq!(d.wires[0].z2, "5.23");
+        assert!(h.can_undo());
+        assert!(h.undo(&mut d), "one undo");
+        assert_eq!(d.wires[0].z2, "5.232", "undo restores the pre-run value");
+        assert!(!h.can_undo(), "the whole typing run was one step");
+    }
+
+    /// Editing a different field opens a new undo step.
+    #[test]
+    fn history_separates_different_fields() {
+        let mut d = doc();
+        let mut h = EditHistory::default();
+        h.before_field_edit(&d, 0, WireField::Z2);
+        d.edit(0, WireField::Z2, "6".into());
+        h.before_field_edit(&d, 0, WireField::X1);
+        d.edit(0, WireField::X1, "1".into());
+
+        assert!(h.undo(&mut d)); // undoes X1
+        assert_eq!(d.wires[0].x1, "0");
+        assert_eq!(d.wires[0].z2, "6", "Z2 edit still applied");
+        assert!(h.undo(&mut d)); // undoes Z2
+        assert_eq!(d.wires[0].z2, "5.232");
+    }
+
+    /// Add/delete are their own undo steps and are not coalesced with edits.
+    #[test]
+    fn history_structural_changes_and_redo() {
+        let mut d = doc();
+        let mut h = EditHistory::default();
+        h.before_structural(&d);
+        d.add_wire();
+        assert_eq!(d.wire_count(), 2);
+
+        assert!(h.undo(&mut d));
+        assert_eq!(d.wire_count(), 1, "undo removes the added wire");
+        assert!(h.can_redo());
+        assert!(h.redo(&mut d));
+        assert_eq!(d.wire_count(), 2, "redo re-adds it");
+    }
+
+    /// A fresh edit after an undo clears the redo stack.
+    #[test]
+    fn history_new_edit_clears_redo() {
+        let mut d = doc();
+        let mut h = EditHistory::default();
+        h.before_field_edit(&d, 0, WireField::Z2);
+        d.edit(0, WireField::Z2, "6".into());
+        h.undo(&mut d);
+        assert!(h.can_redo());
+        h.before_field_edit(&d, 0, WireField::Z2);
+        d.edit(0, WireField::Z2, "7".into());
+        assert!(!h.can_redo(), "a new edit invalidates redo");
+    }
+
+    #[test]
+    fn history_undo_redo_on_empty_is_a_noop() {
+        let mut d = doc();
+        let mut h = EditHistory::default();
+        assert!(!h.undo(&mut d));
+        assert!(!h.redo(&mut d));
+        assert_eq!(d.wire_count(), 1);
     }
 }

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1052,3 +1052,46 @@ fn editor_edit_clears_stale_currents_overlay() {
     );
     assert!(state.viewport.currents_ma.is_none());
 }
+
+/// Undo/redo via messages restores and re-applies a wire edit, and refreshes
+/// the 3-D preview each time.
+#[test]
+fn editor_undo_redo_restores_state() {
+    let mut state = loaded_editor();
+    assert_eq!(state.editor.doc.wires[0].z2, "2.5");
+    state.apply(&Message::EditWireField {
+        row: 0,
+        field: WireField::Z2,
+        value: "3.0".into(),
+    });
+    assert_eq!(state.editor.doc.wires[0].z2, "3.0");
+    let rev_after_edit = state.viewport.scene_rev;
+
+    state.apply(&Message::EditUndo);
+    assert_eq!(state.editor.doc.wires[0].z2, "2.5", "undo restores");
+    assert_ne!(
+        state.viewport.scene_rev, rev_after_edit,
+        "undo rebuilds the preview"
+    );
+
+    state.apply(&Message::EditRedo);
+    assert_eq!(state.editor.doc.wires[0].z2, "3.0", "redo re-applies");
+}
+
+/// Undo reverses an Add, and undo/redo on an empty history is a harmless no-op.
+#[test]
+fn editor_undo_add_and_empty_noop() {
+    let mut state = loaded_editor();
+    // Empty history: undo does nothing, no panic.
+    state.apply(&Message::EditUndo);
+    assert_eq!(state.editor.doc.wire_count(), 1);
+
+    state.apply(&Message::EditWireAdd);
+    assert_eq!(state.editor.doc.wire_count(), 2);
+    state.apply(&Message::EditUndo);
+    assert_eq!(
+        state.editor.doc.wire_count(),
+        1,
+        "undo removes the added wire"
+    );
+}

--- a/examples/dipole_14mhz_test.nec
+++ b/examples/dipole_14mhz_test.nec
@@ -1,0 +1,6 @@
+CM Half-wave dipole at 14.2 MHz — smoke-test deck
+CM
+GW 1 11 0 0 -5.282 0 0 3 0.001
+EX 0 1 6 0 1
+FR 0 1 14.2 0
+EN


### PR DESCRIPTION
Requested follow-up to the wire editor (#324): an **undo/redo stack with history** and keyboard shortcuts.

## What's new
- **`EditHistory`** (`model_doc.rs`, pure + unit-tested): whole-`ModelDoc` snapshots on undo/redo stacks, capped at 200. **Edit coalescing** — consecutive edits to the *same* `(row, field)` collapse into one undo step, so typing `-5.232` into a box is a single undo, not one per keystroke. Structural changes (add/delete) and any undo/redo break the run.
- **`EditorState.history`** + `EditUndo`/`EditRedo` messages: the edit/add/delete arms snapshot the pre-state before mutating; undo/redo restore and refresh the live 3-D preview; loading a deck resets history.
- **UI**: Undo / Redo buttons (disabled when the stack is empty) plus a keyboard subscription — **Ctrl+Z** undo, **Ctrl+Shift+Z** / **Ctrl+Y** redo — wired **only while the Edit tab is active** so it never shadows typing in the other tabs (uses `Modifiers::command`, so it's Cmd on macOS).

## Gates
- ✅ 5 new `EditHistory` unit tests (coalescing, field separation, structural + redo, redo-cleared-on-new-edit, empty no-op) + 2 integration tests (undo/redo restores & rebuilds preview; undo an Add; empty no-op). `cargo test -p nec-gui` green (34 lib + 62 integration), clippy `-D warnings` + fmt clean.
- ⏸️ **Visual** (Ctrl+Z and the buttons) needs a display — handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)