### PR TITLE
feat(gui-chk-009): stream the sweep so the chart fills in live

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -47,6 +47,8 @@ pub enum SweepPhase {
     #[default]
     Idle,
     Running,
+    /// Points arriving incrementally from the streaming sweep (GUI-CHK-009).
+    Streaming(Vec<SweepPoint>),
     Done(Vec<SweepPoint>),
     Failed(String),
 }
@@ -274,8 +276,12 @@ pub enum Message {
     SweepStepChanged(String),
     /// User clicked the Run Sweep button.
     RunSweep,
-    /// Background sweep task completed.
+    /// Background sweep task completed (batch path / error).
     SweepComplete(Result<Vec<SweepPoint>, String>),
+    /// One sweep point arrived from the streaming sweep.
+    SweepPointComputed(SweepPoint),
+    /// The streaming sweep finished (finalize the accumulated points).
+    SweepStreamDone,
     /// User clicked a column header to sort.
     SweepSortBy(SweepSortCol),
     /// User moved the sweep-chart frequency cursor (fraction `0..=1`).
@@ -390,6 +396,23 @@ impl AppState {
             }
             Message::SweepComplete(Err(e)) => {
                 self.sweep_phase = SweepPhase::Failed(e.clone());
+            }
+            Message::SweepPointComputed(pt) => {
+                // Accumulate into a Streaming phase (starting one if needed).
+                match &mut self.sweep_phase {
+                    SweepPhase::Streaming(pts) => pts.push(pt.clone()),
+                    _ => self.sweep_phase = SweepPhase::Streaming(vec![pt.clone()]),
+                }
+            }
+            Message::SweepStreamDone => {
+                // Finalize whatever streamed in (empty stream → a failure note).
+                if let SweepPhase::Streaming(pts) = &self.sweep_phase {
+                    self.sweep_phase = if pts.is_empty() {
+                        SweepPhase::Failed("sweep produced no points".into())
+                    } else {
+                        SweepPhase::Done(pts.clone())
+                    };
+                }
             }
             Message::SweepSortBy(col) => {
                 if self.sweep_sort_col == *col {
@@ -631,7 +654,11 @@ impl AppState {
 
     /// Returns `true` when the Run Sweep button should be enabled.
     pub fn can_sweep(&self) -> bool {
-        !self.deck_path.is_empty() && !matches!(self.sweep_phase, SweepPhase::Running)
+        !self.deck_path.is_empty()
+            && !matches!(
+                self.sweep_phase,
+                SweepPhase::Running | SweepPhase::Streaming(_)
+            )
     }
 
     /// Returns `true` when the Run Pattern button should be enabled.
@@ -675,9 +702,9 @@ impl AppState {
         Ok((start, end, step))
     }
 
-    /// Returns sorted rows for the sweep result table.
+    /// Returns sorted rows for the sweep result table (streaming or done).
     pub fn sorted_sweep_rows(&self) -> Vec<SweepPoint> {
-        let SweepPhase::Done(rows) = &self.sweep_phase else {
+        let (SweepPhase::Streaming(rows) | SweepPhase::Done(rows)) = &self.sweep_phase else {
             return Vec::new();
         };
         let mut v = rows.clone();
@@ -695,10 +722,11 @@ impl AppState {
         v
     }
 
-    /// The swept points in their computed (frequency) order, if a sweep is done.
+    /// The swept points in their computed (frequency) order — available both
+    /// while streaming and once done.
     pub fn sweep_points(&self) -> &[SweepPoint] {
         match &self.sweep_phase {
-            SweepPhase::Done(pts) => pts,
+            SweepPhase::Streaming(pts) | SweepPhase::Done(pts) => pts,
             _ => &[],
         }
     }
@@ -735,6 +763,7 @@ impl AppState {
         match &self.sweep_phase {
             SweepPhase::Idle => String::from("Enter a frequency range and click Run Sweep."),
             SweepPhase::Running => String::from("Sweeping…"),
+            SweepPhase::Streaming(pts) => format!("Sweeping… {} points", pts.len()),
             SweepPhase::Done(pts) => format!("Done — {} points", pts.len()),
             SweepPhase::Failed(e) => format!("Error: {e}"),
         }

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -26,8 +26,8 @@ use nec_gui::model_doc::{ControlEdit, ControlKind, PostSlot, WireField, WireRow}
 use nec_gui::plot::PlotMetric;
 use nec_gui::solve::{
     current_distribution_deck_path, load_currents_path, load_geometry_path, load_model_doc_path,
-    pattern_grid_path, pattern_slice_deck_path, solve_deck_path, solve_deck_str, sweep_deck_path,
-    SolveResult, SweepPoint,
+    pattern_grid_path, pattern_slice_deck_path, read_deck_text, solve_deck_path, solve_deck_str,
+    SolveResult, SweepJob, SweepPoint,
 };
 use std::path::PathBuf;
 
@@ -142,10 +142,43 @@ impl FnecGui {
                     } else {
                         Some(self.state.vars_path.clone())
                     };
-                    Task::perform(
-                        async move { sweep_deck_path(&path, vars.as_deref(), start, end, step) },
-                        Message::SweepComplete,
-                    )
+                    // Read + substitute now (fast, surfaces file errors early), then
+                    // stream the per-frequency solves so the chart fills in live.
+                    match read_deck_text(&path, vars.as_deref()) {
+                        Ok(deck_text) => Task::run(
+                            iced::stream::channel(64, move |mut output| async move {
+                                use iced::futures::SinkExt;
+                                match SweepJob::prepare(&deck_text, start, end, step) {
+                                    Ok(job) => {
+                                        for &f in job.freqs_mhz() {
+                                            match job.solve_at(f) {
+                                                Ok(pt) => {
+                                                    let _ = output
+                                                        .send(Message::SweepPointComputed(pt))
+                                                        .await;
+                                                }
+                                                Err(e) => {
+                                                    let _ = output
+                                                        .send(Message::SweepComplete(Err(e)))
+                                                        .await;
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                        let _ = output.send(Message::SweepStreamDone).await;
+                                    }
+                                    Err(e) => {
+                                        let _ = output.send(Message::SweepComplete(Err(e))).await;
+                                    }
+                                }
+                            }),
+                            |m| m,
+                        ),
+                        Err(e) => {
+                            self.state.apply(&Message::SweepComplete(Err(e)));
+                            Task::none()
+                        }
+                    }
                 }
                 Err(e) => {
                     // Surface parameter error as a completed sweep failure.
@@ -449,7 +482,7 @@ impl FnecGui {
         let status = text(self.state.sweep_status_text());
 
         let result_section: Element<Message> = match &self.state.sweep_phase {
-            SweepPhase::Done(_) => self.sweep_chart_and_table(),
+            SweepPhase::Streaming(_) | SweepPhase::Done(_) => self.sweep_chart_and_table(),
             _ => text("").into(),
         };
 

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -8,11 +8,12 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use nec_model::card::Card;
+use nec_model::deck::NecDeck;
 use nec_parser::parse;
 use nec_solver::{
     assemble_z_matrix_with_ground, build_excitation, build_geometry, build_hallen_rhs, build_loads,
     build_tl_stamps, compute_radiation_pattern, detect_wire_junctions, ground_model_from_deck,
-    solve_hallen, wire_endpoints_from_segs, FarFieldPoint, GroundModel,
+    solve_hallen, wire_endpoints_from_segs, FarFieldPoint, GroundModel, Segment,
 };
 use num_complex::Complex64;
 
@@ -378,69 +379,115 @@ pub fn sweep_deck_str(
     end_mhz: f64,
     step_mhz: f64,
 ) -> Result<Vec<SweepPoint>, String> {
-    if step_mhz <= 0.0 {
-        return Err(format!("step_mhz must be > 0, got {step_mhz}"));
+    let job = SweepJob::prepare(deck_text, start_mhz, end_mhz, step_mhz)?;
+    job.freqs_mhz().iter().map(|&f| job.solve_at(f)).collect()
+}
+
+/// A prepared frequency sweep: geometry, excitation, ground and junctions built
+/// once, so each frequency can be solved independently via [`SweepJob::solve_at`].
+///
+/// This is the streaming-friendly core behind [`sweep_deck_str`] — the GUI drives
+/// it point-by-point so the sweep chart fills in live (GUI-CHK-009).
+pub struct SweepJob {
+    deck: NecDeck,
+    segs: Vec<Segment>,
+    v_vec: Vec<Complex64>,
+    ground: GroundModel,
+    wire_endpoints: Vec<(usize, usize)>,
+    junction_tuples: Vec<(usize, usize, f64)>,
+    freqs_mhz: Vec<f64>,
+}
+
+impl SweepJob {
+    /// Parse the deck and build the frequency-independent pieces once.
+    pub fn prepare(
+        deck_text: &str,
+        start_mhz: f64,
+        end_mhz: f64,
+        step_mhz: f64,
+    ) -> Result<Self, String> {
+        if step_mhz <= 0.0 {
+            return Err(format!("step_mhz must be > 0, got {step_mhz}"));
+        }
+        if start_mhz >= end_mhz {
+            return Err(format!(
+                "start_mhz ({start_mhz}) must be less than end_mhz ({end_mhz})"
+            ));
+        }
+
+        let parsed = parse(deck_text).map_err(|e| e.to_string())?;
+        let deck = parsed.deck;
+        let segs = build_geometry(&deck).map_err(|e| e.to_string())?;
+        let v_vec = build_excitation(&deck, &segs).map_err(|e| e.to_string())?;
+        let ground = ground_model_from_deck(&deck);
+        let wire_endpoints = wire_endpoints_from_segs(&segs);
+        let junction_tuples: Vec<(usize, usize, f64)> =
+            detect_wire_junctions(&segs, &wire_endpoints, 1e-6)
+                .iter()
+                .map(|j| (j.seg_a, j.seg_b, j.sign))
+                .collect();
+
+        let mut freqs_mhz = Vec::new();
+        let mut f = start_mhz;
+        while f <= end_mhz + step_mhz * 1e-9 {
+            freqs_mhz.push(f);
+            f += step_mhz;
+        }
+
+        Ok(Self {
+            deck,
+            segs,
+            v_vec,
+            ground,
+            wire_endpoints,
+            junction_tuples,
+            freqs_mhz,
+        })
     }
-    if start_mhz >= end_mhz {
-        return Err(format!(
-            "start_mhz ({start_mhz}) must be less than end_mhz ({end_mhz})"
-        ));
+
+    /// The frequencies (MHz) this job will solve, in ascending order.
+    pub fn freqs_mhz(&self) -> &[f64] {
+        &self.freqs_mhz
     }
 
-    let parsed = parse(deck_text).map_err(|e| e.to_string())?;
-    let deck = &parsed.deck;
-
-    // Build geometry and excitation once — reused across frequencies.
-    let segs = build_geometry(deck).map_err(|e| e.to_string())?;
-    let v_vec = build_excitation(deck, &segs).map_err(|e| e.to_string())?;
-    let ground = ground_model_from_deck(deck);
-    let wire_endpoints = wire_endpoints_from_segs(&segs);
-    let wire_junctions = detect_wire_junctions(&segs, &wire_endpoints, 1e-6);
-    let junction_tuples: Vec<(usize, usize, f64)> = wire_junctions
-        .iter()
-        .map(|j| (j.seg_a, j.seg_b, j.sign))
-        .collect();
-
-    // Build frequency list.
-    let mut freqs_mhz = Vec::new();
-    let mut f = start_mhz;
-    while f <= end_mhz + step_mhz * 1e-9 {
-        freqs_mhz.push(f);
-        f += step_mhz;
-    }
-
-    let mut results = Vec::with_capacity(freqs_mhz.len());
-
-    for freq_mhz in freqs_mhz {
+    /// Solve the feedpoint impedance at one frequency (MHz).
+    pub fn solve_at(&self, freq_mhz: f64) -> Result<SweepPoint, String> {
         let freq_hz = freq_mhz * 1_000_000.0;
 
-        let mut z_mat = assemble_z_matrix_with_ground(&segs, freq_hz, &ground);
-        let (load_vec, _) = build_loads(deck, &segs, freq_hz);
+        let mut z_mat = assemble_z_matrix_with_ground(&self.segs, freq_hz, &self.ground);
+        let (load_vec, _) = build_loads(&self.deck, &self.segs, freq_hz);
         z_mat.add_to_diagonal(&load_vec);
-        let (tl_stamps, _) = build_tl_stamps(deck, &segs, freq_hz);
+        let (tl_stamps, _) = build_tl_stamps(&self.deck, &self.segs, freq_hz);
         for (row, col, delta) in &tl_stamps {
             z_mat.add_to_entry(*row, *col, *delta);
         }
 
-        let hallen_rhs = build_hallen_rhs(deck, &segs, freq_hz).map_err(|e| e.to_string())?;
+        let hallen_rhs =
+            build_hallen_rhs(&self.deck, &self.segs, freq_hz).map_err(|e| e.to_string())?;
         let sol = solve_hallen(
             &z_mat,
             &hallen_rhs.rhs,
             &hallen_rhs.cos_vec,
-            &wire_endpoints,
-            &junction_tuples,
+            &self.wire_endpoints,
+            &self.junction_tuples,
         )
         .map_err(|e| e.to_string())?;
 
-        let z = feedpoint_impedance(deck, &segs, &v_vec, &sol.currents, freq_hz)?;
-        results.push(SweepPoint {
+        let z = feedpoint_impedance(&self.deck, &self.segs, &self.v_vec, &sol.currents, freq_hz)?;
+        Ok(SweepPoint {
             freq_mhz,
             z_re: z.re,
             z_im: z.im,
-        });
+        })
     }
+}
 
-    Ok(results)
+/// Read a deck file and apply `$VAR` substitution, returning the deck text.
+/// Used by the GUI to prepare a streaming sweep off the UI thread.
+pub fn read_deck_text(path: &Path, vars_path: Option<&str>) -> Result<String, String> {
+    let input = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+    apply_vars(&input, vars_path)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1305,3 +1305,53 @@ fn sweep_cursor_point_none_without_sweep() {
     assert!(state.sweep_cursor_point().is_none());
     assert!(state.sweep_points().is_empty());
 }
+
+// ── Streaming sweep (GUI-CHK-009) ────────────────────────────────────────────
+
+#[test]
+fn streaming_sweep_accumulates_points_then_finalizes() {
+    let mut state = AppState::default();
+    state.apply(&Message::DeckPathChanged("d.nec".into()));
+    state.apply(&Message::RunSweep); // → Running
+    assert_eq!(state.sweep_phase, SweepPhase::Running);
+
+    // Points arrive incrementally.
+    state.apply(&Message::SweepPointComputed(SweepPoint {
+        freq_mhz: 14.0,
+        z_re: 60.0,
+        z_im: -10.0,
+    }));
+    assert!(matches!(state.sweep_phase, SweepPhase::Streaming(ref p) if p.len() == 1));
+    // The chart/table can already read the partial data, and Run is disabled.
+    assert_eq!(state.sweep_points().len(), 1);
+    assert!(!state.can_sweep());
+
+    state.apply(&Message::SweepPointComputed(SweepPoint {
+        freq_mhz: 15.0,
+        z_re: 72.0,
+        z_im: 0.0,
+    }));
+    assert!(state.sweep_status_text().contains('2'));
+
+    state.apply(&Message::SweepStreamDone);
+    assert!(matches!(state.sweep_phase, SweepPhase::Done(ref p) if p.len() == 2));
+    assert!(state.can_sweep(), "Run re-enables once the sweep is done");
+}
+
+#[test]
+fn streaming_sweep_empty_stream_is_a_failure() {
+    let mut state = AppState::default();
+    state.apply(&Message::DeckPathChanged("d.nec".into()));
+    state.apply(&Message::RunSweep);
+    // Force a Streaming phase with no points, then finish.
+    state.apply(&Message::SweepPointComputed(SweepPoint {
+        freq_mhz: 14.0,
+        z_re: 1.0,
+        z_im: 0.0,
+    }));
+    if let SweepPhase::Streaming(pts) = &mut state.sweep_phase {
+        pts.clear();
+    }
+    state.apply(&Message::SweepStreamDone);
+    assert!(matches!(state.sweep_phase, SweepPhase::Failed(_)));
+}


### PR DESCRIPTION
Final slice of GUI redesign Phase 8 — the sweep now emits points **incrementally**, so the SWR/|Z| chart and result table build up as each frequency solves instead of appearing all at once. **Completes Phase 8.**

## Changes
- **`solve.rs`**: `SweepJob` prepares geometry/excitation/ground/junctions once, then `solve_at(freq)` solves a single frequency. `sweep_deck_str` is now a thin loop over it (identical batch result). Added `read_deck_text(path, vars)` to read + `$VAR`-substitute off the async path.
- **`main.rs`**: Run Sweep drives an `iced::stream::channel` via `Task::run` — prepare the job, then for each frequency solve and `send` a `SweepPointComputed`, awaiting between points (yielding to the UI), and a final `SweepStreamDone` (or `SweepComplete(Err)` on failure).
- **`app_state.rs`**: new `SweepPhase::Streaming(Vec<SweepPoint>)`; points accumulate, `SweepStreamDone` finalizes to `Done` (empty → `Failed`). Chart, table, status text, `sweep_points()` and `can_sweep()` treat Streaming like Done, so the partial sweep is visible and Run stays disabled mid-sweep.

## Gates
- ✅ 2 new integration tests (points accumulate → Streaming, partial data readable, Run disabled, then finalize to Done; empty stream → Failed). `cargo test -p nec-gui` green (51 lib + 73 integration), clippy `-D warnings` + fmt clean.
- ⏸️ **Visual** (run a multi-point sweep and watch the curve grow) needs a display — handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)