### PR TITLE
chore: remove stray test deck accidentally committed in #326

### DIFF
--- a/examples/dipole_14mhz_test.nec
+++ b/examples/dipole_14mhz_test.nec
@@ -1,6 +1,0 @@
-CM Half-wave dipole at 14.2 MHz — smoke-test deck
-CM
-GW 1 11 0 0 -5.282 0 0 3 0.001
-EX 0 1 6 0 1
-FR 0 1 14.2 0
-EN


### PR DESCRIPTION
`examples/dipole_14mhz_test.nec` was an untracked scratch deck swept into the undo/redo commit by `git add -A`. Not part of any feature — removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)