### PR TITLE
feat(gui-chk-009): SWR/|Z| sweep chart + frequency cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1641,7 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "log",
+ "lyon_path",
  "once_cell",
  "raw-window-handle",
  "rustc-hash 2.1.2",
@@ -1698,6 +1705,7 @@ dependencies = [
  "iced_glyphon",
  "iced_graphics",
  "log",
+ "lyon",
  "once_cell",
  "rustc-hash 2.1.2",
  "thiserror 1.0.69",
@@ -1973,6 +1981,58 @@ name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+
+[[package]]
+name = "lyon"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0578bdecb7d6d88987b8b2b1e3a4e2f81df9d0ece1078623324a567904e7b7"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e43b7e44161571868f5c931d12583592c223c5583eef86b08aa02b7048a3552"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "num-traits",
+]
 
 [[package]]
 name = "malloc_buf"

--- a/apps/nec-gui/Cargo.toml
+++ b/apps/nec-gui/Cargo.toml
@@ -25,7 +25,7 @@ nec_solver  = { workspace = true }
 nec_project = { workspace = true }
 num-complex = { workspace = true }
 toml        = { workspace = true }
-iced        = { version = "0.13", features = ["advanced"] }
+iced        = { version = "0.13", features = ["advanced", "canvas"] }
 glam        = { workspace = true }
 bytemuck    = { workspace = true }
 

--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -96,6 +96,10 @@ pub struct AppState {
     pub sweep_sort_asc: bool,
     /// Sweep pipeline phase.
     pub sweep_phase: SweepPhase,
+    /// Chart metric (SWR vs |Z|) for the sweep plot.
+    pub sweep_metric: crate::plot::PlotMetric,
+    /// Frequency cursor as a fraction `0..=1` of the swept range (GUI-CHK-009).
+    pub sweep_cursor: f32,
     // ── Pattern tab state ──────────────────────────────────────────────────
     /// Azimuth angle (φ, degrees) for the elevation-plane pattern slice.
     pub pattern_phi_deg: String,
@@ -225,6 +229,8 @@ impl Default for AppState {
             sweep_sort_col: SweepSortCol::FreqMhz,
             sweep_sort_asc: true,
             sweep_phase: SweepPhase::default(),
+            sweep_metric: crate::plot::PlotMetric::Swr,
+            sweep_cursor: 0.5,
             pattern_phi_deg: "0.0".into(),
             pattern_phase: PatternPhase::default(),
             currents_phase: CurrentsPhase::default(),
@@ -272,6 +278,10 @@ pub enum Message {
     SweepComplete(Result<Vec<SweepPoint>, String>),
     /// User clicked a column header to sort.
     SweepSortBy(SweepSortCol),
+    /// User moved the sweep-chart frequency cursor (fraction `0..=1`).
+    SweepCursorChanged(f32),
+    /// User picked the sweep-chart metric (SWR vs |Z|).
+    SweepMetricSelected(crate::plot::PlotMetric),
     // ── Pattern tab ───────────────────────────────────────────────────────
     /// User edited the pattern azimuth angle.
     PatternPhiChanged(String),
@@ -388,6 +398,12 @@ impl AppState {
                     self.sweep_sort_col = *col;
                     self.sweep_sort_asc = true;
                 }
+            }
+            Message::SweepCursorChanged(frac) => {
+                self.sweep_cursor = frac.clamp(0.0, 1.0);
+            }
+            Message::SweepMetricSelected(m) => {
+                self.sweep_metric = *m;
             }
             Message::PatternPhiChanged(s) => self.pattern_phi_deg = s.clone(),
             Message::RunPattern => {
@@ -677,6 +693,28 @@ impl AppState {
             }),
         }
         v
+    }
+
+    /// The swept points in their computed (frequency) order, if a sweep is done.
+    pub fn sweep_points(&self) -> &[SweepPoint] {
+        match &self.sweep_phase {
+            SweepPhase::Done(pts) => pts,
+            _ => &[],
+        }
+    }
+
+    /// The sweep point under the frequency cursor (nearest swept frequency to the
+    /// cursor fraction), for the chart readout. `None` if no sweep is loaded.
+    pub fn sweep_cursor_point(&self) -> Option<SweepPoint> {
+        let pts = self.sweep_points();
+        if pts.is_empty() {
+            return None;
+        }
+        let freqs: Vec<f64> = pts.iter().map(|p| p.freq_mhz).collect();
+        let (fmin, fmax) = crate::plot::finite_bounds(&freqs)?;
+        let target = crate::plot::map_range(f64::from(self.sweep_cursor), 0.0, 1.0, fmin, fmax);
+        let idx = crate::plot::nearest_index(&freqs, target)?;
+        Some(pts[idx].clone())
     }
 
     /// Human-readable status line for the single-frequency tab.

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -8,13 +8,14 @@
 //! cargo run -p nec-gui
 //! ```
 
+mod sweep_plot;
 mod viewport;
 
 use iced::keyboard::{Key, Modifiers};
 use iced::widget::pane_grid::{Axis, Split};
 use iced::widget::{
-    button, checkbox, column, container, pane_grid, pick_list, progress_bar, row, scrollable,
-    shader, text, text_input,
+    button, canvas, checkbox, column, container, pane_grid, pick_list, progress_bar, row,
+    scrollable, shader, slider, text, text_input,
 };
 use iced::{Border, Element, Length, Subscription, Task, Theme};
 use nec_gui::app_state::{
@@ -22,6 +23,7 @@ use nec_gui::app_state::{
     SweepSortCol, ViewportMsg,
 };
 use nec_gui::model_doc::{ControlEdit, ControlKind, PostSlot, WireField, WireRow};
+use nec_gui::plot::PlotMetric;
 use nec_gui::solve::{
     current_distribution_deck_path, load_currents_path, load_geometry_path, load_model_doc_path,
     pattern_grid_path, pattern_slice_deck_path, solve_deck_path, solve_deck_str, sweep_deck_path,
@@ -447,13 +449,75 @@ impl FnecGui {
         let status = text(self.state.sweep_status_text());
 
         let result_section: Element<Message> = match &self.state.sweep_phase {
-            SweepPhase::Done(_) => sweep_result_table(self),
+            SweepPhase::Done(_) => self.sweep_chart_and_table(),
             _ => text("").into(),
         };
 
         column![freq_inputs, run_btn, status, result_section]
             .spacing(8)
             .into()
+    }
+
+    /// The sweep chart (SWR/|Z| canvas + metric picker + frequency cursor) above
+    /// the sortable result table (GUI-CHK-009).
+    fn sweep_chart_and_table(&self) -> Element<'_, Message> {
+        let metric_row = row![
+            text("Chart:"),
+            pick_list(
+                &PlotMetric::ALL[..],
+                Some(self.state.sweep_metric),
+                Message::SweepMetricSelected,
+            ),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
+        let chart = canvas(sweep_plot::SweepPlot {
+            points: self.state.sweep_points().to_vec(),
+            metric: self.state.sweep_metric,
+            cursor_frac: self.state.sweep_cursor,
+        })
+        .width(Length::Fill)
+        .height(Length::Fixed(220.0));
+
+        let cursor_readout = match self.state.sweep_cursor_point() {
+            Some(p) => {
+                let swr = nec_gui::plot::swr(p.z_re, p.z_im, 50.0);
+                let zmag = nec_gui::plot::z_mag(p.z_re, p.z_im);
+                text(format!(
+                    "cursor: {:.3} MHz   Z = {:.2} {} j{:.2} Ω   |Z| = {:.1} Ω   SWR = {}",
+                    p.freq_mhz,
+                    p.z_re,
+                    if p.z_im < 0.0 { "-" } else { "+" },
+                    p.z_im.abs(),
+                    zmag,
+                    if swr.is_finite() {
+                        format!("{swr:.2}")
+                    } else {
+                        "∞".to_string()
+                    }
+                ))
+                .width(Length::Fill)
+            }
+            None => text("").width(Length::Fill),
+        };
+
+        let cursor_slider = slider(
+            0.0..=1.0,
+            self.state.sweep_cursor,
+            Message::SweepCursorChanged,
+        )
+        .step(0.001_f32);
+
+        column![
+            metric_row,
+            chart,
+            cursor_readout,
+            cursor_slider,
+            sweep_result_table(self),
+        ]
+        .spacing(8)
+        .into()
     }
 }
 

--- a/apps/nec-gui/src/plot.rs
+++ b/apps/nec-gui/src/plot.rs
@@ -25,6 +25,15 @@ impl PlotMetric {
             PlotMetric::ZMag => "|Z| (Ω)",
         }
     }
+
+    /// The metrics offered in the chart selector.
+    pub const ALL: [PlotMetric; 2] = [PlotMetric::Swr, PlotMetric::ZMag];
+}
+
+impl std::fmt::Display for PlotMetric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
 }
 
 /// Voltage standing-wave ratio for a load `Z = z_re + j·z_im` on a line of

--- a/apps/nec-gui/src/sweep_plot.rs
+++ b/apps/nec-gui/src/sweep_plot.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 Simon Keimer (DC0SK)
+
+//! Sweep chart canvas (GUI-CHK-009).
+//!
+//! A 2-D `canvas::Program` that plots the sweep result — SWR or |Z| against
+//! frequency — with 1-2-5 axis ticks and a draggable frequency cursor. All the
+//! numeric work (SWR, bounds, ticks, mapping, nearest point) lives in the
+//! headless `nec_gui::plot` module; this file only turns those numbers into
+//! canvas geometry.
+
+use iced::mouse;
+use iced::widget::canvas::{self, Frame, Geometry, Path, Stroke, Text};
+use iced::{Point, Rectangle, Renderer, Size, Theme};
+
+use nec_gui::app_state::Message;
+use nec_gui::plot::{self, PlotMetric};
+use nec_gui::solve::SweepPoint;
+
+/// SWR values above this are clamped for display (an infinite SWR would flatten
+/// the rest of the curve against the axis).
+const SWR_DISPLAY_MAX: f64 = 10.0;
+
+const MARGIN_LEFT: f32 = 44.0;
+const MARGIN_RIGHT: f32 = 12.0;
+const MARGIN_TOP: f32 = 12.0;
+const MARGIN_BOTTOM: f32 = 26.0;
+
+/// The sweep chart, rebuilt each `view()` from the current sweep result.
+pub struct SweepPlot {
+    pub points: Vec<SweepPoint>,
+    pub metric: PlotMetric,
+    /// Frequency cursor as a fraction `0..=1` of the swept range.
+    pub cursor_frac: f32,
+}
+
+impl SweepPlot {
+    /// The plotted y-value of a point under the current metric (SWR clamped).
+    fn value(&self, p: &SweepPoint) -> f64 {
+        match self.metric {
+            PlotMetric::Swr => plot::swr(p.z_re, p.z_im, 50.0).min(SWR_DISPLAY_MAX),
+            PlotMetric::ZMag => plot::z_mag(p.z_re, p.z_im),
+        }
+    }
+}
+
+impl canvas::Program<Message> for SweepPlot {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &(),
+        renderer: &Renderer,
+        theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let mut frame = Frame::new(renderer, bounds.size());
+        let palette = theme.extended_palette();
+        let axis_color = palette.background.strong.color;
+        let grid_color = palette.background.weak.color;
+        let curve_color = palette.primary.strong.color;
+        let text_color = palette.background.strong.text;
+        let cursor_color = palette.danger.strong.color;
+
+        let Size {
+            width: w,
+            height: h,
+        } = frame.size();
+        let (px0, px1) = (MARGIN_LEFT, w - MARGIN_RIGHT);
+        let (py0, py1) = (MARGIN_TOP, h - MARGIN_BOTTOM);
+        if px1 <= px0 || py1 <= py0 {
+            return vec![frame.into_geometry()];
+        }
+
+        // Plot frame.
+        let border = Path::rectangle(Point::new(px0, py0), Size::new(px1 - px0, py1 - py0));
+        frame.stroke(
+            &border,
+            Stroke::default().with_color(axis_color).with_width(1.0),
+        );
+
+        if self.points.len() < 2 {
+            frame.fill_text(Text {
+                content: "Run a sweep to plot it.".to_string(),
+                position: Point::new(px0 + 8.0, py0 + 8.0),
+                color: text_color,
+                size: 13.0.into(),
+                ..Text::default()
+            });
+            return vec![frame.into_geometry()];
+        }
+
+        let freqs: Vec<f64> = self.points.iter().map(|p| p.freq_mhz).collect();
+        let values: Vec<f64> = self.points.iter().map(|p| self.value(p)).collect();
+        let (fmin, fmax) = plot::finite_bounds(&freqs).unwrap_or((0.0, 1.0));
+        let (mut vmin, mut vmax) = plot::finite_bounds(&values).unwrap_or((0.0, 1.0));
+        // SWR floors at 1; give a flat curve some vertical breathing room.
+        if self.metric == PlotMetric::Swr {
+            vmin = vmin.min(1.0);
+        }
+        if (vmax - vmin).abs() < 1e-9 {
+            vmax = vmin + 1.0;
+        }
+
+        let x_px = |f: f64| plot::map_range(f, fmin, fmax, px0 as f64, px1 as f64) as f32;
+        let y_px = |v: f64| plot::map_range(v, vmin, vmax, py1 as f64, py0 as f64) as f32;
+
+        // Grid + tick labels.
+        for t in plot::nice_ticks(fmin, fmax, 6) {
+            let x = x_px(t);
+            frame.stroke(
+                &Path::line(Point::new(x, py0), Point::new(x, py1)),
+                Stroke::default().with_color(grid_color).with_width(1.0),
+            );
+            frame.fill_text(Text {
+                content: format!("{t:.2}"),
+                position: Point::new(x - 14.0, py1 + 4.0),
+                color: text_color,
+                size: 11.0.into(),
+                ..Text::default()
+            });
+        }
+        for t in plot::nice_ticks(vmin, vmax, 5) {
+            let y = y_px(t);
+            frame.stroke(
+                &Path::line(Point::new(px0, y), Point::new(px1, y)),
+                Stroke::default().with_color(grid_color).with_width(1.0),
+            );
+            frame.fill_text(Text {
+                content: format!("{t:.1}"),
+                position: Point::new(2.0, y - 6.0),
+                color: text_color,
+                size: 11.0.into(),
+                ..Text::default()
+            });
+        }
+
+        // Axis titles.
+        frame.fill_text(Text {
+            content: format!("{} vs f (MHz)", self.metric.label()),
+            position: Point::new(px0 + 4.0, 0.0),
+            color: text_color,
+            size: 11.0.into(),
+            ..Text::default()
+        });
+
+        // The curve.
+        let curve = Path::new(|b| {
+            for (i, (&f, &v)) in freqs.iter().zip(values.iter()).enumerate() {
+                let p = Point::new(x_px(f), y_px(v));
+                if i == 0 {
+                    b.move_to(p);
+                } else {
+                    b.line_to(p);
+                }
+            }
+        });
+        frame.stroke(
+            &curve,
+            Stroke::default().with_color(curve_color).with_width(2.0),
+        );
+
+        // Frequency cursor + selected-point marker.
+        let cursor_f = plot::map_range(f64::from(self.cursor_frac), 0.0, 1.0, fmin, fmax);
+        if let Some(idx) = plot::nearest_index(&freqs, cursor_f) {
+            let x = x_px(freqs[idx]);
+            frame.stroke(
+                &Path::line(Point::new(x, py0), Point::new(x, py1)),
+                Stroke::default().with_color(cursor_color).with_width(1.0),
+            );
+            let marker = Path::circle(Point::new(x, y_px(values[idx])), 3.0);
+            frame.fill(&marker, cursor_color);
+        }
+
+        vec![frame.into_geometry()]
+    }
+}

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1241,3 +1241,67 @@ fn editor_add_control_is_undoable() {
         "undo removes the added load"
     );
 }
+
+// ── Sweep chart cursor + metric (GUI-CHK-009) ────────────────────────────────
+
+use nec_gui::plot::PlotMetric;
+
+fn done_sweep() -> AppState {
+    let mut state = AppState::default();
+    let pts = vec![
+        SweepPoint {
+            freq_mhz: 14.0,
+            z_re: 60.0,
+            z_im: -20.0,
+        },
+        SweepPoint {
+            freq_mhz: 15.0,
+            z_re: 72.0,
+            z_im: 0.0,
+        },
+        SweepPoint {
+            freq_mhz: 16.0,
+            z_re: 90.0,
+            z_im: 30.0,
+        },
+    ];
+    state.apply(&Message::SweepComplete(Ok(pts)));
+    state
+}
+
+#[test]
+fn sweep_metric_and_cursor_messages() {
+    let mut state = AppState::default();
+    assert_eq!(state.sweep_metric, PlotMetric::Swr);
+    state.apply(&Message::SweepMetricSelected(PlotMetric::ZMag));
+    assert_eq!(state.sweep_metric, PlotMetric::ZMag);
+    // Cursor is clamped to [0, 1].
+    state.apply(&Message::SweepCursorChanged(1.5));
+    assert!((state.sweep_cursor - 1.0).abs() < 1e-6);
+    state.apply(&Message::SweepCursorChanged(-0.2));
+    assert!(state.sweep_cursor.abs() < 1e-6);
+}
+
+#[test]
+fn sweep_cursor_selects_nearest_point() {
+    let mut state = done_sweep();
+    // Cursor at the far right → highest swept frequency.
+    state.apply(&Message::SweepCursorChanged(1.0));
+    let p = state
+        .sweep_cursor_point()
+        .expect("a point under the cursor");
+    assert!((p.freq_mhz - 16.0).abs() < 1e-9);
+    // Cursor at the left → lowest frequency.
+    state.apply(&Message::SweepCursorChanged(0.0));
+    assert!((state.sweep_cursor_point().unwrap().freq_mhz - 14.0).abs() < 1e-9);
+    // Middle → the 15 MHz point.
+    state.apply(&Message::SweepCursorChanged(0.5));
+    assert!((state.sweep_cursor_point().unwrap().freq_mhz - 15.0).abs() < 1e-9);
+}
+
+#[test]
+fn sweep_cursor_point_none_without_sweep() {
+    let state = AppState::default();
+    assert!(state.sweep_cursor_point().is_none());
+    assert!(state.sweep_points().is_empty());
+}


### PR DESCRIPTION
Second slice of GUI redesign Phase 8 — the canvas plot and frequency slider on top of the pure plot math (#332), driving the existing batch sweep.

## What's new
- **`sweep_plot.rs`** (new): a `canvas::Program` that draws the sweep result as an **SWR-or-|Z|-vs-frequency** line chart — 1-2-5 axis ticks, gridlines, theme colours, and a red **frequency cursor** with a marker on the nearest swept point. Numeric work delegates to `nec_gui::plot` (SWR clamped to 10 for display so an infinite SWR doesn't flatten the curve). Enables iced's `canvas` feature (pulls in `lyon`).
- **Sweep tab**: below the (still sortable) result table now sit a **metric pick-list** (SWR / |Z|), the chart, a **cursor readout** (freq, Z, |Z|, SWR at the cursor), and a **frequency slider** scrubbing the swept range.
- **State**: `sweep_metric` + `sweep_cursor`, messages `SweepMetricSelected` / `SweepCursorChanged` (cursor clamped 0..1), and `sweep_points()` / `sweep_cursor_point()`.

## Gates
- ✅ 3 new integration tests (metric+cursor messages & clamping; cursor selects nearest point at 0/0.5/1; none without a sweep). `cargo test -p nec-gui` green (51 lib + 71 integration), clippy `-D warnings` + fmt clean.
- ⏸️ **Visual** (run a sweep → see the curve, drag the slider, switch SWR/|Z|) needs a display — handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)