### PR TITLE
fix(gui): surface solver caveats instead of silently solving wrong

### DIFF
--- a/apps/nec-gui/src/main.rs
+++ b/apps/nec-gui/src/main.rs
@@ -878,7 +878,7 @@ fn control_del_button(slot: usize) -> Element<'static, Message> {
 
 /// Small impedance result widget for the single-frequency tab.
 fn impedance_view(r: &SolveResult) -> Element<'_, Message> {
-    column![
+    let mut col = column![
         text("─── Result ───"),
         text(format!("Frequency  : {:.3} MHz", r.freq_mhz)),
         text(format!("Z_re       : {:.3} Ω", r.z_re)),
@@ -888,8 +888,13 @@ fn impedance_view(r: &SolveResult) -> Element<'_, Message> {
             (r.z_re * r.z_re + r.z_im * r.z_im).sqrt()
         )),
     ]
-    .spacing(4)
-    .into()
+    .spacing(4);
+    // Surface solver caveats (unreliable topology, deferred ground, unsupported
+    // loads) so the GUI never presents a wrong number as trustworthy.
+    for w in &r.warnings {
+        col = col.push(text(format!("⚠ {w}")).width(Length::Fill));
+    }
+    col.into()
 }
 
 /// Sortable sweep result table.  Borrows the full `FnecGui` to access sort state.

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -12,8 +12,9 @@ use nec_model::deck::NecDeck;
 use nec_parser::parse;
 use nec_solver::{
     assemble_z_matrix_with_ground, build_excitation, build_geometry, build_hallen_rhs, build_loads,
-    build_tl_stamps, compute_radiation_pattern, detect_wire_junctions, ground_model_from_deck,
-    solve_hallen, wire_endpoints_from_segs, FarFieldPoint, GroundModel, Segment,
+    build_tl_stamps, classify_unsupported_topology, compute_radiation_pattern,
+    detect_wire_junctions, ground_model_from_deck, solve_hallen, wire_endpoints_from_segs,
+    FarFieldPoint, GroundModel, Segment, UnsupportedTopology,
 };
 use num_complex::Complex64;
 
@@ -104,7 +105,7 @@ fn apply_vars(input: &str, vars_path: Option<&str>) -> Result<String, String> {
 }
 
 /// Result of a successful single-frequency solve.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SolveResult {
     /// Frequency in MHz.
     pub freq_mhz: f64,
@@ -112,6 +113,10 @@ pub struct SolveResult {
     pub z_re: f64,
     /// Feedpoint reactance (Ω).
     pub z_im: f64,
+    /// Solver caveats for this deck (unreliable topology, deferred ground,
+    /// unsupported loads) — the GUI runs the Hallén solver, so junctions/loops
+    /// and finite-ground currents need the CLI's `--solver mpie`.
+    pub warnings: Vec<String>,
 }
 
 /// One row in the sweep result table.
@@ -265,6 +270,47 @@ pub fn pattern_grid_str(deck_text: &str) -> Result<crate::mesh::PatternSolve, St
 }
 
 /// Run a Hallen solve on `deck_text` (a raw NEC deck string).
+/// Solver caveats the GUI (Hallén-only) should surface for a deck: topologies the
+/// Hallén basis mis-solves (junctions/loops — the CLI's `--solver mpie` handles
+/// them), a deferred/unsupported ground model (treated as free space), and any
+/// loads / transmission lines the builder could not apply.
+fn collect_solve_warnings(
+    deck: &nec_model::deck::NecDeck,
+    segs: &[Segment],
+    ground: &GroundModel,
+    freq_hz: f64,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    match classify_unsupported_topology(segs) {
+        Some(UnsupportedTopology::ClosedLoop) => warnings.push(
+            "Geometry contains a closed loop; the Hallén solver does not model the loop \
+             closure, so the impedance, currents, and pattern are unreliable. Solve this \
+             geometry with the CLI: `fnec --solver mpie`."
+                .to_string(),
+        ),
+        Some(UnsupportedTopology::HighDegreeJunction) => warnings.push(
+            "Geometry has a junction where three or more wires meet; the Hallén solver does \
+             not model the current split there, so results are unreliable. Solve this geometry \
+             with the CLI: `fnec --solver mpie`."
+                .to_string(),
+        ),
+        None => {}
+    }
+    if let GroundModel::Deferred { .. } = ground {
+        warnings.push(
+            "The deck's ground model is not supported by this solver and is treated as free \
+             space — results omit ground effects. Use the CLI with `--ground-solver sommerfeld` \
+             for near-ground impedance."
+                .to_string(),
+        );
+    }
+    let (_lv, load_warnings) = build_loads(deck, segs, freq_hz);
+    warnings.extend(load_warnings.into_iter().map(|w| w.to_string()));
+    let (_ts, tl_warnings) = build_tl_stamps(deck, segs, freq_hz);
+    warnings.extend(tl_warnings.into_iter().map(|w| w.to_string()));
+    warnings
+}
+
 pub fn solve_deck_str(deck_text: &str) -> Result<SolveResult, String> {
     let parsed = parse(deck_text).map_err(|e| e.to_string())?;
     let deck = &parsed.deck;
@@ -322,6 +368,7 @@ pub fn solve_deck_str(deck_text: &str) -> Result<SolveResult, String> {
         freq_mhz: freq_hz / 1_000_000.0,
         z_re: z.re,
         z_im: z.im,
+        warnings: collect_solve_warnings(deck, &segs, &ground, freq_hz),
     })
 }
 

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -58,6 +58,7 @@ fn solve_complete_ok_transitions_to_done() {
         freq_mhz: 14.2,
         z_re: 73.1,
         z_im: -1.5,
+        warnings: Vec::new(),
     };
     state.apply(&Message::SolveComplete(Ok(result.clone())));
     assert_eq!(state.phase, SolvePhase::Done(result));
@@ -127,6 +128,7 @@ fn status_text_done_contains_impedance() {
         freq_mhz: 14.2,
         z_re: 73.1,
         z_im: -1.5,
+        warnings: Vec::new(),
     })));
     let s = state.status_text();
     assert!(s.contains("14.2") || s.contains("MHz"), "freq missing: {s}");
@@ -1159,6 +1161,7 @@ fn editor_apply_solve_enters_solving_then_done() {
         freq_mhz: 14.2,
         z_re: 73.0,
         z_im: 5.0,
+        warnings: Vec::new(),
     })));
     assert!(matches!(state.phase, SolvePhase::Done(_)));
 }
@@ -1394,4 +1397,41 @@ fn browse_messages_are_noops_in_core_state() {
     state.apply(&Message::BrowseVars);
     state.apply(&Message::BrowseSaveDeck);
     assert_eq!(state.deck_path, before, "browse must not change core state");
+}
+
+// ── GUI solver caveats (pre-release fix 1a) ──────────────────────────────────
+
+/// A degree-3 Y-junction deck still solves on the GUI's Hallén path, but the
+/// result carries a warning recommending the CLI's `--solver mpie` (the GUI has
+/// no MPIE path), so the GUI never presents the junction number as trustworthy.
+#[test]
+fn solve_warns_on_high_degree_junction() {
+    const Y: &str = "\
+CM Y-junction
+CE
+GW 1 20 0.0 0.0 0.0 5.0 0.0 0.0 0.001
+GW 2 20 0.0 0.0 0.0 -2.5 4.330127 0.0 0.001
+GW 3 20 0.0 0.0 0.0 -2.5 -4.330127 0.0 0.001
+GE 0
+FR 0 1 0 0 14.2 0
+EX 0 1 10 0 1.0 0.0
+EN
+";
+    let r = solve_deck_str(Y).expect("Y-junction still solves (unreliably)");
+    assert!(
+        r.warnings.iter().any(|w| w.contains("mpie")),
+        "expected an mpie recommendation, got {:?}",
+        r.warnings
+    );
+}
+
+/// A plain free-space dipole is fully supported — no solver caveats.
+#[test]
+fn solve_clean_dipole_has_no_warnings() {
+    let r = solve_deck_str(DIPOLE_DECK).expect("dipole solves");
+    assert!(
+        r.warnings.is_empty(),
+        "unexpected warnings: {:?}",
+        r.warnings
+    );
 }

--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -54,6 +54,19 @@ Controls above the view:
 Click **Solve** to run a single-frequency solve of the deck; the feedpoint
 frequency, resistance, reactance, and |Z| are shown.
 
+> **Solver note.** The GUI runs the **Hallén** solver. For geometries it does not
+> model accurately — junctions where three or more wires meet, closed loops, and
+> near-ground currents over finite ground — the Solve tab shows a ⚠ warning and
+> the numbers should not be trusted. Solve those with the command line, which has
+> the mixed-potential second solver:
+>
+> ```sh
+> fnec --solver mpie [--ground-solver sommerfeld] your-deck.nec
+> ```
+>
+> The GUI also surfaces ⚠ warnings for deferred ground models (treated as free
+> space) and unsupported loads.
+
 ## Sweep tab
 
 Enter a **Start / End / Step** (MHz) and click **Run Sweep**. Results **stream


### PR DESCRIPTION
Pre-release review (fable) finding **1a** — the release's highest-impact item. The GUI runs the Hallén solver and **silently discarded its guard warnings**: a degree-3 junction or closed loop was solved on the exact path the project documents as producing garbage (R≈8 vs the correct ≈64), with no hint to the user; unsupported loads / deferred-ground warnings were dropped too.

- **`solve.rs`**: `SolveResult` gains a `warnings` list, populated by `collect_solve_warnings` — reuses `nec_solver::classify_unsupported_topology` to flag closed loops and high-degree junctions (recommending the CLI's `--solver mpie`), notes a deferred/unsupported ground model (treated as free space), and forwards the load / transmission-line warnings that were previously discarded.
- **`main.rs`**: the Solve tab renders each caveat as a ⚠ line under the impedance.
- **`docs/gui-guide.md`**: a Solver note documents the Hallén limitation and points to `fnec --solver mpie`.

## Gates
- ✅ 2 new headless tests (Y-junction deck warns + recommends mpie; clean dipole has no warnings). `cargo test -p nec-gui` green (55 lib + 77 integration), clippy `-D warnings` + fmt clean.

The 3-D currents/pattern viewport paths share the same solver; this surfaces the caveat on the primary Solve path and documents it in the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)