### PR TITLE
feat(gui): add/remove GN/LD/EX control cards in the editor

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -336,6 +336,10 @@ pub enum Message {
     },
     /// User clicked "Apply + Solve": solve the edited in-memory deck.
     EditApplySolve,
+    /// User clicked "Add ground / load / source" to insert a control card.
+    EditAddControl(crate::model_doc::ControlKind),
+    /// User clicked the delete button on a control card at post-slot `slot`.
+    EditDeleteControl(usize),
 }
 
 impl AppState {
@@ -534,6 +538,16 @@ impl AppState {
                     self.editor.error = Some(e);
                 }
             },
+            Message::EditAddControl(kind) => {
+                self.editor.history.before_structural(&self.editor.doc);
+                self.editor.doc.add_control(*kind);
+                self.refresh_editor_preview();
+            }
+            Message::EditDeleteControl(slot) => {
+                self.editor.history.before_structural(&self.editor.doc);
+                self.editor.doc.delete_control(*slot);
+                self.refresh_editor_preview();
+            }
             Message::SaveDeck => {
                 self.editor.save_status = "Saving…".into();
             }

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -21,7 +21,7 @@ use nec_gui::app_state::{
     ActiveTab, AppState, CurrentsPhase, Message, PatternPhase, SolvePhase, SweepPhase,
     SweepSortCol, ViewportMsg,
 };
-use nec_gui::model_doc::{ControlEdit, PostSlot, WireField, WireRow};
+use nec_gui::model_doc::{ControlEdit, ControlKind, PostSlot, WireField, WireRow};
 use nec_gui::solve::{
     current_distribution_deck_path, load_currents_path, load_geometry_path, load_model_doc_path,
     pattern_grid_path, pattern_slice_deck_path, solve_deck_path, solve_deck_str, sweep_deck_path,
@@ -626,6 +626,7 @@ fn control_editor_row(slot: usize, s: &PostSlot) -> Option<Element<'_, Message>>
             ctrl_field(slot, "seg", &ex.segment, W_INT, ControlEdit::ExSegment),
             ctrl_field(slot, "Vr", &ex.vr, W_COORD, ControlEdit::ExVr),
             ctrl_field(slot, "Vi", &ex.vi, W_COORD, ControlEdit::ExVi),
+            control_del_button(slot),
         ]
         .spacing(6)
         .align_y(iced::Alignment::Center)
@@ -644,6 +645,7 @@ fn control_editor_row(slot: usize, s: &PostSlot) -> Option<Element<'_, Message>>
             ),
             ctrl_field(slot, "εr", &gn.eps_r, W_COORD, ControlEdit::GnEps),
             ctrl_field(slot, "σ", &gn.sigma, W_COORD, ControlEdit::GnSigma),
+            control_del_button(slot),
         ]
         .spacing(6)
         .align_y(iced::Alignment::Center)
@@ -662,6 +664,7 @@ fn control_editor_row(slot: usize, s: &PostSlot) -> Option<Element<'_, Message>>
             ctrl_field(slot, "F1", &ld.f1, W_COORD, ControlEdit::LdF1),
             ctrl_field(slot, "F2", &ld.f2, W_COORD, ControlEdit::LdF2),
             ctrl_field(slot, "F3", &ld.f3, W_COORD, ControlEdit::LdF3),
+            control_del_button(slot),
         ]
         .spacing(6)
         .align_y(iced::Alignment::Center)
@@ -683,6 +686,7 @@ fn control_editor_row(slot: usize, s: &PostSlot) -> Option<Element<'_, Message>>
                 ControlEdit::FrFrequency
             ),
             ctrl_field(slot, "Δ", &fr.step_mhz, W_COORD, ControlEdit::FrStep),
+            control_del_button(slot),
         ]
         .spacing(6)
         .align_y(iced::Alignment::Center)
@@ -690,6 +694,14 @@ fn control_editor_row(slot: usize, s: &PostSlot) -> Option<Element<'_, Message>>
         PostSlot::Other(_) => return None,
     };
     Some(r)
+}
+
+/// The per-row delete button shared by all control-card editors.
+fn control_del_button(slot: usize) -> Element<'static, Message> {
+    button(text("Del"))
+        .on_press(Message::EditDeleteControl(slot))
+        .width(W_DEL)
+        .into()
 }
 
 // ── Stand-alone helper widgets ────────────────────────────────────────────────
@@ -883,7 +895,15 @@ impl FnecGui {
         let save_status = text(self.state.editor.save_status.clone()).width(Length::Fill);
 
         // ── Sources & environment (EX/GN/LD/FR editors) ──────────────────────
-        let mut controls = column![text("Sources & environment")].spacing(4);
+        let add_bar = row![
+            text("Sources & environment"),
+            button(text("+ Ground")).on_press(Message::EditAddControl(ControlKind::Gn)),
+            button(text("+ Load")).on_press(Message::EditAddControl(ControlKind::Ld)),
+            button(text("+ Source")).on_press(Message::EditAddControl(ControlKind::Ex)),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+        let mut controls = column![add_bar].spacing(4);
         let mut any_control = false;
         for (i, slot) in self.state.editor.doc.post_slots().iter().enumerate() {
             if let Some(editor) = control_editor_row(i, slot) {

--- a/apps/nec-gui/src/model_doc.rs
+++ b/apps/nec-gui/src/model_doc.rs
@@ -194,6 +194,22 @@ impl ExRow {
         }
     }
 
+    /// A default 1 V voltage source on tag 1, segment 1.
+    fn new_default() -> Self {
+        Self::from_card(&ExCard {
+            excitation_type: 0,
+            tag: 1,
+            segment: 1,
+            i4: 0,
+            voltage_real: 1.0,
+            voltage_imag: 0.0,
+            polarization_deg: 0.0,
+            polarization_ratio: 0.0,
+            theta_inc: 0.0,
+            phi_inc: 0.0,
+        })
+    }
+
     fn to_card(&self) -> Result<ExCard, String> {
         Ok(ExCard {
             excitation_type: parse_u(&self.kind, "EX type")?,
@@ -225,6 +241,15 @@ impl GnRow {
             ground_type: c.ground_type,
             eps_r: c.eps_r.map(fmt_f).unwrap_or_default(),
             sigma: c.sigma.map(fmt_f).unwrap_or_default(),
+        }
+    }
+
+    /// A default perfect-conductor ground (`GN 1`, no medium).
+    fn new_default() -> Self {
+        Self {
+            ground_type: 1,
+            eps_r: String::new(),
+            sigma: String::new(),
         }
     }
 
@@ -260,6 +285,19 @@ impl LdRow {
             f2: fmt_f(c.f2),
             f3: fmt_f(c.f3),
         }
+    }
+
+    /// A default series-impedance load (`LD 4`) of 0 Ω on tag 1, segment 1.
+    fn new_default() -> Self {
+        Self::from_card(&LdCard {
+            load_type: 4,
+            tag: 1,
+            seg_first: 1,
+            seg_last: 1,
+            f1: 0.0,
+            f2: 0.0,
+            f3: 0.0,
+        })
     }
 
     fn to_card(&self) -> Result<LdCard, String> {
@@ -342,6 +380,33 @@ impl PostSlot {
             PostSlot::Fr(r) => Card::Fr(r.to_card()?),
             PostSlot::Other(c) => c.clone(),
         })
+    }
+}
+
+/// A kind of control card that can be inserted into a deck that lacks it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlKind {
+    Gn,
+    Ld,
+    Ex,
+}
+
+impl PostSlot {
+    /// NEC deck-ordering rank, used to insert a new control card in a sensible
+    /// place: geometry/comments (0) < GN (1) < LD (2) < EX (3) < FR (4) <
+    /// output/misc RP/NE/… (5) < EN (9).
+    fn order_rank(&self) -> u8 {
+        match self {
+            PostSlot::Gn(_) => 1,
+            PostSlot::Ld(_) => 2,
+            PostSlot::Ex(_) => 3,
+            PostSlot::Fr(_) => 4,
+            PostSlot::Other(c) => match c {
+                Card::Comment(_) | Card::Ge(_) | Card::Gm(_) | Card::Gr(_) => 0,
+                Card::En(_) => 9,
+                _ => 5,
+            },
+        }
     }
 }
 
@@ -483,6 +548,33 @@ impl ModelDoc {
     pub fn edit_control(&mut self, slot: usize, edit: &ControlEdit) {
         if let Some(s) = self.post.get_mut(slot) {
             edit.apply_to(s);
+            self.dirty = true;
+        }
+    }
+
+    /// Insert a new default control card (`GN`/`LD`/`EX`), placed in canonical
+    /// NEC order among the existing post cards, and mark the document dirty.
+    pub fn add_control(&mut self, kind: ControlKind) {
+        let slot = match kind {
+            ControlKind::Gn => PostSlot::Gn(GnRow::new_default()),
+            ControlKind::Ld => PostSlot::Ld(LdRow::new_default()),
+            ControlKind::Ex => PostSlot::Ex(ExRow::new_default()),
+        };
+        let rank = slot.order_rank();
+        // Insert before the first existing card that should sort after the new one.
+        let idx = self
+            .post
+            .iter()
+            .position(|s| s.order_rank() > rank)
+            .unwrap_or(self.post.len());
+        self.post.insert(idx, slot);
+        self.dirty = true;
+    }
+
+    /// Remove a post slot by index (no-op if out of range) and mark dirty.
+    pub fn delete_control(&mut self, slot: usize) {
+        if slot < self.post.len() {
+            self.post.remove(slot);
             self.dirty = true;
         }
     }
@@ -915,5 +1007,51 @@ EN
         d.edit_control(4, &ControlEdit::FrFrequency("abc".into()));
         let err = d.to_deck().unwrap_err();
         assert!(err.contains("FR frequency"), "unexpected: {err}");
+    }
+
+    /// Adding GN/LD/EX to a free-space deck inserts them in canonical NEC order
+    /// (GN before LD before EX before FR) and the result still round-trips.
+    #[test]
+    fn add_control_inserts_in_canonical_order() {
+        // Free-space dipole: post = [EX, FR, EN].
+        let mut d = doc();
+        d.add_control(ControlKind::Gn);
+        d.add_control(ControlKind::Ld);
+        assert!(d.dirty);
+        let kinds: Vec<&str> = d
+            .post_slots()
+            .iter()
+            .map(|s| match s {
+                PostSlot::Gn(_) => "gn",
+                PostSlot::Ld(_) => "ld",
+                PostSlot::Ex(_) => "ex",
+                PostSlot::Fr(_) => "fr",
+                PostSlot::Other(_) => "other",
+            })
+            .collect();
+        // GE stays first, GN and LD land before EX/FR, EN stays last.
+        assert_eq!(kinds, ["other", "gn", "ld", "ex", "fr", "other"]);
+        // The synthesised cards are valid and round-trip.
+        let rebuilt = d.to_deck().expect("valid");
+        let reparsed = parse(&write_deck(&rebuilt)).unwrap().deck;
+        assert!(reparsed.cards.iter().any(|c| matches!(c, Card::Gn(_))));
+        assert!(reparsed.cards.iter().any(|c| matches!(c, Card::Ld(_))));
+    }
+
+    #[test]
+    fn add_then_delete_control_restores_post() {
+        let mut d = doc();
+        let before = d.post_slots().len();
+        d.add_control(ControlKind::Ex);
+        assert_eq!(d.post_slots().len(), before + 1);
+        // Delete the newly added EX (it sorts to index 0 of post, before the
+        // original EX/FR/EN in a free-space deck).
+        let ex_idx = d
+            .post_slots()
+            .iter()
+            .position(|s| matches!(s, PostSlot::Ex(_)))
+            .unwrap();
+        d.delete_control(ex_idx);
+        assert_eq!(d.post_slots().len(), before);
     }
 }

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1179,3 +1179,65 @@ fn editor_apply_solve_rejects_invalid_deck() {
     );
     assert!(state.editor.error.is_some());
 }
+
+/// Adding a ground card to a free-space deck inserts a GN editor and keeps the
+/// deck renderable; deleting it restores the original.
+#[test]
+fn editor_add_and_delete_ground_card() {
+    use nec_gui::model_doc::ControlKind;
+    let mut state = loaded_editor();
+    let gn_before = state
+        .editor
+        .doc
+        .post_slots()
+        .iter()
+        .filter(|s| matches!(s, PostSlot::Gn(_)))
+        .count();
+    assert_eq!(gn_before, 0, "EDITOR_DECK is free-space");
+
+    state.apply(&Message::EditAddControl(ControlKind::Gn));
+    let gn_slot = state
+        .editor
+        .doc
+        .post_slots()
+        .iter()
+        .position(|s| matches!(s, PostSlot::Gn(_)))
+        .expect("ground card was added");
+    assert!(state.editor.doc.dirty);
+    assert!(state.editor.doc.to_deck_string().is_ok(), "GN 1 is valid");
+
+    state.apply(&Message::EditDeleteControl(gn_slot));
+    assert!(
+        !state
+            .editor
+            .doc
+            .post_slots()
+            .iter()
+            .any(|s| matches!(s, PostSlot::Gn(_))),
+        "ground card removed"
+    );
+}
+
+/// Add-control is undoable in one step.
+#[test]
+fn editor_add_control_is_undoable() {
+    use nec_gui::model_doc::ControlKind;
+    let mut state = loaded_editor();
+    state.apply(&Message::EditAddControl(ControlKind::Ld));
+    assert!(state
+        .editor
+        .doc
+        .post_slots()
+        .iter()
+        .any(|s| matches!(s, PostSlot::Ld(_))));
+    state.apply(&Message::EditUndo);
+    assert!(
+        !state
+            .editor
+            .doc
+            .post_slots()
+            .iter()
+            .any(|s| matches!(s, PostSlot::Ld(_))),
+        "undo removes the added load"
+    );
+}


### PR DESCRIPTION
Follow-up to the control-card editors: a free-space deck (e.g. `examples/dipole_14mhz.nec`) has no GN/LD cards to edit, so this adds the ability to **insert** them — turning a free-space model into a grounded/loaded one from the GUI.

## What's new
- **`ControlKind {Gn,Ld,Ex}`** + default constructors (GN 1 perfect ground; LD 4 zero-impedance on tag 1; EX 0, a 1 V source on tag 1 seg 1), and `ModelDoc::add_control(kind)` / `delete_control(slot)`. New cards are inserted in **canonical NEC order** via a per-slot `order_rank` (GE/comments < GN < LD < EX < FR < RP/NE < EN), so a synthesised GN lands after GE and before EX/FR — and the deck still round-trips.
- **Messages** `EditAddControl(ControlKind)` / `EditDeleteControl(slot)`, both snapshotted onto the undo history and refreshing the live preview.
- **UI**: "+ Ground / + Load / + Source" buttons in the *Sources & environment* header, and a per-row **Del** button on every control editor.

## Gates
- ✅ 4 new tests (add-in-canonical-order + round-trip, add/delete restores, add+delete ground via messages, add-control undoable). `cargo test -p nec-gui` green (42 lib + 68 integration), clippy `-D warnings` + fmt clean.
- ⏸️ **Visual** (load the free-space dipole → "+ Ground" → pick a type → Apply+Solve) needs a display — handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)