### PR TITLE
test(gui): close the coverage gaps fable's review flagged

### DIFF
--- a/apps/nec-gui/src/model_doc.rs
+++ b/apps/nec-gui/src/model_doc.rs
@@ -993,6 +993,105 @@ EN
     }
 
     #[test]
+    fn every_control_edit_variant_applies() {
+        // gnd_doc post slots: GE(0), GN(1), LD(2), EX(3), FR(4), EN(5).
+        let mut d = gnd_doc();
+        // EX (slot 3).
+        d.edit_control(3, &ControlEdit::ExKind("5".into()));
+        d.edit_control(3, &ControlEdit::ExTag("2".into()));
+        d.edit_control(3, &ControlEdit::ExSegment("7".into()));
+        d.edit_control(3, &ControlEdit::ExVr("3".into()));
+        d.edit_control(3, &ControlEdit::ExVi("4".into()));
+        // GN (slot 1).
+        d.edit_control(1, &ControlEdit::GnType(0));
+        d.edit_control(1, &ControlEdit::GnEps("11".into()));
+        d.edit_control(1, &ControlEdit::GnSigma("0.002".into()));
+        // LD (slot 2).
+        d.edit_control(2, &ControlEdit::LdType(1));
+        d.edit_control(2, &ControlEdit::LdTag("3".into()));
+        d.edit_control(2, &ControlEdit::LdSegFirst("4".into()));
+        d.edit_control(2, &ControlEdit::LdSegLast("5".into()));
+        d.edit_control(2, &ControlEdit::LdF1("6".into()));
+        d.edit_control(2, &ControlEdit::LdF2("7".into()));
+        d.edit_control(2, &ControlEdit::LdF3("8".into()));
+        // FR (slot 4).
+        d.edit_control(4, &ControlEdit::FrStepType(1));
+        d.edit_control(4, &ControlEdit::FrSteps("9".into()));
+        d.edit_control(4, &ControlEdit::FrFrequency("28.0".into()));
+        d.edit_control(4, &ControlEdit::FrStep("0.1".into()));
+
+        // Every field landed in its typed row.
+        let slots = d.post_slots();
+        let PostSlot::Ex(ex) = &slots[3] else {
+            panic!()
+        };
+        assert_eq!(
+            (
+                ex.kind.as_str(),
+                ex.tag.as_str(),
+                ex.segment.as_str(),
+                ex.vr.as_str(),
+                ex.vi.as_str()
+            ),
+            ("5", "2", "7", "3", "4")
+        );
+        let PostSlot::Gn(gn) = &slots[1] else {
+            panic!()
+        };
+        assert_eq!(
+            (gn.ground_type, gn.eps_r.as_str(), gn.sigma.as_str()),
+            (0, "11", "0.002")
+        );
+        let PostSlot::Ld(ld) = &slots[2] else {
+            panic!()
+        };
+        assert_eq!(
+            (
+                ld.load_type,
+                ld.tag.as_str(),
+                ld.seg_first.as_str(),
+                ld.seg_last.as_str(),
+                ld.f1.as_str(),
+                ld.f2.as_str(),
+                ld.f3.as_str()
+            ),
+            (1, "3", "4", "5", "6", "7", "8")
+        );
+        let PostSlot::Fr(fr) = &slots[4] else {
+            panic!()
+        };
+        assert_eq!(
+            (
+                fr.step_type,
+                fr.steps.as_str(),
+                fr.frequency_mhz.as_str(),
+                fr.step_mhz.as_str()
+            ),
+            (1, "9", "28.0", "0.1")
+        );
+        // Still renders to a valid deck.
+        assert!(d.to_deck().is_ok());
+    }
+
+    #[test]
+    fn control_field_key_is_stable_per_field() {
+        // Each variant has a distinct coalescing key (used for undo grouping).
+        let keys = [
+            ControlEdit::ExVr(String::new()).field_key(),
+            ControlEdit::ExVi(String::new()).field_key(),
+            ControlEdit::GnType(0).field_key(),
+            ControlEdit::LdF1(String::new()).field_key(),
+            ControlEdit::FrStep(String::new()).field_key(),
+        ];
+        // All distinct.
+        for (i, a) in keys.iter().enumerate() {
+            for b in &keys[i + 1..] {
+                assert_ne!(a, b, "field keys must be distinct");
+            }
+        }
+    }
+
+    #[test]
     fn edit_control_kind_mismatch_is_a_noop() {
         let mut d = gnd_doc();
         // Slot 1 is GN; an LD edit must not touch it.

--- a/apps/nec-gui/src/session.rs
+++ b/apps/nec-gui/src/session.rs
@@ -110,15 +110,24 @@ impl Session {
     /// Write this session to [`Session::config_path`], creating the directory.
     pub fn save(&self) -> Result<(), String> {
         let path = Self::config_path().ok_or("no config directory (HOME unset)")?;
+        self.save_to(&path)
+    }
+
+    /// Write this session to an explicit path, creating parent directories.
+    pub fn save_to(&self, path: &std::path::Path) -> Result<(), String> {
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
         }
-        std::fs::write(&path, self.to_toml()?).map_err(|e| e.to_string())
+        std::fs::write(path, self.to_toml()?).map_err(|e| e.to_string())
     }
 
     /// Load the persisted session, or `None` if absent/unreadable/corrupt.
     pub fn load() -> Option<Self> {
-        let path = Self::config_path()?;
+        Self::load_from(&Self::config_path()?)
+    }
+
+    /// Load a session from an explicit path, or `None` if absent/unreadable/corrupt.
+    pub fn load_from(path: &std::path::Path) -> Option<Self> {
         let text = std::fs::read_to_string(path).ok()?;
         Self::from_toml(&text).ok()
     }
@@ -186,5 +195,31 @@ mod tests {
         let session = Session::from_toml("deck_path = \"d.nec\"\n").expect("parse");
         assert_eq!(session.deck_path, "d.nec");
         assert_eq!(session.sweep_start, AppState::default().sweep_start);
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn save_to_and_load_from_round_trips_on_disk() {
+        let mut session = Session::default();
+        session.deck_path = "roundtrip.nec".into();
+        session.cam_distance = 9.0;
+        let path = std::env::temp_dir().join("fnec_gui_session_test/session.toml");
+        session.save_to(&path).expect("save creates dirs + writes");
+        let loaded = Session::load_from(&path).expect("load reads it back");
+        assert_eq!(loaded, session);
+        // A missing / unreadable path loads as None (fail-soft).
+        assert!(Session::load_from(std::path::Path::new("/no/such/session.toml")).is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn config_path_points_at_the_app_config_file() {
+        // In any normal environment HOME or XDG_CONFIG_HOME is set.
+        if let Some(p) = Session::config_path() {
+            assert!(
+                p.ends_with("fnec-gui/session.toml"),
+                "unexpected path {p:?}"
+            );
+        }
     }
 }

--- a/apps/nec-gui/src/solve.rs
+++ b/apps/nec-gui/src/solve.rs
@@ -723,3 +723,58 @@ fn solve_for_currents(
 
     Ok((segs, sol.currents, freq_hz, ground))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(name: &str, body: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("fnec_gui_vars_{name}"));
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn load_vars_toml_strings_ints_floats() {
+        let p = tmp("ok.toml", "A = \"1.5\"\nN = 51\nR = 0.001\n");
+        let m = load_vars(&p).expect("toml vars");
+        assert_eq!(m.get("A").map(String::as_str), Some("1.5"));
+        assert_eq!(m.get("N").map(String::as_str), Some("51"));
+        assert_eq!(m.get("R").map(String::as_str), Some("0.001"));
+    }
+
+    #[test]
+    fn load_vars_toml_rejects_unsupported_type() {
+        let p = tmp("bad.toml", "A = [1, 2, 3]\n");
+        let err = load_vars(&p).unwrap_err();
+        assert!(err.contains("unsupported type"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn load_vars_json_flat_object() {
+        let p = tmp("ok.json", "{\"A\": \"1.5\", \"N\": \"51\"}");
+        let m = load_vars(&p).expect("json vars");
+        assert_eq!(m.get("A").map(String::as_str), Some("1.5"));
+        assert_eq!(m.get("N").map(String::as_str), Some("51"));
+    }
+
+    #[test]
+    fn load_vars_json_requires_object() {
+        let p = tmp("bad.json", "[1, 2, 3]");
+        assert!(load_vars(&p).unwrap_err().contains("top-level object"));
+    }
+
+    #[test]
+    fn load_vars_missing_file_errors() {
+        let err = load_vars(std::path::Path::new("/no/such/vars.toml")).unwrap_err();
+        assert!(err.contains("cannot read"));
+    }
+
+    #[test]
+    fn apply_vars_none_is_passthrough_and_some_substitutes() {
+        assert_eq!(apply_vars("GW 1 $N", None).unwrap(), "GW 1 $N");
+        let p = tmp("sub.toml", "N = 51\n");
+        let out = apply_vars("GW 1 $N 0 0 0", Some(p.to_str().unwrap())).unwrap();
+        assert!(out.contains("51"), "substituted: {out}");
+    }
+}

--- a/apps/nec-gui/tests/gui_smoke.rs
+++ b/apps/nec-gui/tests/gui_smoke.rs
@@ -1450,3 +1450,55 @@ fn sweep_point_count_is_capped() {
     // A sane sweep still prepares fine.
     assert!(SweepJob::prepare(DIPOLE_DECK, 14.0, 14.4, 0.1).is_ok());
 }
+
+// ── Additional app_state arm coverage (pre-release) ──────────────────────────
+
+#[test]
+fn editor_deck_load_error_sets_error_and_clears_save_status() {
+    let mut state = AppState::default();
+    // Prime a save status, then a failed load must record the error and clear it.
+    state.editor.save_status = "Saved to x".into();
+    state.apply(&Message::EditDeckLoaded(Err("bad deck".into())));
+    assert_eq!(state.editor.error.as_deref(), Some("bad deck"));
+    assert!(state.editor.save_status.is_empty());
+    assert!(!state.editor.loaded);
+}
+
+#[test]
+fn status_texts_cover_all_phases() {
+    let mut state = AppState::default();
+    // Currents.
+    assert!(state.currents_status_text().contains("Run Currents"));
+    state.apply(&Message::RunCurrents);
+    assert!(state.currents_status_text().contains("Computing"));
+    state.apply(&Message::CurrentsComplete(Err("boom".into())));
+    assert!(state.currents_status_text().contains("boom"));
+    // Pattern.
+    assert!(
+        state.pattern_status_text().contains("azimuth")
+            || state.pattern_status_text().contains("φ")
+    );
+    state.apply(&Message::RunPattern);
+    assert!(state.pattern_status_text().contains("Computing"));
+    state.apply(&Message::PatternComplete(Err("nope".into())));
+    assert!(state.pattern_status_text().contains("nope"));
+    // Sweep failure text.
+    state.apply(&Message::SweepComplete(Err("range".into())));
+    assert!(state.sweep_status_text().contains("range"));
+}
+
+#[test]
+fn viewport_toggles_without_geometry_are_safe() {
+    // Toggling currents/pattern/axes/grid before any geometry is loaded must not
+    // panic and must leave the scene empty.
+    let mut state = AppState::default();
+    for m in [
+        Message::ToggleCurrents(true),
+        Message::TogglePattern(true),
+        Message::ToggleAxes(false),
+        Message::ToggleGrid(false),
+    ] {
+        state.apply(&m);
+    }
+    assert!(state.viewport.scene.is_none());
+}


### PR DESCRIPTION
Ran a **quantitative** coverage pass (`cargo-llvm-cov`) — the review's coverage analysis had been qualitative — and added tests for the untested-but-testable GUI logic it surfaced.

The remaining 0%-coverage files (`sweep_plot.rs`, `viewport/mod.rs`, `viewport/primitive.rs`) are the wgpu/canvas rendering code that can't run without a display (the deliberate lib/binary split), so they stay handed off to the visual gate.

| file | before | after |
|------|-------:|------:|
| `solve.rs` (`load_vars`/`apply_vars`) | 60.9% | **74.7%** |
| `session.rs` (save/load IO) | 72.5% | **86.0%** |
| `model_doc.rs` (ControlEdit arms) | 89.9% | **95.4%** |
| `app_state.rs` (error/status arms) | 85.3% | **89.0%** |

- **solve.rs**: `load_vars` ($VAR TOML/JSON loader) + `apply_vars` were entirely untested — new tests module (TOML types, unsupported-type error, flat JSON, non-object rejection, missing file, passthrough/substitute).
- **session.rs**: split file IO into path-explicit `save_to`/`load_from` (no racy env mutation) behind `save`/`load`; round-trip on disk + config_path assertion.
- **model_doc.rs**: exercise every `ControlEdit` variant + the distinct `field_key` mapping.
- **gui_smoke**: `EditDeckLoaded(Err)`; all currents/pattern/sweep status-text phases; view-option toggles safe with no geometry.

`cargo test -p nec-gui` green (66 lib + 81 integration), clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)