### PR TITLE
docs(gui-chk-009): mark Phase 8 code-complete

### DIFF
--- a/docs/gui-redesign-plan.md
+++ b/docs/gui-redesign-plan.md
@@ -380,7 +380,7 @@ headless).
 | 5 | GUI-CHK-006 | pane_grid layout shell; tabs dissolve into panes — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 2–3 d |
 | 6 | GUI-CHK-007 | Deck writer + GW wire table editor (live preview) — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 3–4 d |
 | 7 | GUI-CHK-008 | EX / GN / LD / FR editors + Apply-and-Solve — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 3 d |
-| 8 | GUI-CHK-009 | Streaming sweep, SWR/|Z| canvas plot, frequency slider | 3 d |
+| 8 | GUI-CHK-009 | Streaming sweep, SWR/|Z| canvas plot, frequency slider — **✅ code + headless gates done (2026-07-10)**; visual pending a display | 3 d |
 | 9 | GUI-CHK-010 | Polish: file dialogs, view options, fit/reset, project save | 2–3 d |
 
 Total ≈ 22–28 dev-days. 0→4 de-risk the GPU path first; 5→8 build the


### PR DESCRIPTION
Marks GUI-CHK-009 code + headless gates done (visual pending a display). Follows #332 (plot math), #333 (chart + slider), #334 (streaming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)