### PR TITLE
fix(cli): MPIE ignored the EX source voltage — impedance scaled by V

### DIFF
--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -1144,7 +1144,16 @@ fn solve_mpie_session(
     }
     .map_err(|e| format!("--solver mpie: {e}"))?;
 
-    Ok(segment_currents(&geom, &sol.basis_currents))
+    // `solve_mpie` drives the feed with a unit (1 V) source; scale the resulting
+    // currents by the deck's actual `EX` voltage so the reported currents are
+    // physical and the feedpoint V/I (in `build_feedpoint_rows`) is independent of
+    // the source voltage — MoM is linear, so I(V) = V·I(1 V).
+    let source_v = Complex64::new(ex.voltage_real, ex.voltage_imag);
+    let mut currents = segment_currents(&geom, &sol.basis_currents);
+    for c in &mut currents {
+        *c *= source_v;
+    }
+    Ok(currents)
 }
 
 /// Whether a deck can be solved on the MPIE path: it is driven by at least one

--- a/apps/nec-cli/tests/mpie_solver_cli.rs
+++ b/apps/nec-cli/tests/mpie_solver_cli.rs
@@ -101,6 +101,29 @@ EN
     assert!((40.0..90.0).contains(&r), "Y-junction R={r} not physical");
 }
 
+/// The reported feedpoint impedance must be independent of the `EX` source
+/// voltage (MoM is linear: Z = V/I with I ∝ V). Regression for the bug where the
+/// MPIE always solved at 1 V, so a deck with EX voltage ≠ 1 V had its impedance
+/// scaled by that voltage.
+#[test]
+fn mpie_impedance_is_independent_of_source_voltage() {
+    let deck_1v = write_deck("dipole_1v", DIPOLE);
+    let deck_2v = write_deck(
+        "dipole_2v",
+        &DIPOLE.replace("EX 0 1 21 0 1.0 0.0", "EX 0 1 21 0 2.0 0.0"),
+    );
+    let z1 = feedpoint_z(&String::from_utf8_lossy(
+        &run_fnec(&["--solver", "mpie", deck_1v.to_str().unwrap()]).stdout,
+    ));
+    let z2 = feedpoint_z(&String::from_utf8_lossy(
+        &run_fnec(&["--solver", "mpie", deck_2v.to_str().unwrap()]).stdout,
+    ));
+    assert!(
+        (z1.0 - z2.0).abs() < 1e-3 && (z1.1 - z2.1).abs() < 1e-3,
+        "impedance must not depend on source voltage: 1V={z1:?} vs 2V={z2:?}"
+    );
+}
+
 /// Loads are not modelled by the MPIE triangle-basis system, so an `LD` deck is
 /// rejected rather than silently ignored.
 #[test]


### PR DESCRIPTION
Pre-release review (fable) finding **2b**. `solve_mpie`/`solve_mpie_ground` always drive the feed with a unit (1 V) source, and the MPIE bridge never rescaled the returned currents by the deck's actual `EX` voltage. `build_feedpoint_rows` then computes `z_in = v_source / current` with `v_source` = the deck voltage V but `current` from the 1 V solve — so **any deck with EX voltage ≠ 1 V reported an impedance multiplied by V** (and a CURRENTS table for 1 V). Latent because every corpus deck uses `EX … 1.0 0.0`.

**Fix:** scale the MPIE segment currents by the complex source voltage in `solve_mpie_session` (MoM is linear, `I(V) = V·I(1 V)`). Currents are now physical and `z_in = V/(V·I) = 1/I` is independent of the source voltage, matching the Hallén path.

**Regression test:** the λ/2 dipole reports the same feedpoint impedance at EX 1.0 V and 2.0 V. `cargo test -p nec-cli --test mpie_solver_cli` green (8/8; V=1 corpus cases unchanged), clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)