### PR TITLE
fix(gui): cap runaway sweeps; test NE/NH deck-writer round-trip

### DIFF
--- a/apps/nec-gui/src/deck_write.rs
+++ b/apps/nec-gui/src/deck_write.rs
@@ -302,6 +302,27 @@ mod tests {
     }
 
     #[test]
+    fn near_field_ne_nh_round_trip() {
+        // No corpus deck exercises NE/NH, so the corpus oracle can't cover
+        // write_near; round-trip both card kinds directly.
+        let deck = parse(
+            "GW 1 11 0 0 -2.5 0 0 2.5 0.001\n\
+             GE 0\n\
+             NE 0 5 1 5 -1 0 -1 0.5 0 0.5\n\
+             NH 1 3 3 3 0.1 0.2 0.3 0.4 0.5 0.6\n\
+             EN\n",
+        )
+        .unwrap()
+        .deck;
+        let reparsed = parse(&write_deck(&deck)).unwrap().deck;
+        assert_eq!(deck.cards, reparsed.cards);
+        // And both mnemonics survive as themselves (NE ≠ NH).
+        let written = write_deck(&deck);
+        assert!(written.contains("\nNE "));
+        assert!(written.contains("\nNH "));
+    }
+
+    #[test]
     fn rp_encodes_normalize_and_avg_power() {
         let deck = parse("RP 0 37 1 1001 0 0 5 0\nEN\n").unwrap().deck;
         let s = write_card(&deck.cards[0]);

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -430,6 +430,11 @@ pub fn sweep_deck_str(
     job.freqs_mhz().iter().map(|&f| job.solve_at(f)).collect()
 }
 
+/// Upper bound on the number of frequency points a single sweep may request,
+/// so a mistyped step (e.g. `0.0001` over a 1000 MHz span) can't queue millions
+/// of matrix solves and freeze the GUI.
+pub const MAX_SWEEP_POINTS: usize = 100_000;
+
 /// A prepared frequency sweep: geometry, excitation, ground and junctions built
 /// once, so each frequency can be solved independently via [`SweepJob::solve_at`].
 ///
@@ -459,6 +464,15 @@ impl SweepJob {
         if start_mhz >= end_mhz {
             return Err(format!(
                 "start_mhz ({start_mhz}) must be less than end_mhz ({end_mhz})"
+            ));
+        }
+        // Guard against a runaway sweep (e.g. a slipped decimal in the step) that
+        // would queue millions of full matrix solves and freeze/OOM the GUI.
+        let point_count = ((end_mhz - start_mhz) / step_mhz).floor() + 1.0;
+        if point_count > MAX_SWEEP_POINTS as f64 {
+            return Err(format!(
+                "sweep would compute {point_count:.0} points (max {MAX_SWEEP_POINTS}); \
+                 widen the step or narrow the range"
             ));
         }
 

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1435,3 +1435,18 @@ fn solve_clean_dipole_has_no_warnings() {
         r.warnings
     );
 }
+
+/// A runaway sweep (mistyped tiny step over a wide range) is rejected before it
+/// can queue millions of solves and freeze the GUI.
+#[test]
+fn sweep_point_count_is_capped() {
+    use nec_gui::solve::{SweepJob, MAX_SWEEP_POINTS};
+    // 1..1000 MHz at 0.0001 MHz ≈ 10^7 points — must be refused.
+    let err = match SweepJob::prepare(DIPOLE_DECK, 1.0, 1000.0, 0.0001) {
+        Err(e) => e,
+        Ok(_) => panic!("runaway sweep must be rejected"),
+    };
+    assert!(err.contains("max") && err.contains(&MAX_SWEEP_POINTS.to_string()));
+    // A sane sweep still prepares fine.
+    assert!(SweepJob::prepare(DIPOLE_DECK, 14.0, 14.4, 0.1).is_ok());
+}


### PR DESCRIPTION
Two pre-release review (fable) findings.

**3a — runaway sweep.** `SweepJob::prepare` had no bound on the point count and the streaming task has no cancel, so a slipped decimal (start 1, end 1000, step 0.0001 ≈ 10⁷ solves) would freeze/OOM the GUI with no escape but killing it. Adds `MAX_SWEEP_POINTS` (100 000) and rejects an over-large sweep up front with an actionable message, before any matrix is built.

**3c — NE/NH writer coverage.** No corpus deck exercises NE/NH, so the deck-writer's parse→write→parse corpus oracle never covered `write_near`. Adds a direct round-trip test for a deck with both NE and NH cards (and asserts the mnemonics stay distinct).

Gates: 2 new tests. `cargo test -p nec-gui` green (56 lib + 78 integration), clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)