### PR TITLE
fix(cli): MPIE guards — mixed-radius warning + no Sommerfeld double-count

### DIFF
--- a/apps/nec-cli/src/main.rs
+++ b/apps/nec-cli/src/main.rs
@@ -40,7 +40,7 @@ use std::process::ExitCode;
 use std::time::Instant;
 use warnings::{
     warn_deferred_ground_model, warn_execution_mode_fallback, warn_ge_ground_reflection_flag,
-    warn_pulse_mode_experimental,
+    warn_mpie_mixed_radius, warn_pulse_mode_experimental,
 };
 
 fn main() -> ExitCode {
@@ -287,6 +287,7 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
     warn_deferred_ground_model(&ground);
+    warn_mpie_mixed_radius(solver_mode, &segs);
 
     let pattern_points: Vec<FarFieldPoint> = deck
         .cards

--- a/apps/nec-cli/src/solve_session.rs
+++ b/apps/nec-cli/src/solve_session.rs
@@ -859,9 +859,13 @@ pub(super) fn build_feedpoint_rows(
 
     // PH9-CHK-006: precompute the Sommerfeld surface-wave ΔZ correction inputs once
     // (applied per feedpoint below) when the user selects the sommerfeld ground
-    // solver over finite ground.
-    let sommerfeld_ground = match (ground_solver, ground) {
-        (GroundSolver::Sommerfeld, GroundModel::SimpleFiniteGround { eps_r, sigma }) => {
+    // solver over finite ground. This delta upgrades the *Hallén + scalar-Γ* result
+    // to the Sommerfeld impedance; the MPIE path already assembles the exact
+    // reflected (Sommerfeld) kernels into its Z-matrix, so applying the delta there
+    // would double-count the surface wave — skip it for `--solver mpie`.
+    let sommerfeld_ground = match (solver_mode, ground_solver, ground) {
+        (SolverMode::Mpie, _, _) => None,
+        (_, GroundSolver::Sommerfeld, GroundModel::SimpleFiniteGround { eps_r, sigma }) => {
             Some((*eps_r, *sigma))
         }
         _ => None,

--- a/apps/nec-cli/src/warnings.rs
+++ b/apps/nec-cli/src/warnings.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Simon Keimer (DC0SK)
 
 use nec_model::card::Card;
-use nec_solver::GroundModel;
+use nec_solver::{GroundModel, Segment};
 
 use super::exec_profile::ExecutionMode;
 use super::solve_session::SolverMode;
@@ -37,6 +37,27 @@ pub(super) fn warn_pulse_mode_experimental(solver_mode: SolverMode) {
 thin-wire antennas. The pulse-basis Pocklington EFIE diverges from the physical solution \
 as segment count increases. Use --solver hallen or --solver sinusoidal for accurate results."
     );
+}
+
+/// The MPIE solver's reduced thin-wire kernel uses a single wire radius (the
+/// first segment's) for the whole geometry. Warn once when a `--solver mpie` deck
+/// mixes radii, since the differently-sized wires are then solved approximately.
+pub(super) fn warn_mpie_mixed_radius(solver_mode: SolverMode, segs: &[Segment]) {
+    if !matches!(solver_mode, SolverMode::Mpie) {
+        return;
+    }
+    let Some(first) = segs.first() else { return };
+    let r0 = first.radius;
+    let mixed = segs
+        .iter()
+        .any(|s| (s.radius - r0).abs() > 1e-9 * r0.max(s.radius));
+    if mixed {
+        eprintln!(
+            "warning: --solver mpie models a single wire radius; this deck mixes radii, so \
+all segments are solved with the first wire's radius ({r0} m) — impedance for the \
+differently-sized wires will be approximate"
+        );
+    }
 }
 
 pub(super) fn warn_deferred_ground_model(ground: &GroundModel) {

--- a/apps/nec-cli/tests/mpie_solver_cli.rs
+++ b/apps/nec-cli/tests/mpie_solver_cli.rs
@@ -124,6 +124,45 @@ fn mpie_impedance_is_independent_of_source_voltage() {
     );
 }
 
+/// The MPIE reduced kernel uses one wire radius for the whole geometry; a deck
+/// mixing radii under `--solver mpie` must warn (rather than silently solve the
+/// thin and fat wires with the same radius).
+#[test]
+fn mpie_warns_on_mixed_radii() {
+    let deck = write_deck(
+        "mixed_radii",
+        "\
+CM mixed-radius collinear dipole (fat + thin halves)
+CE
+GW 1 20 0.0 0.0 -2.5 0.0 0.0 0.0 0.002
+GW 2 20 0.0 0.0 0.0 0.0 0.0 2.5 0.0005
+GE 0
+FR 0 1 0 0 14.2 0
+EX 0 1 10 0 1.0 0.0
+XQ
+EN
+",
+    );
+    let out = run_fnec(&["--solver", "mpie", deck.to_str().unwrap()]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("single wire radius") || stderr.contains("mixes radii"),
+        "expected a mixed-radius warning on the MPIE path:\n{stderr}"
+    );
+}
+
+/// A uniform-radius deck must NOT emit the mixed-radius warning (no false positive).
+#[test]
+fn mpie_uniform_radius_no_mixed_warning() {
+    let deck = write_deck("uniform_radius", DIPOLE);
+    let out = run_fnec(&["--solver", "mpie", deck.to_str().unwrap()]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("mixes radii"),
+        "uniform-radius deck should not warn about mixed radii:\n{stderr}"
+    );
+}
+
 /// Loads are not modelled by the MPIE triangle-basis system, so an `LD` deck is
 /// rejected rather than silently ignored.
 #[test]


### PR DESCRIPTION
Two pre-release review (fable) findings on the MPIE path.

**2c — mixed-radius warning.** The MPIE reduced thin-wire kernel uses a **single** wire radius (the first segment's) for the whole geometry, but a deck mixing radii (fat driver + thin parasitics) was solved silently with the wrong radius on all but the first wire. Adds a one-time `warn_mpie_mixed_radius` alongside the other pre-solve warnings.

**2d — no Sommerfeld double-count.** `build_feedpoint_rows` added the Sommerfeld surface-wave ΔZ correction whenever `--ground-solver sommerfeld` was set over finite ground, regardless of solver mode. The MPIE path **already** assembles the exact reflected (Sommerfeld) kernels into its Z-matrix, so `--solver mpie --ground-solver sommerfeld` double-counted the surface wave. Now skipped for `SolverMode::Mpie`.

Tests: mixed-radius deck warns; uniform-radius deck doesn't (no false positive). `cargo test -p nec-cli --test mpie_solver_cli` green (10/10), clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)