### PR TITLE
feat(gui-chk-010): viewport view options — toggle axes and ground grid

### DIFF
--- a/apps/nec-gui/src/app_state.rs
+++ b/apps/nec-gui/src/app_state.rs
@@ -160,6 +160,8 @@ pub struct ViewportState {
     pub lobe_rev: u64,
     /// Whether to overlay the 3-D radiation-pattern lobe.
     pub show_pattern: bool,
+    /// Reference-geometry display toggles (axes / ground grid) — GUI-CHK-010.
+    pub scene_opts: crate::mesh::SceneOptions,
 }
 
 impl ViewportState {
@@ -174,8 +176,10 @@ impl ViewportState {
         } else {
             None
         };
-        self.scene = Some(std::sync::Arc::new(crate::mesh::build_scene_colored(
-            geo, mags,
+        self.scene = Some(std::sync::Arc::new(crate::mesh::build_scene_opts(
+            geo,
+            mags,
+            self.scene_opts,
         )));
         self.scene_rev = self.scene_rev.wrapping_add(1);
     }
@@ -319,6 +323,10 @@ pub enum Message {
     Pattern3dComplete(Result<crate::mesh::PatternSolve, String>),
     /// User toggled the 3-D radiation-pattern lobe overlay.
     TogglePattern(bool),
+    /// User toggled the xyz axis triad (GUI-CHK-010).
+    ToggleAxes(bool),
+    /// User toggled the z=0 ground grid (GUI-CHK-010).
+    ToggleGrid(bool),
     /// User dragged the workbench pane divider (new split ratio in [0,1]). The
     /// `pane_grid::State` itself lives in the binary; this carries only the ratio.
     PaneResized(f32),
@@ -509,6 +517,14 @@ impl AppState {
             Message::TogglePattern(on) => {
                 self.viewport.show_pattern = *on;
                 self.viewport.rebuild_lobe();
+            }
+            Message::ToggleAxes(on) => {
+                self.viewport.scene_opts.show_axes = *on;
+                self.viewport.rebuild_scene();
+            }
+            Message::ToggleGrid(on) => {
+                self.viewport.scene_opts.show_grid = *on;
+                self.viewport.rebuild_scene();
             }
             // Pane layout lives in the iced binary (see main.rs); no core state.
             Message::PaneResized(_) => {}

--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -404,15 +404,25 @@ impl FnecGui {
         };
         let pattern_toggle = checkbox("Show pattern", self.state.viewport.show_pattern)
             .on_toggle(Message::TogglePattern);
+        let axes_toggle = checkbox("Axes", self.state.viewport.scene_opts.show_axes)
+            .on_toggle(Message::ToggleAxes);
+        let grid_toggle = checkbox("Grid", self.state.viewport.scene_opts.show_grid)
+            .on_toggle(Message::ToggleGrid);
         // Two shorter control rows instead of one long one — a single row of every
         // button + the status text is wider than the pane and forces the whole
         // window to overflow (iced rows do not wrap).
         let geo_controls = row![load_btn, currents_btn, currents_toggle]
             .spacing(10)
             .align_y(iced::Alignment::Center);
-        let view_controls = row![pattern_btn, pattern_toggle, reset_btn]
-            .spacing(10)
-            .align_y(iced::Alignment::Center);
+        let view_controls = row![
+            pattern_btn,
+            pattern_toggle,
+            axes_toggle,
+            grid_toggle,
+            reset_btn
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Center);
         // Long free-form text must be Fill-width so it wraps to the pane instead of
         // widening it (text defaults to Shrink = single unbroken line).
         let status = status.width(Length::Fill);

--- a/apps/nec-gui/src/mesh.rs
+++ b/apps/nec-gui/src/mesh.rs
@@ -105,24 +105,53 @@ pub struct GeometryCurrents {
     pub currents_ma: Vec<f32>,
 }
 
-/// Assemble the full scene mesh with uniform wire color.
+/// Viewport display toggles for the reference geometry (GUI-CHK-010).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SceneOptions {
+    /// Draw the xyz axis triad.
+    pub show_axes: bool,
+    /// Draw the z=0 ground grid (only when the deck has a ground plane).
+    pub show_grid: bool,
+}
+
+impl Default for SceneOptions {
+    fn default() -> Self {
+        Self {
+            show_axes: true,
+            show_grid: true,
+        }
+    }
+}
+
+/// Assemble the full scene mesh with uniform wire color and default options.
 pub fn build_scene(geo: &SceneGeometry) -> MeshData {
     build_scene_colored(geo, None)
+}
+
+/// Assemble the scene mesh with default view options (axes + grid on).
+pub fn build_scene_colored(geo: &SceneGeometry, currents_ma: Option<&[f32]>) -> MeshData {
+    build_scene_opts(geo, currents_ma, SceneOptions::default())
 }
 
 /// Assemble the scene mesh, optionally coloring each wire segment by its current
 /// magnitude (per-segment `currents_ma`, aligned to `geo.wires`). Magnitudes are
 /// normalized by the maximum, so the feedpoint (peak `|I|`) is hot and the tips
 /// (near-zero) are cold. Grid/axes precede the wires, whose vertices stay at the
-/// stable base (see [`wire_vertex_base`]).
-pub fn build_scene_colored(geo: &SceneGeometry, currents_ma: Option<&[f32]>) -> MeshData {
+/// stable base (see [`wire_vertex_base`]); `opts` toggles the axes and ground grid.
+pub fn build_scene_opts(
+    geo: &SceneGeometry,
+    currents_ma: Option<&[f32]>,
+    opts: SceneOptions,
+) -> MeshData {
     let (center, radius) = geo.bounds();
     let mut v = Vec::new();
 
-    if geo.has_ground {
+    if geo.has_ground && opts.show_grid {
         push_ground_grid(&mut v, center, radius);
     }
-    push_axes(&mut v, radius);
+    if opts.show_axes {
+        push_axes(&mut v, radius);
+    }
 
     let peak = currents_ma
         .map(|m| m.iter().copied().fold(0.0_f32, f32::max))
@@ -386,6 +415,44 @@ mod tests {
         // The last two vertices are the single wire.
         assert_eq!(m.vertices[base].pos, [0.0, 0.0, 1.0]);
         assert_eq!(m.vertices[base + 1].pos, [0.0, 0.0, 3.0]);
+    }
+
+    #[test]
+    fn scene_options_toggle_axes_and_grid() {
+        // Free space, axes off → wires only.
+        let g = tri_deck_geo();
+        let m = build_scene_opts(
+            &g,
+            None,
+            SceneOptions {
+                show_axes: false,
+                show_grid: true,
+            },
+        );
+        assert_eq!(m.vertices.len(), 3 * 2, "axes off → just the 3 wires");
+
+        // Ground, grid off → axes + wires, no grid.
+        let gg = SceneGeometry::from_segments(vec![([0.0, 0.0, 1.0], [0.0, 0.0, 3.0])], true);
+        let no_grid = build_scene_opts(
+            &gg,
+            None,
+            SceneOptions {
+                show_axes: true,
+                show_grid: false,
+            },
+        );
+        assert_eq!(no_grid.vertices.len(), AXIS_VERTS + 2, "grid off");
+
+        // Everything off → wires only.
+        let bare = build_scene_opts(
+            &gg,
+            None,
+            SceneOptions {
+                show_axes: false,
+                show_grid: false,
+            },
+        );
+        assert_eq!(bare.vertices.len(), 2, "axes+grid off → just the wire");
     }
 
     #[test]

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1355,3 +1355,30 @@ fn streaming_sweep_empty_stream_is_a_failure() {
     state.apply(&Message::SweepStreamDone);
     assert!(matches!(state.sweep_phase, SweepPhase::Failed(_)));
 }
+
+// ── Viewport view options (GUI-CHK-010) ──────────────────────────────────────
+
+#[test]
+fn viewport_axes_and_grid_toggles_rebuild_scene() {
+    let mut state = AppState::default();
+    // Load a grounded geometry so both axes and grid are present.
+    let geo = nec_gui::solve::load_geometry_str("GW 1 5 0 0 1 0 0 3 0.001\nGE 1\nGN 1\nEN\n")
+        .expect("geometry");
+    state.apply(&Message::GeometryLoaded(Ok(geo)));
+    assert!(state.viewport.scene_opts.show_axes);
+    assert!(state.viewport.scene_opts.show_grid);
+    let full = state.viewport.scene.as_ref().unwrap().vertices.len();
+
+    // Turning axes off rebuilds with fewer vertices.
+    let rev = state.viewport.scene_rev;
+    state.apply(&Message::ToggleAxes(false));
+    assert!(!state.viewport.scene_opts.show_axes);
+    assert_ne!(state.viewport.scene_rev, rev);
+    let no_axes = state.viewport.scene.as_ref().unwrap().vertices.len();
+    assert!(no_axes < full, "axes off → fewer vertices");
+
+    // Turning the grid off too removes more.
+    state.apply(&Message::ToggleGrid(false));
+    let bare = state.viewport.scene.as_ref().unwrap().vertices.len();
+    assert!(bare < no_axes, "grid off → fewer still");
+}


### PR DESCRIPTION
First slice of the polish phase (GUI redesign Phase 9). Display toggles for the reference geometry in the 3-D viewport.

- **`mesh.rs`**: `SceneOptions { show_axes, show_grid }` (default both on) + `build_scene_opts` that conditionally emits the axis triad and the z=0 ground grid; `build_scene_colored` is now the default-options wrapper (unchanged behaviour).
- **`app_state.rs`**: `ViewportState.scene_opts`; `ToggleAxes` / `ToggleGrid` rebuild the scene mesh.
- **`main.rs`**: "Axes" and "Grid" checkboxes in the viewport controls.

## Gates
- ✅ 1 mesh unit test (axes/grid on/off → expected vertex counts) + 1 integration test (toggles rebuild with fewer vertices). `cargo test -p nec-gui` green (52 lib + 74 integration), clippy `-D warnings` + fmt clean.
- ⏸️ **Visual** (toggle Axes / Grid in the 3-D view) handed off: `cargo run -p nec-gui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)